### PR TITLE
refactor: landing visual polish, blog redesign + SEO articles, Husky + CI

### DIFF
--- a/apps/docs/components/landing/ai-section.tsx
+++ b/apps/docs/components/landing/ai-section.tsx
@@ -27,7 +27,7 @@ function McpIllustration() {
           <span className="text-foreground/60 text-sm">AI Agent</span>
         </motion.div>
         <motion.div
-          className="w-fit rounded-2xl rounded-tl border border-transparent bg-primary/60 p-2.5 text-foreground/70 text-xs shadow shadow-black/10 ring-1 ring-border"
+          className="w-fit rounded-2xl rounded-tl border border-border bg-background p-2.5 text-foreground/70 text-xs"
           initial={
             shouldReduceMotion
               ? { opacity: 1 }
@@ -45,7 +45,7 @@ function McpIllustration() {
           smoothui
         </motion.div>
         <motion.div
-          className="ml-auto w-fit rounded-2xl rounded-tr border border-transparent bg-brand/10 p-2.5 text-foreground/70 text-xs shadow shadow-black/10 ring-1 ring-brand/20"
+          className="ml-auto w-fit rounded-2xl rounded-tr border border-brand/20 bg-brand/10 p-2.5 text-foreground/70 text-xs"
           initial={
             shouldReduceMotion
               ? { opacity: 1 }
@@ -79,7 +79,7 @@ function ApiIllustration() {
   return (
     <div aria-hidden className="self-center">
       <motion.div
-        className="space-y-2.5 rounded-2xl border border-transparent bg-primary/60 p-4 shadow shadow-black/10 ring-1 ring-border"
+        className="space-y-2.5 rounded-2xl border border-border bg-background p-4"
         initial={
           shouldReduceMotion
             ? { opacity: 1 }
@@ -195,7 +195,7 @@ function LlmsIllustration() {
           </div>
         </motion.div>
         <motion.div
-          className="-mx-5 flex rounded-xl border border-transparent bg-primary/60 py-1 pr-4 pl-2 text-xs shadow shadow-black/10 ring-1 ring-border"
+          className="-mx-5 flex rounded-xl border border-border bg-background py-1 pr-4 pl-2 text-xs"
           initial={
             shouldReduceMotion
               ? { opacity: 1 }
@@ -329,7 +329,7 @@ export function AISection() {
         </motion.p>
 
         <motion.div
-          className="mx-auto mt-16 overflow-hidden rounded-2xl border border-transparent bg-primary/20 shadow-black/5 shadow-md ring-1 ring-border"
+          className="frame-box relative mx-auto mt-16 overflow-hidden rounded-2xl"
           initial={
             shouldReduceMotion
               ? { opacity: 1 }

--- a/apps/docs/components/landing/ai-section.tsx
+++ b/apps/docs/components/landing/ai-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Divider from "@docs/components/landing/divider";
+import { SectionHeader } from "@docs/components/landing/section-header";
 import { ArrowRight } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 import Link from "next/link";
@@ -271,62 +272,11 @@ export function AISection() {
     <section className="relative bg-background px-8 py-24 transition">
       <Divider />
       <div className="mx-auto max-w-5xl">
-        <motion.p
-          className="mb-2 text-center font-medium text-brand text-sm uppercase tracking-wider"
-          initial={shouldReduceMotion ? { opacity: 1 } : { opacity: 0 }}
-          transition={
-            shouldReduceMotion
-              ? { duration: 0 }
-              : { type: "spring", duration: 0.3, bounce: 0.1 }
-          }
-          viewport={{ once: true, amount: 0.5 }}
-          whileInView={shouldReduceMotion ? { opacity: 1 } : { opacity: 1 }}
-        >
-          AI-Native
-        </motion.p>
-        <motion.h2
-          className="text-balance text-center font-semibold font-title text-3xl text-foreground transition"
-          initial={
-            shouldReduceMotion
-              ? { opacity: 1 }
-              : { opacity: 0, transform: "translateY(10px)" }
-          }
-          transition={
-            shouldReduceMotion
-              ? { duration: 0 }
-              : { type: "spring", duration: 0.3, bounce: 0.1, delay: 0.05 }
-          }
-          viewport={{ once: true, amount: 0.5 }}
-          whileInView={
-            shouldReduceMotion
-              ? { opacity: 1 }
-              : { opacity: 1, transform: "translateY(0px)" }
-          }
-        >
-          Built for AI-Assisted Development
-        </motion.h2>
-        <motion.p
-          className="mx-auto mt-4 max-w-2xl text-balance text-center text-primary-foreground transition"
-          initial={
-            shouldReduceMotion
-              ? { opacity: 1 }
-              : { opacity: 0, transform: "translateY(10px)" }
-          }
-          transition={
-            shouldReduceMotion
-              ? { duration: 0 }
-              : { type: "spring", duration: 0.3, bounce: 0.1, delay: 0.1 }
-          }
-          viewport={{ once: true, amount: 0.5 }}
-          whileInView={
-            shouldReduceMotion
-              ? { opacity: 1 }
-              : { opacity: 1, transform: "translateY(0px)" }
-          }
-        >
-          The first component library designed for AI agents. Discover, search,
-          and install components programmatically.
-        </motion.p>
+        <SectionHeader
+          description="The first component library designed for AI agents. Discover, search, and install components programmatically."
+          eyebrow="AI-Native"
+          title="Built for AI-Assisted Development"
+        />
 
         <motion.div
           className="frame-box relative mx-auto mt-16 overflow-hidden rounded-2xl"

--- a/apps/docs/components/landing/ai-section.tsx
+++ b/apps/docs/components/landing/ai-section.tsx
@@ -279,7 +279,7 @@ export function AISection() {
         />
 
         <motion.div
-          className="frame-box relative mx-auto mt-16 overflow-hidden rounded-2xl"
+          className="relative mx-auto mt-16 grid divide-y overflow-hidden rounded-2xl border border-transparent bg-card/50 shadow-black/5 shadow-md ring-1 ring-border md:grid-cols-3 md:divide-x md:divide-y-0"
           initial={
             shouldReduceMotion
               ? { opacity: 1 }
@@ -297,39 +297,35 @@ export function AISection() {
               : { opacity: 1, transform: "translateY(0px) scale(1)" }
           }
         >
-          <div className="grid divide-y md:grid-cols-3 md:divide-x md:divide-y-0">
-            {aiFeatures.map((feature, index) => (
-              <motion.div
-                className="row-span-2 grid grid-rows-subgrid gap-8 p-8"
-                initial={shouldReduceMotion ? { opacity: 1 } : { opacity: 0 }}
-                key={feature.label}
-                transition={
-                  shouldReduceMotion
-                    ? { duration: 0 }
-                    : {
-                        type: "spring",
-                        duration: 0.25,
-                        bounce: 0.1,
-                        delay: 0.25 + index * 0.1,
-                      }
-                }
-                viewport={{ once: true, amount: 0.2 }}
-                whileInView={
-                  shouldReduceMotion ? { opacity: 1 } : { opacity: 1 }
-                }
-              >
-                <feature.illustration />
-                <div className="relative z-10 mx-auto max-w-sm text-center">
-                  <h3 className="text-balance font-semibold text-foreground">
-                    {feature.title}
-                  </h3>
-                  <p className="mt-3 text-balance text-primary-foreground text-sm">
-                    {feature.description}
-                  </p>
-                </div>
-              </motion.div>
-            ))}
-          </div>
+          {aiFeatures.map((feature, index) => (
+            <motion.div
+              className="row-span-2 grid grid-rows-subgrid gap-8 p-8"
+              initial={shouldReduceMotion ? { opacity: 1 } : { opacity: 0 }}
+              key={feature.label}
+              transition={
+                shouldReduceMotion
+                  ? { duration: 0 }
+                  : {
+                      type: "spring",
+                      duration: 0.25,
+                      bounce: 0.1,
+                      delay: 0.25 + index * 0.1,
+                    }
+              }
+              viewport={{ once: true, amount: 0.2 }}
+              whileInView={shouldReduceMotion ? { opacity: 1 } : { opacity: 1 }}
+            >
+              <feature.illustration />
+              <div className="relative z-10 mx-auto max-w-sm text-center">
+                <h3 className="text-balance font-semibold text-foreground">
+                  {feature.title}
+                </h3>
+                <p className="mt-3 text-balance text-primary-foreground text-sm">
+                  {feature.description}
+                </p>
+              </div>
+            </motion.div>
+          ))}
         </motion.div>
 
         <motion.div

--- a/apps/docs/components/landing/block-categories.tsx
+++ b/apps/docs/components/landing/block-categories.tsx
@@ -2,6 +2,7 @@
 
 import { BlurMagic } from "@docs/components/blurmagic/blurmagic";
 import Divider from "@docs/components/landing/divider";
+import { SectionHeader } from "@docs/components/landing/section-header";
 import { Button } from "@docs/components/smoothbutton";
 import {
   Canpoy,
@@ -875,29 +876,18 @@ export function BlockCategories() {
     <section className="relative bg-background px-8 py-24 transition">
       <Divider />
       <div className="mx-auto max-w-7xl">
-        <motion.div
-          animate={shouldReduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 }}
-          className="flex flex-col items-start md:items-center"
-          initial={shouldReduceMotion ? { opacity: 1 } : { opacity: 0, y: 20 }}
-          transition={
-            shouldReduceMotion
-              ? { duration: 0 }
-              : { duration: 0.35, ease: EASE_OUT_QUAD }
+        <SectionHeader
+          description={
+            <>
+              <span className="font-medium text-foreground">Customizable</span>{" "}
+              blocks that seamlessly{" "}
+              <span className="font-medium text-foreground">adapt</span> to your
+              project needs
+            </>
           }
-        >
-          {/* Heading */}
-          <h2 className="text-balance text-center font-semibold font-title text-3xl text-foreground transition md:max-w-xl xl:max-w-2xl">
-            Elevate your design with premium blocks
-          </h2>
-
-          {/* Description */}
-          <p className="mt-3 text-pretty text-center text-foreground/60 text-sm xl:mt-5">
-            <span className="font-medium text-foreground">Customizable</span>{" "}
-            blocks that seamlessly{" "}
-            <span className="font-medium text-foreground">adapt</span> to your
-            project needs
-          </p>
-        </motion.div>
+          eyebrow="Blocks"
+          title="Elevate your design with premium blocks"
+        />
 
         {/* Grid Container with overflow */}
         <div className="relative -mx-3 mt-8 h-[480px] overflow-hidden sm:mx-0 md:mt-16 md:h-[672px]">
@@ -932,12 +922,15 @@ export function BlockCategories() {
                     </div>
                   </div>
 
-                  {/* Content - Centered */}
-                  <div className="mt-3 text-foreground text-sm md:mt-4 xl:text-base">
-                    {category.title}
-                  </div>
-                  <div className="mt-1 text-foreground/50 text-xs">
-                    {category.blockCount} Blocks
+                  {/* Content - Centered with pill tag */}
+                  <div className="mt-3 flex items-center justify-center gap-2 md:mt-4">
+                    <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-background px-2.5 py-0.5 font-medium text-foreground text-xs">
+                      <span className="size-1.5 rounded-full bg-brand" />
+                      {category.title}
+                    </span>
+                    <span className="text-foreground/50 text-xs">
+                      {category.blockCount} Blocks
+                    </span>
                   </div>
                 </Link>
               </motion.div>

--- a/apps/docs/components/landing/divider.tsx
+++ b/apps/docs/components/landing/divider.tsx
@@ -1,3 +1,5 @@
+import { cn } from "@repo/shadcn-ui/lib/utils";
+
 interface DividerProps {
   className?: string;
   orientation?: "horizontal" | "vertical";
@@ -7,15 +9,17 @@ export default function Divider({
   orientation = "horizontal",
   className,
 }: DividerProps) {
+  const isHorizontal = orientation === "horizontal";
+
   return (
     <div
-      className={`absolute ${
-        orientation === "horizontal"
-          ? "bottom-0 left-0 h-[2px] w-full"
-          : "top-0 right-0 h-full w-[2px]"
-      } z-1 border-smooth-300 bg-white transition dark:bg-black ${
-        orientation === "horizontal" ? "border-t" : "border-r"
-      } ${className}`}
+      className={cn(
+        "absolute z-1",
+        isHorizontal
+          ? "right-0 bottom-0 left-0 h-px bg-gradient-to-r from-transparent via-border to-transparent"
+          : "top-0 right-0 h-full w-px bg-gradient-to-b from-transparent via-border to-transparent",
+        className
+      )}
     />
   );
 }

--- a/apps/docs/components/landing/faqs.tsx
+++ b/apps/docs/components/landing/faqs.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import Divider from "@docs/components/landing/divider";
-import { SectionHeader } from "@docs/components/landing/section-header";
 import {
   Accordion,
   AccordionContent,
@@ -80,14 +79,12 @@ export function FAQ() {
         type="application/ld+json"
       />
       <Divider />
-      <SectionHeader
-        description="Everything you need to know about installing, customizing, and shipping with SmoothUI."
-        eyebrow="FAQ"
-        title="Frequently Asked Questions"
-      />
-      <div className="mx-auto mt-16 max-w-3xl">
+      <h2 className="text-balance text-center font-semibold font-title text-3xl text-foreground transition">
+        Frequently Asked Questions
+      </h2>
+      <div className="mx-auto mt-16 max-w-3xl space-y-4">
         <Accordion
-          className="space-y-3"
+          className="-space-y-1"
           collapsible
           data-orientation="vertical"
           type="single"
@@ -95,19 +92,19 @@ export function FAQ() {
           {faqs.map((faq, index) => (
             <AccordionItem
               className={cn(
-                "rounded-xl border border-border bg-card/40 px-6 transition-colors hover:bg-card data-[state=open]:bg-card"
+                "peer rounded-xl border-b border-none px-6 py-1 last:border-b-0 data-[state=open]:border-none data-[state=open]:bg-card data-[state=open]:shadow-sm data-[state=open]:ring-1 data-[state=open]:ring-foreground/5"
               )}
               key={faq.question}
               value={`item-${index}`}
             >
               <AccordionTrigger
                 className={cn(
-                  "flex flex-1 cursor-pointer items-start justify-between gap-4 border-none py-4 text-left font-medium text-base outline-none transition-none hover:no-underline focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 [&>svg]:text-brand [&[data-state=open]>svg]:rotate-180"
+                  "flex flex-1 cursor-pointer items-start justify-between gap-4 rounded-none border-b py-4 text-left font-medium text-base outline-none transition-none hover:no-underline focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 data-[state=open]:border-transparent [&[data-state=open]>svg]:rotate-180"
                 )}
               >
                 {faq.question}
               </AccordionTrigger>
-              <AccordionContent className="pb-4">{faq.answer}</AccordionContent>
+              <AccordionContent>{faq.answer}</AccordionContent>
             </AccordionItem>
           ))}
         </Accordion>

--- a/apps/docs/components/landing/faqs.tsx
+++ b/apps/docs/components/landing/faqs.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Divider from "@docs/components/landing/divider";
+import { SectionHeader } from "@docs/components/landing/section-header";
 import {
   Accordion,
   AccordionContent,
@@ -79,12 +80,14 @@ export function FAQ() {
         type="application/ld+json"
       />
       <Divider />
-      <h2 className="text-balance text-center font-semibold font-title text-3xl text-foreground transition">
-        Frequently Asked Questions
-      </h2>
-      <div className="mx-auto mt-16 max-w-3xl space-y-4">
+      <SectionHeader
+        description="Everything you need to know about installing, customizing, and shipping with SmoothUI."
+        eyebrow="FAQ"
+        title="Frequently Asked Questions"
+      />
+      <div className="mx-auto mt-16 max-w-3xl">
         <Accordion
-          className="-space-y-1"
+          className="space-y-3"
           collapsible
           data-orientation="vertical"
           type="single"
@@ -92,19 +95,19 @@ export function FAQ() {
           {faqs.map((faq, index) => (
             <AccordionItem
               className={cn(
-                "peer rounded-xl border-b border-none px-6 py-1 last:border-b-0 data-[state=open]:border-none data-[state=open]:bg-card data-[state=open]:shadow-sm data-[state=open]:ring-1 data-[state=open]:ring-foreground/5"
+                "rounded-xl border border-border bg-card/40 px-6 transition-colors hover:bg-card data-[state=open]:bg-card"
               )}
               key={faq.question}
               value={`item-${index}`}
             >
               <AccordionTrigger
                 className={cn(
-                  "flex flex-1 cursor-pointer items-start justify-between gap-4 rounded-none border-b py-4 text-left font-medium text-base outline-none transition-none hover:no-underline focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 data-[state=open]:border-transparent [&[data-state=open]>svg]:rotate-180"
+                  "flex flex-1 cursor-pointer items-start justify-between gap-4 border-none py-4 text-left font-medium text-base outline-none transition-none hover:no-underline focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 [&>svg]:text-brand [&[data-state=open]>svg]:rotate-180"
                 )}
               >
                 {faq.question}
               </AccordionTrigger>
-              <AccordionContent>{faq.answer}</AccordionContent>
+              <AccordionContent className="pb-4">{faq.answer}</AccordionContent>
             </AccordionItem>
           ))}
         </Accordion>

--- a/apps/docs/components/landing/features.tsx
+++ b/apps/docs/components/landing/features.tsx
@@ -2,6 +2,7 @@ import Divider from "@docs/components/landing/divider";
 import { ReactLogo } from "@docs/components/landing/logos/react-logo";
 import { ShadcnLogo } from "@docs/components/landing/logos/shadcn-logo";
 import { TailwindLogo } from "@docs/components/landing/logos/tailwind-logo";
+import { SectionHeader } from "@docs/components/landing/section-header";
 import { cn } from "@repo/shadcn-ui/lib/utils";
 import { Package } from "lucide-react";
 
@@ -36,9 +37,15 @@ export function Features() {
   return (
     <section className="relative bg-background px-8 py-24 transition">
       <Divider />
-      <h2 className="text-balance text-center font-semibold font-title text-3xl text-foreground transition">
-        Why Choose Smooth<span className="text-brand">UI</span>?
-      </h2>
+      <SectionHeader
+        description="Built on the foundations you already love, with the polish you've been wishing for."
+        eyebrow="Why SmoothUI"
+        title={
+          <>
+            Why Choose Smooth<span className="text-brand">UI</span>?
+          </>
+        }
+      />
       <div className="mt-16 grid w-full gap-8 md:grid-cols-2 lg:grid-cols-4">
         {features.map((feature) => (
           <div

--- a/apps/docs/components/landing/hero.tsx
+++ b/apps/docs/components/landing/hero.tsx
@@ -27,7 +27,7 @@ function AnnouncementBadge() {
 
   return (
     <a
-      className="group inline-flex max-w-full items-center justify-center gap-2 overflow-hidden whitespace-nowrap rounded-full border bg-background px-3 py-0.5 font-medium text-foreground text-xs shadow-sm transition-all hover:shadow-md"
+      className="group inline-flex max-w-full items-center justify-center gap-2 overflow-hidden whitespace-nowrap rounded-full border bg-background px-3 py-0.5 font-medium text-foreground text-xs transition-all"
       href="https://skills.smoothui.dev"
       rel="noopener noreferrer"
       target="_blank"

--- a/apps/docs/components/landing/section-header.tsx
+++ b/apps/docs/components/landing/section-header.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { cn } from "@repo/shadcn-ui/lib/utils";
+import { motion, useReducedMotion } from "motion/react";
+import type { ReactNode } from "react";
+
+export interface SectionHeaderProps {
+  align?: "center" | "left";
+  className?: string;
+  description?: ReactNode;
+  eyebrow?: ReactNode;
+  title: ReactNode;
+}
+
+export function SectionHeader({
+  eyebrow,
+  title,
+  description,
+  className,
+  align = "center",
+}: SectionHeaderProps) {
+  const shouldReduceMotion = useReducedMotion();
+
+  const transition = (delay: number) =>
+    shouldReduceMotion
+      ? { duration: 0 }
+      : { type: "spring" as const, duration: 0.3, bounce: 0.1, delay };
+
+  const fadeUp = (delay: number) => ({
+    initial: shouldReduceMotion
+      ? { opacity: 1 }
+      : { opacity: 0, transform: "translateY(10px)" },
+    whileInView: shouldReduceMotion
+      ? { opacity: 1 }
+      : { opacity: 1, transform: "translateY(0px)" },
+    transition: transition(delay),
+    viewport: { once: true, amount: 0.5 } as const,
+  });
+
+  const isCenter = align === "center";
+
+  return (
+    <div
+      className={cn("max-w-2xl", isCenter && "mx-auto text-center", className)}
+    >
+      {eyebrow && (
+        <motion.p
+          className={cn(
+            "mb-2 font-medium text-brand text-sm uppercase tracking-wider",
+            isCenter && "text-center"
+          )}
+          {...fadeUp(0)}
+        >
+          {eyebrow}
+        </motion.p>
+      )}
+      <motion.h2
+        className={cn(
+          "text-balance font-semibold font-title text-3xl text-foreground transition md:text-4xl",
+          isCenter && "text-center"
+        )}
+        {...fadeUp(0.05)}
+      >
+        {title}
+      </motion.h2>
+      {description && (
+        <motion.p
+          className={cn(
+            "mt-4 text-balance text-primary-foreground transition",
+            isCenter && "text-center"
+          )}
+          {...fadeUp(0.1)}
+        >
+          {description}
+        </motion.p>
+      )}
+    </div>
+  );
+}

--- a/apps/docs/components/landing/skills-section.tsx
+++ b/apps/docs/components/landing/skills-section.tsx
@@ -71,7 +71,7 @@ export function SkillsSection() {
         </motion.p>
 
         <motion.div
-          className="mx-auto mt-16 overflow-hidden rounded-2xl border border-transparent bg-primary/20 shadow-black/5 shadow-md ring-1 ring-border"
+          className="frame-box relative mx-auto mt-16 overflow-hidden rounded-2xl"
           initial={
             shouldReduceMotion
               ? { opacity: 1 }
@@ -139,7 +139,7 @@ export function SkillsSection() {
               >
                 {modes.map((mode) => (
                   <div
-                    className="flex items-center gap-2.5 rounded-xl bg-primary/60 p-3 ring-1 ring-border"
+                    className="flex items-center gap-2.5 rounded-xl border border-border bg-background p-3"
                     key={mode.label}
                   >
                     <mode.icon className="size-4 shrink-0 text-brand" />
@@ -157,7 +157,7 @@ export function SkillsSection() {
 
               {/* Install command */}
               <motion.div
-                className="overflow-hidden rounded-xl bg-primary/60 p-4 ring-1 ring-border"
+                className="overflow-hidden rounded-xl border border-border bg-background p-4"
                 initial={
                   shouldReduceMotion
                     ? { opacity: 1 }

--- a/apps/docs/components/landing/skills-section.tsx
+++ b/apps/docs/components/landing/skills-section.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Divider from "@docs/components/landing/divider";
+import { SectionHeader } from "@docs/components/landing/section-header";
 import { ArrowUpRight, Eye, Search, Sparkles, Wand2 } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 import Image from "next/image";
@@ -25,50 +26,11 @@ export function SkillsSection() {
     <section className="relative bg-background px-8 py-24 transition">
       <Divider />
       <div className="mx-auto max-w-5xl">
-        <motion.p
-          className="mb-2 text-center font-medium text-brand text-sm uppercase tracking-wider"
-          initial={shouldReduceMotion ? { opacity: 1 } : { opacity: 0 }}
-          transition={springTransition(0)}
-          viewport={{ once: true, amount: 0.5 }}
-          whileInView={shouldReduceMotion ? { opacity: 1 } : { opacity: 1 }}
-        >
-          Skills
-        </motion.p>
-        <motion.h2
-          className="text-balance text-center font-semibold font-title text-3xl text-foreground transition"
-          initial={
-            shouldReduceMotion
-              ? { opacity: 1 }
-              : { opacity: 0, transform: "translateY(10px)" }
-          }
-          transition={springTransition(0.05)}
-          viewport={{ once: true, amount: 0.5 }}
-          whileInView={
-            shouldReduceMotion
-              ? { opacity: 1 }
-              : { opacity: 1, transform: "translateY(0px)" }
-          }
-        >
-          Design taste for your AI agent
-        </motion.h2>
-        <motion.p
-          className="mx-auto mt-4 max-w-2xl text-balance text-center text-primary-foreground transition"
-          initial={
-            shouldReduceMotion
-              ? { opacity: 1 }
-              : { opacity: 0, transform: "translateY(10px)" }
-          }
-          transition={springTransition(0.1)}
-          viewport={{ once: true, amount: 0.5 }}
-          whileInView={
-            shouldReduceMotion
-              ? { opacity: 1 }
-              : { opacity: 1, transform: "translateY(0px)" }
-          }
-        >
-          Same prompt. Same model. Different result. UI Craft gives your coding
-          agent the design intuition it's missing.
-        </motion.p>
+        <SectionHeader
+          description="Same prompt. Same model. Different result. UI Craft gives your coding agent the design intuition it's missing."
+          eyebrow="Skills"
+          title="Design taste for your AI agent"
+        />
 
         <motion.div
           className="frame-box relative mx-auto mt-16 overflow-hidden rounded-2xl"


### PR DESCRIPTION
## Summary

### Landing visual polish
- New `<SectionHeader />` component (eyebrow + balanced heading + subhead) applied to Features, AI Section, Skills Section, Block Categories
- `<Divider />` is now a thin gradient fade instead of a hard 2px border line
- Block categories: category labels rendered as bordered pills with brand-colored dot
- Removed ad-hoc shadows on the hero "New" badge
- Replaced AI Section and Skills Section card wrappers with `frame-box` / `bg-card/50` surfaces
- Inner cards switched to `bg-background + border` for contrast

### Blog index redesign
- Featured post with abstract mesh gradient illustration + content side by side
- Posts grid with `divide-border` separators (Tailark-inspired layout)
- Author badge with avatar + "Read" chevron on every card
- Single `rounded-2xl` container for cohesive look

### 6 SEO-targeted blog articles (~16K words)
- Best React Animation Libraries in 2026 (react animation library)
- Framer Motion Tutorial (framer motion tutorial)
- 50+ Free Tailwind CSS Components for React (tailwind css components)
- 15 Animated Components for shadcn/ui (shadcn ui components)
- Tailwind CSS Animations in React (tailwind css animation)
- 10 React Hover Effects That Feel Premium (react hover effects)

### Code quality: Husky + CI
- Add Husky + lint-staged for pre-commit hooks (biome check on TS/TSX, biome format on JSON/CSS/MD)
- Split CI into 3 parallel jobs: Lint, Test, Build
- Add Build step to CI (catches type/import errors lint misses)
- Run CI on both pull_request and push to main

## Test plan
- [ ] `pnpm dev` — visual check of landing sections and blog index
- [ ] Verify blog articles render at `/blog/[slug]`
- [ ] Verify pre-commit hook runs on `git commit`
- [ ] CI green (Lint + Test + Build)