### PR TITLE
feat(docs): add Resources nav dropdown and 4 new interactive blog tutorials

### DIFF
--- a/apps/docs/components/blog/interactive-animated-tabs-tutorial.tsx
+++ b/apps/docs/components/blog/interactive-animated-tabs-tutorial.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { cn } from "@repo/shadcn-ui/lib/utils";
+import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
+import { motion, useReducedMotion } from "motion/react";
+import { useEffect, useRef, useState } from "react";
+
+const SmoothUIIsotype = () => (
+  <div className="flex size-7 items-center justify-center rounded-full bg-brand/20">
+    <svg
+      aria-hidden="true"
+      className="size-4 text-brand"
+      fill="currentColor"
+      viewBox="0 0 512 512"
+    >
+      <circle cx="256" cy="256" r="200" />
+    </svg>
+  </div>
+);
+
+const STEPS = [
+  {
+    id: "markup",
+    title: "Semantic Markup",
+    description:
+      "Start with role=tablist + role=tab so keyboard users and screen readers work out of the box.",
+  },
+  {
+    id: "state",
+    title: "Active State",
+    description: "Track which tab is active and style it differently.",
+  },
+  {
+    id: "indicator",
+    title: "Shared Indicator",
+    description:
+      "Add a motion.span with a shared layoutId inside the active tab — Motion handles the slide for you.",
+  },
+  {
+    id: "spring",
+    title: "Spring Transition",
+    description:
+      "Use a snappy spring (bounce ≤ 0.1) so the indicator feels tight, not floaty.",
+  },
+  {
+    id: "keyboard",
+    title: "Keyboard Navigation",
+    description:
+      "Handle Arrow keys, Home and End. Move focus to the newly active tab.",
+  },
+  {
+    id: "accessibility",
+    title: "Reduced Motion",
+    description:
+      "Skip the spring entirely when the user has prefers-reduced-motion set.",
+  },
+] as const;
+
+type StepId = (typeof STEPS)[number]["id"];
+
+const CODE_SNIPPETS: Record<StepId, string> = {
+  markup: `<div role="tablist">
+  {tabs.map((tab) => (
+    <button key={tab.id} role="tab" aria-selected={active === tab.id}>
+      {tab.label}
+    </button>
+  ))}
+</div>`,
+  state: `const [active, setActive] = useState(tabs[0].id);
+
+<button
+  role="tab"
+  aria-selected={active === tab.id}
+  className={active === tab.id ? "text-foreground" : "text-muted-foreground"}
+  onClick={() => setActive(tab.id)}
+>`,
+  indicator: `{active === tab.id && (
+  <motion.span
+    layoutId="tabs-indicator"
+    className="absolute inset-0 rounded-full bg-background shadow-sm"
+  />
+)}`,
+  spring: `<motion.span
+  layoutId="tabs-indicator"
+  transition={{ type: "spring", duration: 0.25, bounce: 0.05 }}
+/>`,
+  keyboard: `const onKeyDown = (e: KeyboardEvent, i: number) => {
+  if (e.key === "ArrowRight") setActive(tabs[(i + 1) % tabs.length].id);
+  if (e.key === "ArrowLeft") setActive(tabs[(i - 1 + tabs.length) % tabs.length].id);
+  if (e.key === "Home") setActive(tabs[0].id);
+  if (e.key === "End") setActive(tabs[tabs.length - 1].id);
+};`,
+  accessibility: `const shouldReduceMotion = useReducedMotion();
+
+<motion.span
+  layoutId="tabs-indicator"
+  transition={shouldReduceMotion
+    ? { duration: 0 }
+    : { type: "spring", duration: 0.25, bounce: 0.05 }}
+/>`,
+};
+
+const TABS = [
+  { id: "overview", label: "Overview" },
+  { id: "analytics", label: "Analytics" },
+  { id: "reports", label: "Reports" },
+] as const;
+
+interface InteractiveAnimatedTabsTutorialProps {
+  className?: string;
+}
+
+export function InteractiveAnimatedTabsTutorial({
+  className,
+}: InteractiveAnimatedTabsTutorialProps) {
+  const [currentStep, setCurrentStep] = useState<StepId>("markup");
+  const [active, setActive] = useState<(typeof TABS)[number]["id"]>(
+    TABS[0].id
+  );
+  const shouldReduceMotion = useReducedMotion();
+  const stepRefs = useRef<Map<string, HTMLElement>>(new Map());
+  const indicatorRef = useRef<HTMLDivElement>(null);
+
+  const stepIndex = STEPS.findIndex((s) => s.id === currentStep);
+  const showActiveState = stepIndex >= 1;
+  const showIndicator = stepIndex >= 2;
+  const useSpring = stepIndex >= 3;
+  const respectReducedMotion = stepIndex >= 5;
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            const id = entry.target.getAttribute("data-step");
+            if (id) setCurrentStep(id as StepId);
+          }
+        }
+      },
+      { threshold: 0.5, rootMargin: "-20% 0px -20% 0px" }
+    );
+    for (const ref of stepRefs.current.values()) observer.observe(ref);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const activeRef = stepRefs.current.get(currentStep);
+    const container =
+      indicatorRef.current?.parentElement?.querySelector(".space-y-6");
+    if (activeRef && indicatorRef.current && container) {
+      const top =
+        activeRef.getBoundingClientRect().top -
+        container.getBoundingClientRect().top +
+        16;
+      indicatorRef.current.style.transform = `translateY(${top}px)`;
+    }
+  }, [currentStep]);
+
+  const handleStepClick = (stepId: StepId) => {
+    stepRefs.current
+      .get(stepId)
+      ?.scrollIntoView({ behavior: "smooth", block: "center" });
+  };
+
+  const effectiveReduced = respectReducedMotion && shouldReduceMotion;
+
+  return (
+    <div className={cn("relative", className)}>
+      <div className="grid min-w-0 gap-8 lg:grid-cols-[1fr_400px]">
+        <div className="relative min-w-0">
+          <div
+            className="absolute -left-1 z-10 hidden transition-transform duration-300 ease-out lg:block"
+            ref={indicatorRef}
+            style={{ transform: "translateY(16px)" }}
+          >
+            <SmoothUIIsotype />
+          </div>
+          <div className="space-y-6 lg:pl-8">
+            {STEPS.map((step) => (
+              <section
+                className={cn(
+                  "relative cursor-pointer scroll-mt-32 rounded-xl p-4 transition-all hover:bg-muted/50",
+                  currentStep === step.id && "bg-muted/30"
+                )}
+                data-step={step.id}
+                key={step.id}
+                onClick={() => handleStepClick(step.id)}
+                ref={(el) => {
+                  if (el) stepRefs.current.set(step.id, el);
+                }}
+              >
+                <h3 className="mb-1 font-semibold text-foreground uppercase tracking-wide">
+                  {step.title}
+                </h3>
+                <p className="mb-4 text-muted-foreground text-sm">
+                  {step.description}
+                </p>
+                <div className="[&_figure]:!my-0 [&_pre]:!text-xs max-w-full overflow-x-auto rounded-lg text-sm [&_figure]:rounded-lg">
+                  <DynamicCodeBlock
+                    code={CODE_SNIPPETS[step.id]}
+                    lang="tsx"
+                    options={{
+                      themes: {
+                        light: "catppuccin-latte",
+                        dark: "catppuccin-mocha",
+                      },
+                    }}
+                  />
+                </div>
+              </section>
+            ))}
+          </div>
+        </div>
+
+        <div className="not-prose lg:sticky lg:top-32 lg:h-fit">
+          <div className="overflow-hidden rounded-2xl border bg-muted/20">
+            <div className="flex items-center justify-between border-b bg-muted/30 px-4 py-2">
+              <span className="font-medium text-muted-foreground text-xs uppercase tracking-wider">
+                Live Preview
+              </span>
+              <span className="rounded-full bg-brand/10 px-2 py-0.5 font-medium text-brand text-xs">
+                Step {stepIndex + 1}/{STEPS.length}
+              </span>
+            </div>
+            <div className="flex min-h-[350px] items-center justify-center bg-background p-8">
+              <div
+                aria-label="Tabs"
+                className="relative inline-flex gap-1 rounded-full bg-muted p-1"
+                role="tablist"
+              >
+                {TABS.map((tab) => {
+                  const isActive = active === tab.id;
+                  const isActiveStyled = showActiveState && isActive;
+                  return (
+                    <button
+                      aria-selected={isActive}
+                      className={cn(
+                        "relative z-10 rounded-full px-4 py-2 font-medium text-sm transition-colors",
+                        isActiveStyled
+                          ? "text-foreground"
+                          : "text-muted-foreground hover:text-foreground"
+                      )}
+                      key={tab.id}
+                      onClick={() => setActive(tab.id)}
+                      role="tab"
+                      type="button"
+                    >
+                      {showIndicator && isActive && (
+                        <motion.span
+                          className="-z-10 absolute inset-0 rounded-full border border-border bg-background shadow-sm"
+                          layoutId="tutorial-tabs-indicator"
+                          transition={
+                            effectiveReduced
+                              ? { duration: 0 }
+                              : useSpring
+                                ? {
+                                    type: "spring",
+                                    duration: 0.25,
+                                    bounce: 0.05,
+                                  }
+                                : { duration: 0.2 }
+                          }
+                        />
+                      )}
+                      {tab.label}
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/components/blog/interactive-magnetic-button-tutorial.tsx
+++ b/apps/docs/components/blog/interactive-magnetic-button-tutorial.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+import { cn } from "@repo/shadcn-ui/lib/utils";
+import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
+import { motion, useReducedMotion, useSpring } from "motion/react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type MouseEvent,
+} from "react";
+
+const SmoothUIIsotype = () => (
+  <div className="flex size-7 items-center justify-center rounded-full bg-brand/20">
+    <svg
+      aria-hidden="true"
+      className="size-4 text-brand"
+      fill="currentColor"
+      viewBox="0 0 512 512"
+    >
+      <circle cx="256" cy="256" r="200" />
+    </svg>
+  </div>
+);
+
+const STEPS = [
+  {
+    id: "button",
+    title: "Base Button",
+    description: "Start with a plain button — no motion, no tracking.",
+  },
+  {
+    id: "track",
+    title: "Track the Cursor",
+    description:
+      "Measure the distance from the button center to the pointer on mouse move.",
+  },
+  {
+    id: "pull",
+    title: "Pull Towards the Cursor",
+    description:
+      "Translate the button proportionally, with a strength factor so it only drifts slightly.",
+  },
+  {
+    id: "radius",
+    title: "Radius Falloff",
+    description:
+      "Only react within a radius. The further from center, the weaker the pull.",
+  },
+  {
+    id: "spring",
+    title: "Spring Return",
+    description:
+      "Wrap the x/y values in useSpring so movement — and the release — feels organic.",
+  },
+  {
+    id: "accessibility",
+    title: "Accessibility",
+    description:
+      "Disable the effect on touch devices and when the user prefers reduced motion.",
+  },
+] as const;
+
+type StepId = (typeof STEPS)[number]["id"];
+
+const CODE_SNIPPETS: Record<StepId, string> = {
+  button: `<button className="rounded-md bg-primary px-6 py-2 text-primary-foreground">
+  Hover me
+</button>`,
+  track: `const handleMouseMove = (e: MouseEvent<HTMLDivElement>) => {
+  const rect = buttonRef.current!.getBoundingClientRect();
+  const centerX = rect.left + rect.width / 2;
+  const centerY = rect.top + rect.height / 2;
+  const dx = e.clientX - centerX;
+  const dy = e.clientY - centerY;
+};`,
+  pull: `// strength = 0.3 means the button drifts 30% of the distance
+x.set(dx * strength);
+y.set(dy * strength);
+
+// In JSX
+<motion.div style={{ x, y }}>
+  <button>Magnetic</button>
+</motion.div>`,
+  radius: `const distance = Math.sqrt(dx * dx + dy * dy);
+
+if (distance < radius) {
+  const falloff = 1 - distance / radius;
+  x.set(dx * strength * falloff);
+  y.set(dy * strength * falloff);
+} else {
+  x.set(0);
+  y.set(0);
+}`,
+  spring: `const x = useSpring(0, { duration: 0.4, bounce: 0.1 });
+const y = useSpring(0, { duration: 0.4, bounce: 0.1 });
+
+// On mouse leave, snap back:
+const handleMouseLeave = () => {
+  x.set(0);
+  y.set(0);
+};`,
+  accessibility: `const shouldReduceMotion = useReducedMotion();
+const [isHoverDevice, setIsHoverDevice] = useState(false);
+
+useEffect(() => {
+  const mq = window.matchMedia("(hover: hover) and (pointer: fine)");
+  setIsHoverDevice(mq.matches);
+}, []);
+
+const disabled = shouldReduceMotion || !isHoverDevice;`,
+};
+
+interface InteractiveMagneticButtonTutorialProps {
+  className?: string;
+}
+
+export function InteractiveMagneticButtonTutorial({
+  className,
+}: InteractiveMagneticButtonTutorialProps) {
+  const [currentStep, setCurrentStep] = useState<StepId>("button");
+  const shouldReduceMotion = useReducedMotion();
+  const stepRefs = useRef<Map<string, HTMLElement>>(new Map());
+  const indicatorRef = useRef<HTMLDivElement>(null);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const stepIndex = STEPS.findIndex((s) => s.id === currentStep);
+  const showTrack = stepIndex >= 1;
+  const showPull = stepIndex >= 2;
+  const showRadius = stepIndex >= 3;
+  const showSpring = stepIndex >= 4;
+
+  const strength = 0.4;
+  const radius = 140;
+
+  const rawX = useSpring(0, { duration: 0.4, bounce: 0.1 });
+  const rawY = useSpring(0, { duration: 0.4, bounce: 0.1 });
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            const id = entry.target.getAttribute("data-step");
+            if (id) setCurrentStep(id as StepId);
+          }
+        }
+      },
+      { threshold: 0.5, rootMargin: "-20% 0px -20% 0px" }
+    );
+    for (const ref of stepRefs.current.values()) observer.observe(ref);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const activeRef = stepRefs.current.get(currentStep);
+    const container =
+      indicatorRef.current?.parentElement?.querySelector(".space-y-6");
+    if (activeRef && indicatorRef.current && container) {
+      const top =
+        activeRef.getBoundingClientRect().top -
+        container.getBoundingClientRect().top +
+        16;
+      indicatorRef.current.style.transform = `translateY(${top}px)`;
+    }
+  }, [currentStep]);
+
+  const handleMouseMove = useCallback(
+    (event: MouseEvent<HTMLDivElement>) => {
+      if (!showTrack || !buttonRef.current || shouldReduceMotion) return;
+      const rect = buttonRef.current.getBoundingClientRect();
+      const centerX = rect.left + rect.width / 2;
+      const centerY = rect.top + rect.height / 2;
+      const dx = event.clientX - centerX;
+      const dy = event.clientY - centerY;
+      const distance = Math.sqrt(dx * dx + dy * dy);
+
+      if (!showPull) return;
+
+      if (showRadius) {
+        if (distance < radius) {
+          const falloff = 1 - distance / radius;
+          rawX.set(dx * strength * falloff);
+          rawY.set(dy * strength * falloff);
+        } else {
+          rawX.set(0);
+          rawY.set(0);
+        }
+      } else {
+        rawX.set(dx * strength);
+        rawY.set(dy * strength);
+      }
+    },
+    [showTrack, showPull, showRadius, shouldReduceMotion, rawX, rawY]
+  );
+
+  const handleMouseLeave = () => {
+    rawX.set(0);
+    rawY.set(0);
+  };
+
+  const handleStepClick = (stepId: StepId) => {
+    stepRefs.current
+      .get(stepId)
+      ?.scrollIntoView({ behavior: "smooth", block: "center" });
+  };
+
+  return (
+    <div className={cn("relative", className)}>
+      <div className="grid min-w-0 gap-8 lg:grid-cols-[1fr_400px]">
+        <div className="relative min-w-0">
+          <div
+            className="absolute -left-1 z-10 hidden transition-transform duration-300 ease-out lg:block"
+            ref={indicatorRef}
+            style={{ transform: "translateY(16px)" }}
+          >
+            <SmoothUIIsotype />
+          </div>
+
+          <div className="space-y-6 lg:pl-8">
+            {STEPS.map((step) => (
+              <section
+                className={cn(
+                  "relative cursor-pointer scroll-mt-32 rounded-xl p-4 transition-all hover:bg-muted/50",
+                  currentStep === step.id && "bg-muted/30"
+                )}
+                data-active={currentStep === step.id}
+                data-step={step.id}
+                key={step.id}
+                onClick={() => handleStepClick(step.id)}
+                ref={(el) => {
+                  if (el) stepRefs.current.set(step.id, el);
+                }}
+              >
+                <h3 className="mb-1 font-semibold text-foreground uppercase tracking-wide">
+                  {step.title}
+                </h3>
+                <p className="mb-4 text-muted-foreground text-sm">
+                  {step.description}
+                </p>
+                <div className="[&_figure]:!my-0 [&_pre]:!text-xs max-w-full overflow-x-auto rounded-lg text-sm [&_figure]:rounded-lg">
+                  <DynamicCodeBlock
+                    code={CODE_SNIPPETS[step.id]}
+                    lang="tsx"
+                    options={{
+                      themes: {
+                        light: "catppuccin-latte",
+                        dark: "catppuccin-mocha",
+                      },
+                    }}
+                  />
+                </div>
+              </section>
+            ))}
+          </div>
+        </div>
+
+        <div className="not-prose lg:sticky lg:top-32 lg:h-fit">
+          <div className="overflow-hidden rounded-2xl border bg-muted/20">
+            <div className="flex items-center justify-between border-b bg-muted/30 px-4 py-2">
+              <span className="font-medium text-muted-foreground text-xs uppercase tracking-wider">
+                Live Preview
+              </span>
+              <span className="rounded-full bg-brand/10 px-2 py-0.5 font-medium text-brand text-xs">
+                Step {stepIndex + 1}/{STEPS.length}
+              </span>
+            </div>
+            {/* biome-ignore lint/a11y/noStaticElementInteractions: preview area */}
+            <div
+              className="flex min-h-[350px] items-center justify-center bg-background p-8"
+              onMouseLeave={handleMouseLeave}
+              onMouseMove={handleMouseMove}
+              role="presentation"
+            >
+              <motion.div
+                style={
+                  showSpring
+                    ? { x: rawX, y: rawY }
+                    : showPull
+                      ? { x: rawX.get(), y: rawY.get() }
+                      : undefined
+                }
+              >
+                <button
+                  className="rounded-md bg-primary px-6 py-2 font-medium text-primary-foreground text-sm shadow-sm"
+                  ref={buttonRef}
+                  type="button"
+                >
+                  Hover me
+                </button>
+              </motion.div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/components/blog/interactive-number-flow-tutorial.tsx
+++ b/apps/docs/components/blog/interactive-number-flow-tutorial.tsx
@@ -1,0 +1,290 @@
+"use client";
+
+import { cn } from "@repo/shadcn-ui/lib/utils";
+import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { useEffect, useRef, useState } from "react";
+
+const SmoothUIIsotype = () => (
+  <div className="flex size-7 items-center justify-center rounded-full bg-brand/20">
+    <svg
+      aria-hidden="true"
+      className="size-4 text-brand"
+      fill="currentColor"
+      viewBox="0 0 512 512"
+    >
+      <circle cx="256" cy="256" r="200" />
+    </svg>
+  </div>
+);
+
+const STEPS = [
+  {
+    id: "static",
+    title: "Static Number",
+    description: "Start by rendering a number with tabular-nums so digits stay aligned.",
+  },
+  {
+    id: "digits",
+    title: "Split into Digits",
+    description:
+      "Convert the value to a string and animate each character independently.",
+  },
+  {
+    id: "presence",
+    title: "Animate Per Digit",
+    description:
+      "Use AnimatePresence keyed by the character so each digit can enter and exit.",
+  },
+  {
+    id: "direction",
+    title: "Direction-Aware",
+    description:
+      "Slide up when the value increases, slide down when it decreases.",
+  },
+  {
+    id: "spring",
+    title: "Spring Timing",
+    description: "A quick spring with low bounce keeps the motion crisp.",
+  },
+  {
+    id: "accessibility",
+    title: "Reduced Motion",
+    description: "Fall back to an instant swap when users prefer less motion.",
+  },
+] as const;
+
+type StepId = (typeof STEPS)[number]["id"];
+
+const CODE_SNIPPETS: Record<StepId, string> = {
+  static: `<span className="tabular-nums">{value}</span>`,
+  digits: `const digits = value.toString().split("");
+
+<span className="tabular-nums">
+  {digits.map((d, i) => <span key={i}>{d}</span>)}
+</span>`,
+  presence: `<AnimatePresence mode="popLayout" initial={false}>
+  <motion.span
+    key={digit + index}
+    initial={{ y: 12, opacity: 0 }}
+    animate={{ y: 0, opacity: 1 }}
+    exit={{ y: -12, opacity: 0 }}
+  >
+    {digit}
+  </motion.span>
+</AnimatePresence>`,
+  direction: `const direction = value > previous ? 1 : -1;
+
+initial={{ y: 12 * direction, opacity: 0 }}
+exit={{ y: -12 * direction, opacity: 0 }}`,
+  spring: `transition={{
+  type: "spring",
+  duration: 0.3,
+  bounce: 0.1,
+}}`,
+  accessibility: `const shouldReduceMotion = useReducedMotion();
+
+transition={shouldReduceMotion
+  ? { duration: 0 }
+  : { type: "spring", duration: 0.3, bounce: 0.1 }}`,
+};
+
+interface InteractiveNumberFlowTutorialProps {
+  className?: string;
+}
+
+export function InteractiveNumberFlowTutorial({
+  className,
+}: InteractiveNumberFlowTutorialProps) {
+  const [currentStep, setCurrentStep] = useState<StepId>("static");
+  const [value, setValue] = useState(100);
+  const previousValueRef = useRef(100);
+  const shouldReduceMotion = useReducedMotion();
+  const stepRefs = useRef<Map<string, HTMLElement>>(new Map());
+  const indicatorRef = useRef<HTMLDivElement>(null);
+
+  const stepIndex = STEPS.findIndex((s) => s.id === currentStep);
+  const splitDigits = stepIndex >= 1;
+  const animate = stepIndex >= 2;
+  const directional = stepIndex >= 3;
+  const useSpring = stepIndex >= 4;
+  const respectReducedMotion = stepIndex >= 5;
+
+  const direction = directional
+    ? value >= previousValueRef.current
+      ? 1
+      : -1
+    : 1;
+
+  useEffect(() => {
+    previousValueRef.current = value;
+  }, [value]);
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            const id = entry.target.getAttribute("data-step");
+            if (id) setCurrentStep(id as StepId);
+          }
+        }
+      },
+      { threshold: 0.5, rootMargin: "-20% 0px -20% 0px" }
+    );
+    for (const ref of stepRefs.current.values()) observer.observe(ref);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const activeRef = stepRefs.current.get(currentStep);
+    const container =
+      indicatorRef.current?.parentElement?.querySelector(".space-y-6");
+    if (activeRef && indicatorRef.current && container) {
+      const top =
+        activeRef.getBoundingClientRect().top -
+        container.getBoundingClientRect().top +
+        16;
+      indicatorRef.current.style.transform = `translateY(${top}px)`;
+    }
+  }, [currentStep]);
+
+  const handleStepClick = (stepId: StepId) => {
+    stepRefs.current
+      .get(stepId)
+      ?.scrollIntoView({ behavior: "smooth", block: "center" });
+  };
+
+  const effectiveReduced = respectReducedMotion && shouldReduceMotion;
+  const transition = effectiveReduced
+    ? { duration: 0 }
+    : useSpring
+      ? { type: "spring" as const, duration: 0.3, bounce: 0.1 }
+      : { duration: 0.2 };
+
+  const digits = value.toString().split("");
+
+  return (
+    <div className={cn("relative", className)}>
+      <div className="grid min-w-0 gap-8 lg:grid-cols-[1fr_400px]">
+        <div className="relative min-w-0">
+          <div
+            className="absolute -left-1 z-10 hidden transition-transform duration-300 ease-out lg:block"
+            ref={indicatorRef}
+            style={{ transform: "translateY(16px)" }}
+          >
+            <SmoothUIIsotype />
+          </div>
+          <div className="space-y-6 lg:pl-8">
+            {STEPS.map((step) => (
+              <section
+                className={cn(
+                  "relative cursor-pointer scroll-mt-32 rounded-xl p-4 transition-all hover:bg-muted/50",
+                  currentStep === step.id && "bg-muted/30"
+                )}
+                data-step={step.id}
+                key={step.id}
+                onClick={() => handleStepClick(step.id)}
+                ref={(el) => {
+                  if (el) stepRefs.current.set(step.id, el);
+                }}
+              >
+                <h3 className="mb-1 font-semibold text-foreground uppercase tracking-wide">
+                  {step.title}
+                </h3>
+                <p className="mb-4 text-muted-foreground text-sm">
+                  {step.description}
+                </p>
+                <div className="[&_figure]:!my-0 [&_pre]:!text-xs max-w-full overflow-x-auto rounded-lg text-sm [&_figure]:rounded-lg">
+                  <DynamicCodeBlock
+                    code={CODE_SNIPPETS[step.id]}
+                    lang="tsx"
+                    options={{
+                      themes: {
+                        light: "catppuccin-latte",
+                        dark: "catppuccin-mocha",
+                      },
+                    }}
+                  />
+                </div>
+              </section>
+            ))}
+          </div>
+        </div>
+
+        <div className="not-prose lg:sticky lg:top-32 lg:h-fit">
+          <div className="overflow-hidden rounded-2xl border bg-muted/20">
+            <div className="flex items-center justify-between border-b bg-muted/30 px-4 py-2">
+              <span className="font-medium text-muted-foreground text-xs uppercase tracking-wider">
+                Live Preview
+              </span>
+              <span className="rounded-full bg-brand/10 px-2 py-0.5 font-medium text-brand text-xs">
+                Step {stepIndex + 1}/{STEPS.length}
+              </span>
+            </div>
+            <div className="flex min-h-[350px] flex-col items-center justify-center gap-6 bg-background p-8">
+              <div className="flex items-baseline gap-1 font-semibold text-5xl text-foreground tabular-nums">
+                <span className="text-muted-foreground text-2xl">$</span>
+                {splitDigits ? (
+                  <span className="inline-flex overflow-hidden">
+                    {digits.map((digit, index) =>
+                      animate ? (
+                        <span
+                          className="relative inline-block h-[1em] overflow-hidden leading-none"
+                          // biome-ignore lint/suspicious/noArrayIndexKey: digit position is meaningful
+                          key={`slot-${index}`}
+                          style={{ width: "0.6em" }}
+                        >
+                          <AnimatePresence initial={false} mode="popLayout">
+                            <motion.span
+                              animate={{ y: 0, opacity: 1 }}
+                              className="absolute inset-0 flex items-center justify-center"
+                              exit={{
+                                y: -18 * direction,
+                                opacity: 0,
+                              }}
+                              initial={{
+                                y: 18 * direction,
+                                opacity: 0,
+                              }}
+                              key={`${digit}-${index}-${value}`}
+                              transition={transition}
+                            >
+                              {digit}
+                            </motion.span>
+                          </AnimatePresence>
+                        </span>
+                      ) : (
+                        // biome-ignore lint/suspicious/noArrayIndexKey: static render
+                        <span key={`static-${index}`}>{digit}</span>
+                      )
+                    )}
+                  </span>
+                ) : (
+                  <span>{value}</span>
+                )}
+              </div>
+
+              <div className="flex gap-2">
+                <button
+                  className="rounded-md border border-border bg-muted px-3 py-1.5 font-medium text-sm hover:bg-muted/70"
+                  onClick={() => setValue((v) => Math.max(0, v - 7))}
+                  type="button"
+                >
+                  − 7
+                </button>
+                <button
+                  className="rounded-md border border-border bg-muted px-3 py-1.5 font-medium text-sm hover:bg-muted/70"
+                  onClick={() => setValue((v) => v + 7)}
+                  type="button"
+                >
+                  + 7
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/components/blog/interactive-scramble-hover-tutorial.tsx
+++ b/apps/docs/components/blog/interactive-scramble-hover-tutorial.tsx
@@ -1,0 +1,273 @@
+"use client";
+
+import { cn } from "@repo/shadcn-ui/lib/utils";
+import { DynamicCodeBlock } from "fumadocs-ui/components/dynamic-codeblock";
+import { useEffect, useRef, useState } from "react";
+
+const SmoothUIIsotype = () => (
+  <div className="flex size-7 items-center justify-center rounded-full bg-brand/20">
+    <svg
+      aria-hidden="true"
+      className="size-4 text-brand"
+      fill="currentColor"
+      viewBox="0 0 512 512"
+    >
+      <circle cx="256" cy="256" r="200" />
+    </svg>
+  </div>
+);
+
+const CHARACTERS =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*".split(
+    ""
+  );
+
+const STEPS = [
+  {
+    id: "base",
+    title: "Base Text",
+    description: "Start with a simple button rendering a string.",
+  },
+  {
+    id: "scramble",
+    title: "Scramble Function",
+    description:
+      "Write a pure function that replaces every character (except spaces) with a random one.",
+  },
+  {
+    id: "interval",
+    title: "Interval Loop",
+    description:
+      "On hover, run setInterval to reshuffle the text every few milliseconds.",
+  },
+  {
+    id: "timeout",
+    title: "Stop & Restore",
+    description:
+      "Use setTimeout so the scramble lasts a fixed duration, then reset to the original text.",
+  },
+  {
+    id: "cleanup",
+    title: "Cleanup on Leave",
+    description:
+      "Clear timers when the pointer leaves so animations don't leak or overlap.",
+  },
+  {
+    id: "accessibility",
+    title: "Accessibility",
+    description:
+      "Detect hover-capable devices and respect prefers-reduced-motion.",
+  },
+] as const;
+
+type StepId = (typeof STEPS)[number]["id"];
+
+const CODE_SNIPPETS: Record<StepId, string> = {
+  base: `<button>{text}</button>`,
+  scramble: `const CHARACTERS = "ABC...xyz0123!@#".split("");
+
+function scrambleText(original: string) {
+  return original
+    .split("")
+    .map((c) =>
+      c === " " ? " " : CHARACTERS[Math.floor(Math.random() * CHARACTERS.length)]
+    )
+    .join("");
+}`,
+  interval: `const [display, setDisplay] = useState(text);
+
+const handleMouseEnter = () => {
+  intervalRef.current = setInterval(() => {
+    setDisplay(scrambleText(text));
+  }, 30);
+};`,
+  timeout: `const handleMouseEnter = () => {
+  intervalRef.current = setInterval(() => {
+    setDisplay(scrambleText(text));
+  }, 30);
+
+  timeoutRef.current = setTimeout(() => {
+    clearInterval(intervalRef.current!);
+    setDisplay(text); // snap back to original
+  }, 600);
+};`,
+  cleanup: `const handleMouseLeave = () => {
+  clearInterval(intervalRef.current!);
+  clearTimeout(timeoutRef.current!);
+  setDisplay(text);
+};`,
+  accessibility: `useEffect(() => {
+  const motion = matchMedia("(prefers-reduced-motion: reduce)");
+  const hover = matchMedia("(hover: hover) and (pointer: fine)");
+  setReduced(motion.matches);
+  setHasHover(hover.matches);
+}, []);
+
+const onEnter = reduced || !hasHover ? undefined : handleMouseEnter;`,
+};
+
+interface InteractiveScrambleHoverTutorialProps {
+  className?: string;
+}
+
+function scrambleText(original: string) {
+  return original
+    .split("")
+    .map((c) =>
+      c === " "
+        ? " "
+        : CHARACTERS[Math.floor(Math.random() * CHARACTERS.length)]
+    )
+    .join("");
+}
+
+export function InteractiveScrambleHoverTutorial({
+  className,
+}: InteractiveScrambleHoverTutorialProps) {
+  const ORIGINAL = "Scramble Me";
+  const [currentStep, setCurrentStep] = useState<StepId>("base");
+  const [display, setDisplay] = useState(ORIGINAL);
+  const stepRefs = useRef<Map<string, HTMLElement>>(new Map());
+  const indicatorRef = useRef<HTMLDivElement>(null);
+  const intervalRef = useRef<NodeJS.Timeout | null>(null);
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  const stepIndex = STEPS.findIndex((s) => s.id === currentStep);
+  const canScramble = stepIndex >= 2;
+  const hasTimeout = stepIndex >= 3;
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            const id = entry.target.getAttribute("data-step");
+            if (id) setCurrentStep(id as StepId);
+          }
+        }
+      },
+      { threshold: 0.5, rootMargin: "-20% 0px -20% 0px" }
+    );
+    for (const ref of stepRefs.current.values()) observer.observe(ref);
+    return () => observer.disconnect();
+  }, []);
+
+  useEffect(() => {
+    const activeRef = stepRefs.current.get(currentStep);
+    const container =
+      indicatorRef.current?.parentElement?.querySelector(".space-y-6");
+    if (activeRef && indicatorRef.current && container) {
+      const top =
+        activeRef.getBoundingClientRect().top -
+        container.getBoundingClientRect().top +
+        16;
+      indicatorRef.current.style.transform = `translateY(${top}px)`;
+    }
+  }, [currentStep]);
+
+  const clearTimers = () => {
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    if (timeoutRef.current) clearTimeout(timeoutRef.current);
+  };
+
+  const handleEnter = () => {
+    if (!canScramble) return;
+    clearTimers();
+    intervalRef.current = setInterval(() => {
+      setDisplay(scrambleText(ORIGINAL));
+    }, 30);
+    if (hasTimeout) {
+      timeoutRef.current = setTimeout(() => {
+        if (intervalRef.current) clearInterval(intervalRef.current);
+        setDisplay(ORIGINAL);
+      }, 600);
+    }
+  };
+
+  const handleLeave = () => {
+    clearTimers();
+    setDisplay(ORIGINAL);
+  };
+
+  const handleStepClick = (stepId: StepId) => {
+    stepRefs.current
+      .get(stepId)
+      ?.scrollIntoView({ behavior: "smooth", block: "center" });
+  };
+
+  return (
+    <div className={cn("relative", className)}>
+      <div className="grid min-w-0 gap-8 lg:grid-cols-[1fr_400px]">
+        <div className="relative min-w-0">
+          <div
+            className="absolute -left-1 z-10 hidden transition-transform duration-300 ease-out lg:block"
+            ref={indicatorRef}
+            style={{ transform: "translateY(16px)" }}
+          >
+            <SmoothUIIsotype />
+          </div>
+          <div className="space-y-6 lg:pl-8">
+            {STEPS.map((step) => (
+              <section
+                className={cn(
+                  "relative cursor-pointer scroll-mt-32 rounded-xl p-4 transition-all hover:bg-muted/50",
+                  currentStep === step.id && "bg-muted/30"
+                )}
+                data-step={step.id}
+                key={step.id}
+                onClick={() => handleStepClick(step.id)}
+                ref={(el) => {
+                  if (el) stepRefs.current.set(step.id, el);
+                }}
+              >
+                <h3 className="mb-1 font-semibold text-foreground uppercase tracking-wide">
+                  {step.title}
+                </h3>
+                <p className="mb-4 text-muted-foreground text-sm">
+                  {step.description}
+                </p>
+                <div className="[&_figure]:!my-0 [&_pre]:!text-xs max-w-full overflow-x-auto rounded-lg text-sm [&_figure]:rounded-lg">
+                  <DynamicCodeBlock
+                    code={CODE_SNIPPETS[step.id]}
+                    lang="tsx"
+                    options={{
+                      themes: {
+                        light: "catppuccin-latte",
+                        dark: "catppuccin-mocha",
+                      },
+                    }}
+                  />
+                </div>
+              </section>
+            ))}
+          </div>
+        </div>
+
+        <div className="not-prose lg:sticky lg:top-32 lg:h-fit">
+          <div className="overflow-hidden rounded-2xl border bg-muted/20">
+            <div className="flex items-center justify-between border-b bg-muted/30 px-4 py-2">
+              <span className="font-medium text-muted-foreground text-xs uppercase tracking-wider">
+                Live Preview
+              </span>
+              <span className="rounded-full bg-brand/10 px-2 py-0.5 font-medium text-brand text-xs">
+                Step {stepIndex + 1}/{STEPS.length}
+              </span>
+            </div>
+            <div className="flex min-h-[350px] items-center justify-center bg-background p-8">
+              <button
+                className="rounded-md bg-muted px-6 py-3 font-mono font-semibold text-foreground text-lg tabular-nums"
+                onBlur={handleLeave}
+                onFocus={handleEnter}
+                onMouseEnter={handleEnter}
+                onMouseLeave={handleLeave}
+                type="button"
+              >
+                {display}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/docs/components/landing/navbar/menu-illustration.tsx
+++ b/apps/docs/components/landing/navbar/menu-illustration.tsx
@@ -150,6 +150,189 @@ export function MenuIllustration({
   );
 }
 
+// Resources MenuIllustration - for blog, sponsors, skills
+export function ResourcesMenuIllustration({
+  activeSection,
+  className = "",
+}: MenuIllustrationProps) {
+  return (
+    <motion.svg
+      animate={{ opacity: 1 }}
+      aria-label={`Resources menu illustration for ${activeSection} section`}
+      className={cn(className, "overflow-hidden rounded-md")}
+      fill="none"
+      height="231"
+      initial={{ opacity: 0 }}
+      role="img"
+      style={{ overflow: "hidden" }}
+      transition={{ duration: 0.3, ease: "easeOut" }}
+      viewBox="0 0 231 231"
+      width="231"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <defs>
+        <clipPath id="clip0_resources">
+          <rect height="231" rx="7.22" width="231" />
+        </clipPath>
+      </defs>
+      <g clipPath="url(#clip0_resources)">
+        <rect
+          className="fill-brand-secondary"
+          height="231"
+          rx="7.22"
+          width="231"
+        />
+
+        {/* Blog — stacked article cards */}
+        <motion.g
+          animate={{
+            opacity: activeSection === "blog" ? 1 : 0,
+            y: activeSection === "blog" ? 0 : 20,
+          }}
+          initial={{ opacity: 0, y: 20 }}
+          transition={{ duration: 0.4, ease: "easeOut" }}
+        >
+          <rect
+            height="55"
+            rx="10"
+            style={{ fill: "var(--color-brand-lighter)" }}
+            width="260"
+            x="-15"
+            y="24"
+          />
+          <rect
+            height="12"
+            rx="6"
+            style={{ fill: "var(--color-brand)" }}
+            width="120"
+            x="20"
+            y="38"
+          />
+          <rect
+            height="8"
+            rx="4"
+            style={{ fill: "var(--color-brand-light)" }}
+            width="180"
+            x="20"
+            y="58"
+          />
+          <rect
+            height="55"
+            rx="10"
+            style={{ fill: "var(--color-brand-light)" }}
+            width="260"
+            x="-15"
+            y="88"
+          />
+          <rect
+            height="12"
+            rx="6"
+            style={{ fill: "var(--color-brand)" }}
+            width="150"
+            x="20"
+            y="102"
+          />
+          <rect
+            height="8"
+            rx="4"
+            style={{ fill: "var(--color-brand-lighter)" }}
+            width="160"
+            x="20"
+            y="122"
+          />
+          <rect
+            height="55"
+            rx="10"
+            style={{ fill: "var(--color-brand-lighter)" }}
+            width="260"
+            x="-15"
+            y="152"
+          />
+          <rect
+            height="12"
+            rx="6"
+            style={{ fill: "var(--color-brand)" }}
+            width="100"
+            x="20"
+            y="166"
+          />
+          <rect
+            height="8"
+            rx="4"
+            style={{ fill: "var(--color-brand-light)" }}
+            width="190"
+            x="20"
+            y="186"
+          />
+        </motion.g>
+
+        {/* Sponsors — big heart */}
+        <motion.g
+          animate={{
+            opacity: activeSection === "sponsors" ? 1 : 0,
+            scale: activeSection === "sponsors" ? 1 : 0.9,
+          }}
+          initial={{ opacity: 0, scale: 0.9 }}
+          style={{ transformOrigin: "115.5px 115.5px" }}
+          transition={{ duration: 0.4, ease: "easeOut" }}
+        >
+          <path
+            d="M115.5 185 C 60 150, 30 115, 30 80 C 30 55, 50 38, 75 38 C 92 38, 108 48, 115.5 62 C 123 48, 139 38, 156 38 C 181 38, 201 55, 201 80 C 201 115, 171 150, 115.5 185 Z"
+            style={{ fill: "var(--color-brand)" }}
+          />
+          <path
+            d="M115.5 165 C 75 137, 50 110, 50 83 C 50 68, 62 57, 78 57 C 92 57, 105 66, 115.5 80 C 126 66, 139 57, 153 57 C 169 57, 181 68, 181 83 C 181 110, 156 137, 115.5 165 Z"
+            style={{ fill: "var(--color-brand-light)" }}
+          />
+        </motion.g>
+
+        {/* Skills — wand + sparkles (centered on canvas diagonal) */}
+        <motion.g
+          animate={{
+            opacity: activeSection === "skills" ? 1 : 0,
+            rotate: activeSection === "skills" ? 0 : -8,
+          }}
+          initial={{ opacity: 0, rotate: -8 }}
+          style={{ transformOrigin: "115.5px 115.5px" }}
+          transition={{ duration: 0.4, ease: "easeOut" }}
+        >
+          {/* Wand shaft — centered bar rotated on the canvas diagonal */}
+          <rect
+            height="18"
+            rx="9"
+            style={{ fill: "var(--color-brand)" }}
+            transform="rotate(-45 115.5 115.5)"
+            width="150"
+            x="40.5"
+            y="106.5"
+          />
+          {/* Wand tip sparkle (top-right end) */}
+          <path
+            d="M167 60 L174 78 L192 85 L174 92 L167 110 L160 92 L142 85 L160 78 Z"
+            style={{ fill: "var(--color-brand-lighter)" }}
+          />
+          {/* Handle dot (bottom-left end) */}
+          <circle
+            cx="64"
+            cy="167"
+            r="10"
+            style={{ fill: "var(--color-brand-lighter)" }}
+          />
+          {/* Balanced accent sparkles */}
+          <path
+            d="M58 58 L62 70 L74 74 L62 78 L58 90 L54 78 L42 74 L54 70 Z"
+            style={{ fill: "var(--color-brand-light)" }}
+          />
+          <path
+            d="M173 155 L176 164 L185 167 L176 170 L173 179 L170 170 L161 167 L170 164 Z"
+            style={{ fill: "var(--color-brand-light)" }}
+          />
+        </motion.g>
+      </g>
+    </motion.svg>
+  );
+}
+
 // Blocks MenuIllustration - for hero, pricing, testimonial
 export function BlocksMenuIllustration({
   activeSection,

--- a/apps/docs/components/landing/navbar/mobile-navbar.tsx
+++ b/apps/docs/components/landing/navbar/mobile-navbar.tsx
@@ -4,6 +4,7 @@ import Logo from "@docs/components/logo";
 import { Button } from "@docs/components/smoothbutton";
 import {
   Book,
+  Compass,
   FileText,
   Heart,
   Layers3,
@@ -203,18 +204,48 @@ export function MobileNavbar({ className }: MobileNavbarProps) {
                 <Book size={16} />
                 Docs
               </Link>
-              <Link className="mobile-navbar-link" href="/blog">
-                <FileText size={16} />
-                Blog
-              </Link>
-              <Link className="mobile-navbar-link" href="/docs/guides/sponsors">
-                <Heart size={16} />
-                Sponsors
-              </Link>
-              <a className="mobile-navbar-link" href="https://skills.smoothui.dev" rel="noopener noreferrer" target="_blank">
-                <Wand2 size={16} />
-                Skills
-              </a>
+            </motion.div>
+
+            <motion.div
+              animate={
+                shouldReduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }
+              }
+              className="mobile-navbar-section"
+              initial={
+                shouldReduceMotion ? { opacity: 1 } : { opacity: 0, y: 10 }
+              }
+              transition={
+                shouldReduceMotion
+                  ? { duration: 0 }
+                  : { delay: 0.18, duration: 0.2 }
+              }
+            >
+              <div className="mobile-navbar-section-title">
+                <Compass size={16} />
+                Resources
+              </div>
+              <div className="mobile-navbar-links">
+                <Link className="mobile-navbar-link" href="/blog">
+                  <FileText size={16} />
+                  Blog
+                </Link>
+                <Link
+                  className="mobile-navbar-link"
+                  href="/docs/guides/sponsors"
+                >
+                  <Heart size={16} />
+                  Sponsors
+                </Link>
+                <a
+                  className="mobile-navbar-link"
+                  href="https://skills.smoothui.dev"
+                  rel="noopener noreferrer"
+                  target="_blank"
+                >
+                  <Wand2 size={16} />
+                  Skills
+                </a>
+              </div>
             </motion.div>
 
             <motion.div

--- a/apps/docs/components/landing/navbar/navbar.tsx
+++ b/apps/docs/components/landing/navbar/navbar.tsx
@@ -12,6 +12,7 @@ import {
 import {
   ArrowRight,
   Book,
+  Compass,
   FileText,
   Heart,
   Layers3,
@@ -33,7 +34,11 @@ import { useIsMobile } from "@repo/shadcn-ui/hooks/use-mobile";
 import Link from "next/link";
 import { cn } from "@/lib/utils";
 import { GithubStars } from "./github-stars";
-import { BlocksMenuIllustration, MenuIllustration } from "./menu-illustration";
+import {
+  BlocksMenuIllustration,
+  MenuIllustration,
+  ResourcesMenuIllustration,
+} from "./menu-illustration";
 import { MobileNavbar } from "./mobile-navbar";
 
 // Preview components data
@@ -80,6 +85,7 @@ interface NavbarProps {
 export default function Navbar({ className }: NavbarProps) {
   const [hoveredComponent, setHoveredComponent] = useState<string | null>(null);
   const [hoveredBlock, setHoveredBlock] = useState<string | null>(null);
+  const [hoveredResource, setHoveredResource] = useState<string | null>(null);
   const isMobile = useIsMobile();
 
   // Show mobile navbar on mobile devices
@@ -229,19 +235,62 @@ export default function Navbar({ className }: NavbarProps) {
           </NavigationMenuLink>
         </NavigationMenuItem>
         <NavigationMenuItem>
-          <NavigationMenuLink className="trigger" href="/blog">
-            <FileText size={16} /> Blog
-          </NavigationMenuLink>
-        </NavigationMenuItem>
-        <NavigationMenuItem>
-          <NavigationMenuLink className="trigger" href="/docs/guides/sponsors">
-            <Heart size={16} /> Sponsors
-          </NavigationMenuLink>
-        </NavigationMenuItem>
-        <NavigationMenuItem>
-          <NavigationMenuLink className="trigger" href="https://skills.smoothui.dev" rel="noopener noreferrer" target="_blank">
-            <Wand2 size={16} /> Skills
-          </NavigationMenuLink>
+          <NavigationMenuTrigger className="trigger !cursor-default">
+            <Compass size={16} />
+            Resources
+          </NavigationMenuTrigger>
+          <NavigationMenuContent className="content">
+            <div className="enhanced-submenu">
+              <div className="submenu-nav">
+                <div className="submenu-items">
+                  <EnhancedListItem
+                    href="/blog"
+                    icon={<FileText size={20} />}
+                    onHover={() => setHoveredResource("blog")}
+                    onLeave={() => setHoveredResource(null)}
+                    title="Blog"
+                  >
+                    Interactive tutorials and deep dives on components.
+                  </EnhancedListItem>
+                  <EnhancedListItem
+                    href="/docs/guides/sponsors"
+                    icon={<Heart size={20} />}
+                    onHover={() => setHoveredResource("sponsors")}
+                    onLeave={() => setHoveredResource(null)}
+                    title="Sponsors"
+                  >
+                    Support the project and meet our backers.
+                  </EnhancedListItem>
+                  <EnhancedListItem
+                    external
+                    href="https://skills.smoothui.dev"
+                    icon={<Wand2 size={20} />}
+                    onHover={() => setHoveredResource("skills")}
+                    onLeave={() => setHoveredResource(null)}
+                    title="Skills"
+                  >
+                    Claude Code skills to scaffold SmoothUI components.
+                  </EnhancedListItem>
+                </div>
+                <Link
+                  className="mt-4 flex items-center gap-2 font-medium text-foreground/70 text-sm transition-colors hover:text-foreground"
+                  href="/blog"
+                >
+                  Read the blog
+                  <ArrowRight size={14} />
+                </Link>
+              </div>
+
+              <div className="submenu-preview">
+                <div className="flex h-full w-full items-center justify-center">
+                  <ResourcesMenuIllustration
+                    activeSection={hoveredResource ?? "blog"}
+                    className="h-full w-full"
+                  />
+                </div>
+              </div>
+            </div>
+          </NavigationMenuContent>
         </NavigationMenuItem>
       </NavigationMenuList>
       <div className="viewport-position">
@@ -261,6 +310,7 @@ interface EnhancedListItemProps {
   href: string;
   onHover: () => void;
   onLeave: () => void;
+  external?: boolean;
 }
 
 function EnhancedListItem({
@@ -270,8 +320,13 @@ function EnhancedListItem({
   href,
   onHover,
   onLeave,
+  external,
   ...props
 }: EnhancedListItemProps) {
+  const externalProps = external
+    ? { rel: "noopener noreferrer", target: "_blank" }
+    : {};
+
   return (
     <NavigationMenuLink asChild>
       <Link
@@ -279,6 +334,7 @@ function EnhancedListItem({
         href={href}
         onMouseEnter={onHover}
         onMouseLeave={onLeave}
+        {...externalProps}
         {...props}
       >
         <div className="enhanced-list-item-icon frame-box relative">{icon}</div>

--- a/apps/docs/content/blog/building-animated-tabs.mdx
+++ b/apps/docs/content/blog/building-animated-tabs.mdx
@@ -1,0 +1,34 @@
+---
+title: "Building Animated Tabs with a Shared Layout Indicator"
+description: "How to build tabs where a single pill slides smoothly between the active option, with full keyboard support and reduced-motion compliance."
+date: "2026-04-14"
+author: "Eduardo Calvo"
+---
+
+import { InteractiveAnimatedTabsTutorial } from "@docs/components/blog/interactive-animated-tabs-tutorial";
+import { Installer } from "@docs/components/installer";
+
+In this tutorial, we'll build the **Animated Tabs** component step by step. Click between tabs in the preview to see the shared indicator slide as each layer is added.
+
+<InteractiveAnimatedTabsTutorial className="mt-8" />
+
+---
+
+## Key Takeaways
+
+After building this component, you've learned:
+
+1. **`layoutId`** is Motion's magic for shared-element transitions
+2. **`role="tablist"` + `aria-selected`** gives you accessibility for free
+3. **Arrow keys + Home/End** are expected in tab widgets — don't skip them
+4. **Spring with `bounce: 0.05`** keeps the slide tight and professional
+5. **Reduce motion = `duration: 0`** — instant, not "soft"
+6. **Unique `layoutId` per instance** prevents cross-talk when you render multiple tab groups
+
+---
+
+## Install the Component
+
+<Installer packageName="animated-tabs" />
+
+Check out the [full documentation](/docs/components/animated-tabs) for all props and variations.

--- a/apps/docs/content/blog/building-magnetic-button.mdx
+++ b/apps/docs/content/blog/building-magnetic-button.mdx
@@ -1,0 +1,34 @@
+---
+title: "Building a Magnetic Button with Cursor Physics"
+description: "Learn how to build a button that's pulled towards the user's cursor — with radius falloff, spring physics, and full accessibility support."
+date: "2026-04-14"
+author: "Eduardo Calvo"
+---
+
+import { InteractiveMagneticButtonTutorial } from "@docs/components/blog/interactive-magnetic-button-tutorial";
+import { Installer } from "@docs/components/installer";
+
+In this tutorial, we'll build the **Magnetic Button** step by step. Move your cursor near the preview — the button will lean towards you as you add each layer.
+
+<InteractiveMagneticButtonTutorial className="mt-8" />
+
+---
+
+## Key Takeaways
+
+After building this component, you've learned:
+
+1. **Distance math** with `getBoundingClientRect` + `Math.sqrt` drives the effect
+2. **A strength factor < 1** keeps the motion subtle — 0.3–0.4 is a sweet spot
+3. **Radius falloff** makes the interaction local instead of global
+4. **`useSpring`** turns raw deltas into organic motion, including the snap-back
+5. **Touch + reduced-motion checks** are not optional — always gate hover effects
+6. **Only animate `transform`** (via `x`/`y` motion values) for 60fps performance
+
+---
+
+## Install the Component
+
+<Installer packageName="magnetic-button" />
+
+Check out the [full documentation](/docs/components/magnetic-button) for all props and variations.

--- a/apps/docs/content/blog/building-number-flow.mdx
+++ b/apps/docs/content/blog/building-number-flow.mdx
@@ -1,0 +1,34 @@
+---
+title: "Building a Number Flow Animation"
+description: "A step-by-step guide to animating numeric values digit-by-digit with direction-aware motion, tabular alignment, and accessibility in mind."
+date: "2026-04-14"
+author: "Eduardo Calvo"
+---
+
+import { InteractiveNumberFlowTutorial } from "@docs/components/blog/interactive-number-flow-tutorial";
+import { Installer } from "@docs/components/installer";
+
+In this tutorial, we'll build a **Number Flow** animation step by step. Use the + / − buttons in the preview to trigger the animation as each layer is added.
+
+<InteractiveNumberFlowTutorial className="mt-8" />
+
+---
+
+## Key Takeaways
+
+After building this component, you've learned:
+
+1. **`tabular-nums`** keeps digits at a fixed width — essential for any animated counter
+2. **Split by character** so digits can enter and exit independently
+3. **`AnimatePresence` with `mode="popLayout"`** lets old and new digits coexist during transition
+4. **Direction-aware motion** (sliding up vs. down) makes increments and decrements feel different
+5. **Springs with low bounce** read as "mechanical" — perfect for numbers and counters
+6. **Reduced motion swaps instantly** — the number still updates, just without the slide
+
+---
+
+## Install the Component
+
+<Installer packageName="number-flow" />
+
+Check out the [full documentation](/docs/components/number-flow) for all props and variations.

--- a/apps/docs/content/blog/building-scramble-hover.mdx
+++ b/apps/docs/content/blog/building-scramble-hover.mdx
@@ -1,0 +1,34 @@
+---
+title: "Building a Scramble-on-Hover Text Effect"
+description: "A tutorial on crafting the cyberpunk-style text scramble effect with pure React, timers, and proper cleanup — no external libs required."
+date: "2026-04-14"
+author: "Eduardo Calvo"
+---
+
+import { InteractiveScrambleHoverTutorial } from "@docs/components/blog/interactive-scramble-hover-tutorial";
+import { Installer } from "@docs/components/installer";
+
+In this tutorial, we'll build the **Scramble Hover** effect step by step. Hover the preview text after each step to see what you've unlocked.
+
+<InteractiveScrambleHoverTutorial className="mt-8" />
+
+---
+
+## Key Takeaways
+
+After building this component, you've learned:
+
+1. **Pure, stateless scramble functions** are easy to test and reuse
+2. **Preserve spaces** so the silhouette of the text stays readable
+3. **30ms intervals** feel glitchy without being unreadable; 600ms total is a natural duration
+4. **Refs for timers** — never put `setInterval` IDs in state
+5. **Always clean up** both timers on leave; otherwise hovers can stack
+6. **Gate on `hover:hover`** so touch devices don't fire the effect on tap
+
+---
+
+## Install the Component
+
+<Installer packageName="scramble-hover" />
+
+Check out the [full documentation](/docs/components/scramble-hover) for all props and variations.

--- a/packages/smoothui/tsconfig.json
+++ b/packages/smoothui/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "@repo/typescript-config/nextjs.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@repo/*": ["../*"],
+      "@/components/*": ["../shadcn-ui/components/*"],
+      "@/lib/*": ["../shadcn-ui/lib/*"]
+    },
+    "strictNullChecks": true
+  },
+  "include": [
+    "components/**/*.ts",
+    "components/**/*.tsx",
+    "hooks/**/*.ts",
+    "hooks/**/*.tsx",
+    "utils/**/*.ts",
+    "lib/**/*.ts"
+  ],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- Refactor navbar (desktop + mobile) to group **Blog**, **Sponsors**, and **Skills** under a new **Resources** dropdown so the top-level bar stays tidy as we add more items.
- Add `ResourcesMenuIllustration` with three animated sections (blog cards, sponsors heart, skills wand) matching the existing Components/Blocks preview pattern.
- Add 4 new interactive tutorial blog posts following the existing scroll-triggered format:
  - Building a Magnetic Button with Cursor Physics
  - Building a Scramble-on-Hover Text Effect
  - Building Animated Tabs with a Shared Layout Indicator
  - Building a Number Flow Animation

## Test plan
- [ ] `pnpm dev` — verify Resources dropdown renders on desktop, illustration swaps between blog/sponsors/skills on hover
- [ ] Verify mobile navbar shows the new Resources section
- [ ] Open each of the 4 new blog posts and scroll through each step to confirm the live preview updates
- [ ] Test `prefers-reduced-motion` — animations should be instant in all four tutorials
- [ ] `pnpm check` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added four interactive step-by-step tutorials with live previews: animated tabs, magnetic button, number flow, and scramble-on-hover.
  * Reworked navigation to a consolidated "Resources" menu (including blog, sponsors, skills) with an animated preview illustration and mobile adjustments.

* **Documentation**
  * Published four new blog posts embedding each interactive tutorial and installation/key-takeaway notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->