### PR TITLE
fix: remove test dependency from turbo build task

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -5,7 +5,7 @@
   "envMode": "loose",
   "tasks": {
     "build": {
-      "dependsOn": ["^build", "test"],
+      "dependsOn": ["^build"],
       "outputs": [".next/**", "!.next/cache/**", ".basehub/**"]
     },
     "test": {


### PR DESCRIPTION
## Summary
Remove `test` from `build.dependsOn` in `turbo.json`. CI already runs Test and Build as separate parallel jobs — having turbo re-run tests inside the Build job caused a false failure from a jsdom canvas error (106/106 tests pass but the process exits 1).

## Test plan
- [ ] CI Build job passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build pipeline configuration to streamline the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->