### PR TITLE
chore: add Dependabot auto-merge for patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
+    open-pull-requests-limit: 10

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge patch updates
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge "$PR_URL" --squash --auto
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Automates security patch management:

- **`dependabot.yml`** — weekly npm dependency checks (Mondays), patches grouped into single PRs, limit 10 open PRs
- **`dependabot-auto-merge.yml`** — automatically squash-merges Dependabot PRs that are **semver-patch only**, and **only after CI passes** (Lint + Test + Build)

Minor and major version bumps stay open for manual review.

## How it works

1. Dependabot opens a PR for a patch update (e.g., `4.12.12` → `4.12.14`)
2. CI runs (Lint + Test + Build)
3. If CI passes → auto-merge via squash
4. If CI fails → PR stays open, you get notified

## Test plan
- [ ] CI green on this PR
- [ ] After merge, verify the workflow appears in Actions tab

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated dependency update checks and auto-merging workflow configured for patch-level updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->