### PR TITLE
fix: resolve fumadocs 16.7 breaking changes

### DIFF
--- a/apps/docs/app/docs/[...slug]/page.tsx
+++ b/apps/docs/app/docs/[...slug]/page.tsx
@@ -146,9 +146,7 @@ export default async function Page(props: PageProps<"/docs/[...slug]">) {
     <>
       <BreadcrumbSchema slugs={page.slugs} title={page.data.title} />
       <DocsPage
-        container={{
-          className: "max-w-[75rem]",
-        }}
+        className="max-w-[75rem]"
         full={page.data.full ?? page.slugs.includes("blocks")}
         tableOfContent={{
           style: "clerk",

--- a/apps/docs/components/blog-float-nav.tsx
+++ b/apps/docs/components/blog-float-nav.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useSearchContext } from "fumadocs-ui/provider";
+import { useSearchContext } from "fumadocs-ui/contexts/search";
 import { Moon, Search, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 import { ColorPickerFloatNav } from "./color-picker-float-nav";

--- a/apps/docs/mdx-components.tsx
+++ b/apps/docs/mdx-components.tsx
@@ -69,17 +69,6 @@ export function getMDXComponents(components?: MDXComponents): MDXComponents {
   } satisfies MDXComponents;
 }
 
-declare module "mdx/types.js" {
-  // Augment the MDX types to make it understand React.
-  // biome-ignore lint/style/noNamespace: JSX type augmentation requires namespace structure
-  namespace JSX {
-    type Element = React.JSX.Element;
-    type ElementClass = React.JSX.ElementClass;
-    type ElementType = React.JSX.ElementType;
-    type IntrinsicElements = React.JSX.IntrinsicElements;
-  }
-}
-
 declare global {
   type MDXProvidedComponents = ReturnType<typeof getMDXComponents>;
 }

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@biomejs/biome": "2.4.10",
     "@smoothui/data": "workspace:*",
     "@types/node": "^24.10.10",
-    "esbuild": "^0.27.3",
+    "esbuild": "^0.27.7",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "tsup": "^8.5.1",
@@ -70,6 +70,7 @@
     "overrides": {
       "react": "^19.2.1",
       "react-dom": "^19.2.1",
+      "shiki": ">=4.0.0",
       "glob": ">=10.5.0",
       "@types/react": "^19.2.7",
       "@types/react-dom": "^19.2.3",

--- a/packages/smoothui/blocks/faqs/faq-1/index.tsx
+++ b/packages/smoothui/blocks/faqs/faq-1/index.tsx
@@ -174,7 +174,7 @@ export function FaqsGrid({
                     initial={false}
                     layoutId="activeTab"
                     transition={{
-                      type: "spring",
+                      type: "spring" as const,
                       stiffness: SPRING_STIFFNESS,
                       damping: SPRING_DAMPING,
                     }}

--- a/packages/smoothui/blocks/headers/header-2/index.tsx
+++ b/packages/smoothui/blocks/headers/header-2/index.tsx
@@ -130,7 +130,7 @@ export function HeroProduct({
                 >
                   <motion.div
                     transition={{
-                      type: "spring",
+                      type: "spring" as const,
                       stiffness: 400,
                       damping: 10,
                     }}
@@ -148,7 +148,7 @@ export function HeroProduct({
 
                   <motion.div
                     transition={{
-                      type: "spring",
+                      type: "spring" as const,
                       stiffness: 400,
                       damping: 10,
                     }}
@@ -182,7 +182,7 @@ export function HeroProduct({
                 <motion.div
                   className="mt-12 md:mt-16"
                   transition={{
-                    type: "spring",
+                    type: "spring" as const,
                     stiffness: 300,
                     damping: 20,
                   }}

--- a/packages/smoothui/blocks/headers/header-3/index.tsx
+++ b/packages/smoothui/blocks/headers/header-3/index.tsx
@@ -61,7 +61,7 @@ export function HeroShowcase({
           animate={{ opacity: 1, scale: 1, filter: "blur(0px)" }}
           className="relative overflow-hidden bg-gradient-to-b from-background to-muted"
           initial={{ opacity: 0, scale: 1.04, filter: "blur(12px)" }}
-          transition={{ type: "spring", bounce: 0.32, duration: 0.9 }}
+          transition={{ type: "spring" as const, bounce: 0.32, duration: 0.9 }}
         >
           <div className="mx-auto grid max-w-5xl items-center gap-10 px-6 py-24 lg:grid-cols-2 lg:gap-20">
             <AnimatedGroup
@@ -91,7 +91,7 @@ export function HeroShowcase({
                       key={`${avatar.src}-${index}`}
                       style={{ display: "inline-block" }}
                       transition={{
-                        type: "spring",
+                        type: "spring" as const,
                         stiffness: 300,
                         damping: 20,
                       }}

--- a/packages/smoothui/blocks/logos/logo-cloud-2/index.tsx
+++ b/packages/smoothui/blocks/logos/logo-cloud-2/index.tsx
@@ -99,7 +99,10 @@ export function LogoCloudAnimated({
               >
                 <motion.div
                   className="mb-2 text-4xl *:fill-foreground"
-                  transition={{ type: "spring", stiffness: SPRING_STIFFNESS }}
+                  transition={{
+                    type: "spring" as const,
+                    stiffness: SPRING_STIFFNESS,
+                  }}
                   whileHover={{ scale: HOVER_SCALE, rotate: HOVER_ROTATE }}
                 >
                   <logo.logo />
@@ -123,7 +126,10 @@ export function LogoCloudAnimated({
               >
                 <motion.div
                   className="mb-2 text-4xl *:fill-foreground"
-                  transition={{ type: "spring", stiffness: SPRING_STIFFNESS }}
+                  transition={{
+                    type: "spring" as const,
+                    stiffness: SPRING_STIFFNESS,
+                  }}
                   whileHover={{ scale: HOVER_SCALE, rotate: HOVER_ROTATE }}
                 >
                   <logo.logo />
@@ -147,7 +153,10 @@ export function LogoCloudAnimated({
               >
                 <motion.div
                   className="mb-2 text-4xl *:fill-foreground"
-                  transition={{ type: "spring", stiffness: SPRING_STIFFNESS }}
+                  transition={{
+                    type: "spring" as const,
+                    stiffness: SPRING_STIFFNESS,
+                  }}
                   whileHover={{ scale: HOVER_SCALE, rotate: HOVER_ROTATE }}
                 >
                   <logo.logo />

--- a/packages/smoothui/blocks/logos/logo-cloud-4/index.tsx
+++ b/packages/smoothui/blocks/logos/logo-cloud-4/index.tsx
@@ -76,7 +76,7 @@ function LogoItem({ logo, isHoverDevice, shouldReduceMotion }: LogoItemProps) {
         shouldReduceMotion
           ? { duration: 0 }
           : {
-              type: "spring",
+              type: "spring" as const,
               duration: 0.25,
               bounce: 0.05,
             }
@@ -113,7 +113,7 @@ function LogoItem({ logo, isHoverDevice, shouldReduceMotion }: LogoItemProps) {
               shouldReduceMotion
                 ? { duration: 0 }
                 : {
-                    type: "spring",
+                    type: "spring" as const,
                     duration: 0.25,
                     bounce: 0.05,
                   }

--- a/packages/smoothui/blocks/shared/animated-group.tsx
+++ b/packages/smoothui/blocks/shared/animated-group.tsx
@@ -62,35 +62,35 @@ const presetVariants: Record<PresetType, Variants> = {
     hidden: { scale: 0.5 },
     visible: {
       scale: 1,
-      transition: { type: "spring", stiffness: 300, damping: 20 },
+      transition: { type: "spring" as const, stiffness: 300, damping: 20 },
     },
   },
   flip: {
     hidden: { rotateX: -90 },
     visible: {
       rotateX: 0,
-      transition: { type: "spring", stiffness: 300, damping: 20 },
+      transition: { type: "spring" as const, stiffness: 300, damping: 20 },
     },
   },
   bounce: {
     hidden: { y: -50 },
     visible: {
       y: 0,
-      transition: { type: "spring", stiffness: 400, damping: 10 },
+      transition: { type: "spring" as const, stiffness: 400, damping: 10 },
     },
   },
   rotate: {
     hidden: { rotate: -180 },
     visible: {
       rotate: 0,
-      transition: { type: "spring", stiffness: 200, damping: 15 },
+      transition: { type: "spring" as const, stiffness: 200, damping: 15 },
     },
   },
   swing: {
     hidden: { rotate: -10 },
     visible: {
       rotate: 0,
-      transition: { type: "spring", stiffness: 300, damping: 8 },
+      transition: { type: "spring" as const, stiffness: 300, damping: 8 },
     },
   },
 };

--- a/packages/smoothui/blocks/shared/animated-text.tsx
+++ b/packages/smoothui/blocks/shared/animated-text.tsx
@@ -20,7 +20,12 @@ export function AnimatedText({
     <motion.div
       animate={{ opacity: 1, filter: "blur(0px)", y: 0 }}
       initial={{ opacity: 0, filter: "blur(12px)", y: 12 }}
-      transition={{ type: "spring", bounce: 0.3, duration: 1.5, delay }}
+      transition={{
+        type: "spring" as const,
+        bounce: 0.3,
+        duration: 1.5,
+        delay,
+      }}
     >
       <Tag className={className}>{children}</Tag>
     </motion.div>

--- a/packages/smoothui/blocks/stats/stats-1/index.tsx
+++ b/packages/smoothui/blocks/stats/stats-1/index.tsx
@@ -81,7 +81,7 @@ export function StatsGrid({
                 transition={{
                   duration: 0.8,
                   delay: index * STAGGER_DELAY + VALUE_DELAY_OFFSET,
-                  type: "spring",
+                  type: "spring" as const,
                   stiffness: 200,
                 }}
               >

--- a/packages/smoothui/blocks/stats/stats-2/index.tsx
+++ b/packages/smoothui/blocks/stats/stats-2/index.tsx
@@ -103,7 +103,7 @@ export function StatsCards({
               transition={{
                 duration: 0.6,
                 delay: index * STAGGER_DELAY,
-                type: "spring",
+                type: "spring" as const,
                 stiffness: 100,
               }}
             >
@@ -119,7 +119,7 @@ export function StatsCards({
                 transition={{
                   duration: 0.6,
                   delay: index * STAGGER_DELAY + ICON_STAGGER_OFFSET,
-                  type: "spring",
+                  type: "spring" as const,
                   stiffness: 200,
                 }}
               >
@@ -139,7 +139,7 @@ export function StatsCards({
                 transition={{
                   duration: 0.8,
                   delay: index * STAGGER_DELAY + VALUE_DELAY_OFFSET,
-                  type: "spring",
+                  type: "spring" as const,
                   stiffness: 200,
                 }}
               >

--- a/packages/smoothui/blocks/team/team-1/index.tsx
+++ b/packages/smoothui/blocks/team/team-1/index.tsx
@@ -50,13 +50,21 @@ export function TeamGrid({
             >
               <motion.div
                 className="group"
-                transition={{ type: "spring", stiffness: 300, damping: 20 }}
+                transition={{
+                  type: "spring" as const,
+                  stiffness: 300,
+                  damping: 20,
+                }}
                 whileHover={{ scale: 1.02 }}
               >
                 {/* Avatar */}
                 <motion.div
                   className="relative overflow-hidden rounded-2xl"
-                  transition={{ type: "spring", stiffness: 300, damping: 20 }}
+                  transition={{
+                    type: "spring" as const,
+                    stiffness: 300,
+                    damping: 20,
+                  }}
                   whileHover={{ scale: 1.05 }}
                 >
                   <img

--- a/packages/smoothui/blocks/team/team-2/index.tsx
+++ b/packages/smoothui/blocks/team/team-2/index.tsx
@@ -165,7 +165,7 @@ export function TeamCarousel({
                 }}
                 className="-ml-4 flex max-w-[min(calc(100vw-4rem),24rem)] select-none"
                 transition={{
-                  type: "spring",
+                  type: "spring" as const,
                   stiffness: 300,
                   damping: 30,
                 }}

--- a/packages/smoothui/blocks/testimonials/testimonials-1/index.tsx
+++ b/packages/smoothui/blocks/testimonials/testimonials-1/index.tsx
@@ -47,7 +47,7 @@ export function TestimonialsSimple() {
               exit={{ opacity: 0, y: -30 }}
               initial={{ opacity: 0, y: 30 }}
               key={index}
-              transition={{ type: "spring", duration: 0.5 }}
+              transition={{ type: "spring" as const, duration: 0.5 }}
             >
               &ldquo;{testimonials[index].quote}&rdquo;
             </motion.blockquote>
@@ -61,7 +61,7 @@ export function TestimonialsSimple() {
               exit={{ opacity: 0, filter: "blur(8px)" }}
               initial={{ opacity: 0, filter: "blur(8px)" }}
               key={index}
-              transition={{ type: "spring", duration: 0.5 }}
+              transition={{ type: "spring" as const, duration: 0.5 }}
             >
               <img
                 alt={`${testimonials[index].name} avatar`}
@@ -105,7 +105,7 @@ export function TestimonialsSimple() {
                   border: "none",
                 }}
                 transition={{
-                  type: "spring",
+                  type: "spring" as const,
                   stiffness: 300,
                   damping: 30,
                   duration: 0.4,

--- a/packages/smoothui/components/ai-branch/index.tsx
+++ b/packages/smoothui/components/ai-branch/index.tsx
@@ -116,7 +116,7 @@ export const AIBranchMessages = ({ children }: AIBranchMessagesProps) => {
           ? { duration: 0 }
           : {
               duration: 0.25,
-              type: "spring",
+              type: "spring" as const,
               stiffness: 300,
               damping: 30,
             }
@@ -182,7 +182,12 @@ export const AIBranchPrevious = ({
       transition={
         shouldReduceMotion
           ? { duration: 0 }
-          : { type: "spring", stiffness: 400, damping: 25, duration: 0.2 }
+          : {
+              type: "spring" as const,
+              stiffness: 400,
+              damping: 25,
+              duration: 0.2,
+            }
       }
       type="button"
       whileHover={shouldReduceMotion ? {} : { scale: 1.05 }}
@@ -217,7 +222,12 @@ export const AIBranchNext = ({ className, children }: AIBranchNextProps) => {
       transition={
         shouldReduceMotion
           ? { duration: 0 }
-          : { type: "spring", stiffness: 400, damping: 25, duration: 0.2 }
+          : {
+              type: "spring" as const,
+              stiffness: 400,
+              damping: 25,
+              duration: 0.2,
+            }
       }
       type="button"
       whileHover={shouldReduceMotion ? {} : { scale: 1.05 }}
@@ -302,7 +312,7 @@ export function LegacyAiBranch({
           initial={{ opacity: 0, y: 10 }}
           transition={{
             duration: 0.3,
-            type: "spring",
+            type: "spring" as const,
             stiffness: 300,
             damping: 30,
           }}
@@ -328,7 +338,7 @@ export function LegacyAiBranch({
                       shouldReduceMotion
                         ? { duration: 0 }
                         : {
-                            type: "spring",
+                            type: "spring" as const,
                             stiffness: 400,
                             damping: 25,
                             duration: 0.2,
@@ -352,7 +362,7 @@ export function LegacyAiBranch({
                       shouldReduceMotion
                         ? { duration: 0 }
                         : {
-                            type: "spring",
+                            type: "spring" as const,
                             stiffness: 400,
                             damping: 25,
                             duration: 0.2,
@@ -379,7 +389,7 @@ export function LegacyAiBranch({
                       shouldReduceMotion
                         ? { duration: 0 }
                         : {
-                            type: "spring",
+                            type: "spring" as const,
                             stiffness: 400,
                             damping: 25,
                             duration: 0.2,
@@ -410,7 +420,7 @@ export function LegacyAiBranch({
                       shouldReduceMotion
                         ? { duration: 0 }
                         : {
-                            type: "spring",
+                            type: "spring" as const,
                             stiffness: 400,
                             damping: 25,
                             duration: 0.2,

--- a/packages/smoothui/components/ai-branch/package.json
+++ b/packages/smoothui/components/ai-branch/package.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "@repo/shadcn-ui": "workspace:*",
     "lucide-react": "^0.545.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/packages/smoothui/components/ai-input/index.tsx
+++ b/packages/smoothui/components/ai-input/index.tsx
@@ -97,7 +97,7 @@ export function MorphSurface() {
           shouldReduceMotion
             ? { duration: 0 }
             : {
-                type: "spring",
+                type: "spring" as const,
                 stiffness: SPRING_STIFFNESS / SPEED,
                 damping: SPRING_DAMPING,
                 mass: SPRING_MASS,
@@ -226,7 +226,7 @@ function Feedback({
               shouldReduceMotion
                 ? { duration: 0 }
                 : {
-                    type: "spring",
+                    type: "spring" as const,
                     stiffness: SPRING_STIFFNESS / SPEED,
                     damping: SPRING_DAMPING,
                     mass: SPRING_MASS,

--- a/packages/smoothui/components/ai-input/package.json
+++ b/packages/smoothui/components/ai-input/package.json
@@ -8,7 +8,7 @@
     "@repo/smooth-button": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "class-variance-authority": "^0.7.1"
   },
   "devDependencies": {

--- a/packages/smoothui/components/animated-avatar-group/package.json
+++ b/packages/smoothui/components/animated-avatar-group/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/animated-file-upload/package.json
+++ b/packages/smoothui/components/animated-file-upload/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/animated-input/index.tsx
+++ b/packages/smoothui/components/animated-input/index.tsx
@@ -16,7 +16,7 @@ const LABEL_TRANSITION = {
     EASE_IN_OUT_CUBIC_Y1,
     EASE_IN_OUT_CUBIC_X2,
     EASE_IN_OUT_CUBIC_Y2,
-  ], // standard material easing
+  ] as [number, number, number, number], // cubic-bezier tuple
 };
 
 export interface AnimatedInputProps {

--- a/packages/smoothui/components/animated-input/package.json
+++ b/packages/smoothui/components/animated-input/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/animated-o-t-p-input/package.json
+++ b/packages/smoothui/components/animated-o-t-p-input/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.545.0",
     "input-otp": "^1.2.4"
   },

--- a/packages/smoothui/components/animated-progress-bar/index.tsx
+++ b/packages/smoothui/components/animated-progress-bar/index.tsx
@@ -16,7 +16,7 @@ const MIN_PROGRESS_VALUE = 0;
 const MAX_PROGRESS_VALUE = 100;
 
 const SPRING = {
-  type: "spring",
+  type: "spring" as const,
   damping: 10,
   mass: 0.75,
   stiffness: 100,

--- a/packages/smoothui/components/animated-progress-bar/package.json
+++ b/packages/smoothui/components/animated-progress-bar/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/animated-stepper/package.json
+++ b/packages/smoothui/components/animated-stepper/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/animated-tabs/package.json
+++ b/packages/smoothui/components/animated-tabs/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/animated-tags/index.tsx
+++ b/packages/smoothui/components/animated-tags/index.tsx
@@ -73,7 +73,7 @@ export default function AnimatedTags({
                 transition={
                   shouldReduceMotion
                     ? { duration: 0 }
-                    : { duration: 0.25, bounce: 0, type: "spring" }
+                    : { duration: 0.25, bounce: 0, type: "spring" as const }
                 }
               >
                 {tag}{" "}
@@ -116,7 +116,7 @@ export default function AnimatedTags({
               transition={
                 shouldReduceMotion
                   ? { duration: 0 }
-                  : { duration: 0.25, bounce: 0, type: "spring" }
+                  : { duration: 0.25, bounce: 0, type: "spring" as const }
               }
             >
               {tag}{" "}

--- a/packages/smoothui/components/animated-tags/package.json
+++ b/packages/smoothui/components/animated-tags/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.545.0"
   },
   "devDependencies": {

--- a/packages/smoothui/components/animated-toggle/package.json
+++ b/packages/smoothui/components/animated-toggle/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/animated-tooltip/package.json
+++ b/packages/smoothui/components/animated-tooltip/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/app-download-stack/index.tsx
+++ b/packages/smoothui/components/app-download-stack/index.tsx
@@ -150,7 +150,8 @@ export default function AppDownloadStack({
   ]);
 
   const stackVariants = useMemo(
-    () => ({
+    // biome-ignore lint/suspicious/noExplicitAny: Variants type requires flexible return
+    (): Record<string, (i: number) => any> => ({
       initial: (i: number) =>
         shouldReduceMotion
           ? {

--- a/packages/smoothui/components/app-download-stack/package.json
+++ b/packages/smoothui/components/app-download-stack/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.545.0"
   },
   "devDependencies": {

--- a/packages/smoothui/components/apple-invites/index.tsx
+++ b/packages/smoothui/components/apple-invites/index.tsx
@@ -202,7 +202,12 @@ export default function AppleInvites({
         zIndex: 3,
         transition: shouldReduceMotion
           ? { duration: 0 }
-          : { type: "spring", stiffness: 300, damping: 30, duration: 0.25 },
+          : {
+              type: "spring" as const,
+              stiffness: 300,
+              damping: 30,
+              duration: 0.25,
+            },
       },
       left: {
         x: "-130%",
@@ -212,7 +217,12 @@ export default function AppleInvites({
         zIndex: 2,
         transition: shouldReduceMotion
           ? { duration: 0 }
-          : { type: "spring", stiffness: 300, damping: 30, duration: 0.25 },
+          : {
+              type: "spring" as const,
+              stiffness: 300,
+              damping: 30,
+              duration: 0.25,
+            },
       },
       right: {
         x: "30%",
@@ -222,7 +232,12 @@ export default function AppleInvites({
         zIndex: 2,
         transition: shouldReduceMotion
           ? { duration: 0 }
-          : { type: "spring", stiffness: 300, damping: 30, duration: 0.25 },
+          : {
+              type: "spring" as const,
+              stiffness: 300,
+              damping: 30,
+              duration: 0.25,
+            },
       },
       hidden: {
         opacity: 0,

--- a/packages/smoothui/components/apple-invites/package.json
+++ b/packages/smoothui/components/apple-invites/package.json
@@ -8,7 +8,7 @@
     "@smoothui/data": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.545.0",
     "popmotion": "^11.0.3"
   },

--- a/packages/smoothui/components/basic-accordion/index.tsx
+++ b/packages/smoothui/components/basic-accordion/index.tsx
@@ -80,7 +80,7 @@ export default function BasicAccordion({
                           opacity: 1,
                           transition: {
                             height: {
-                              type: "spring",
+                              type: "spring" as const,
                               stiffness: 500,
                               damping: 40,
                               duration: 0.25,

--- a/packages/smoothui/components/basic-accordion/package.json
+++ b/packages/smoothui/components/basic-accordion/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.545.0"
   },
   "devDependencies": {

--- a/packages/smoothui/components/basic-dropdown/index.tsx
+++ b/packages/smoothui/components/basic-dropdown/index.tsx
@@ -188,7 +188,7 @@ export default function BasicDropdown({
             transition={
               shouldReduceMotion
                 ? { duration: 0 }
-                : { type: "spring", bounce: 0.1, duration: 0.25 }
+                : { type: "spring" as const, bounce: 0.1, duration: 0.25 }
             }
           >
             <ul
@@ -219,7 +219,7 @@ export default function BasicDropdown({
                     shouldReduceMotion
                       ? { duration: 0 }
                       : {
-                          type: "spring",
+                          type: "spring" as const,
                           stiffness: 300,
                           damping: 30,
                           duration: 0.2,
@@ -250,7 +250,7 @@ export default function BasicDropdown({
                           shouldReduceMotion
                             ? { duration: 0 }
                             : {
-                                type: "spring",
+                                type: "spring" as const,
                                 stiffness: 300,
                                 damping: 20,
                                 duration: 0.2,

--- a/packages/smoothui/components/basic-dropdown/package.json
+++ b/packages/smoothui/components/basic-dropdown/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.545.0"
   },
   "devDependencies": {

--- a/packages/smoothui/components/basic-modal/index.tsx
+++ b/packages/smoothui/components/basic-modal/index.tsx
@@ -157,7 +157,7 @@ export default function BasicModal({
                 shouldReduceMotion
                   ? { duration: 0 }
                   : {
-                      type: "spring",
+                      type: "spring" as const,
                       damping: 25,
                       stiffness: 300,
                       duration: 0.25,

--- a/packages/smoothui/components/basic-modal/package.json
+++ b/packages/smoothui/components/basic-modal/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.545.0",
     "usehooks-ts": "^1.0.0"
   },

--- a/packages/smoothui/components/basic-toast/index.tsx
+++ b/packages/smoothui/components/basic-toast/index.tsx
@@ -92,7 +92,7 @@ export default function BasicToast({
           transition={
             shouldReduceMotion
               ? { duration: 0 }
-              : { type: "spring", bounce: 0.1, duration: 0.25 }
+              : { type: "spring" as const, bounce: 0.1, duration: 0.25 }
           }
         >
           <div className="flex-shrink-0">{toastIcons[type]}</div>

--- a/packages/smoothui/components/basic-toast/package.json
+++ b/packages/smoothui/components/basic-toast/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.545.0"
   },
   "devDependencies": {

--- a/packages/smoothui/components/book/package.json
+++ b/packages/smoothui/components/book/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/breadcrumb/package.json
+++ b/packages/smoothui/components/breadcrumb/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.474.0"
   },
   "devDependencies": {

--- a/packages/smoothui/components/button-copy/index.tsx
+++ b/packages/smoothui/components/button-copy/index.tsx
@@ -93,7 +93,7 @@ export default function ButtonCopy({
             transition={
               shouldReduceMotion
                 ? { duration: 0 }
-                : { type: "spring", duration: 0.25, bounce: 0 }
+                : { type: "spring" as const, duration: 0.25, bounce: 0 }
             }
           >
             {icons[buttonState]}

--- a/packages/smoothui/components/button-copy/package.json
+++ b/packages/smoothui/components/button-copy/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.545.0"
   },
   "devDependencies": {

--- a/packages/smoothui/components/checkbox/package.json
+++ b/packages/smoothui/components/checkbox/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "radix-ui": "^1.4.2"
   },
   "devDependencies": {

--- a/packages/smoothui/components/clip-corners-button/index.tsx
+++ b/packages/smoothui/components/clip-corners-button/index.tsx
@@ -63,7 +63,12 @@ export function ClipCornersButton({
         transition={
           shouldReduceMotion
             ? { duration: 0 }
-            : { type: "spring", stiffness: 400, damping: 24, duration: 0.2 }
+            : {
+                type: "spring" as const,
+                stiffness: 400,
+                damping: 24,
+                duration: 0.2,
+              }
         }
       >
         <svg
@@ -92,7 +97,12 @@ export function ClipCornersButton({
         transition={
           shouldReduceMotion
             ? { duration: 0 }
-            : { type: "spring", stiffness: 400, damping: 24, duration: 0.2 }
+            : {
+                type: "spring" as const,
+                stiffness: 400,
+                damping: 24,
+                duration: 0.2,
+              }
         }
       >
         <svg
@@ -121,7 +131,12 @@ export function ClipCornersButton({
         transition={
           shouldReduceMotion
             ? { duration: 0 }
-            : { type: "spring", stiffness: 400, damping: 24, duration: 0.2 }
+            : {
+                type: "spring" as const,
+                stiffness: 400,
+                damping: 24,
+                duration: 0.2,
+              }
         }
       >
         <svg
@@ -150,7 +165,12 @@ export function ClipCornersButton({
         transition={
           shouldReduceMotion
             ? { duration: 0 }
-            : { type: "spring", stiffness: 400, damping: 24, duration: 0.2 }
+            : {
+                type: "spring" as const,
+                stiffness: 400,
+                damping: 24,
+                duration: 0.2,
+              }
         }
       >
         <svg

--- a/packages/smoothui/components/clip-corners-button/package.json
+++ b/packages/smoothui/components/clip-corners-button/package.json
@@ -8,7 +8,7 @@
     "@repo/smooth-button": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/combobox/package.json
+++ b/packages/smoothui/components/combobox/package.json
@@ -8,7 +8,7 @@
     "@repo/smooth-button": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.469.0"
   },
   "devDependencies": {

--- a/packages/smoothui/components/context-menu/package.json
+++ b/packages/smoothui/components/context-menu/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/contribution-graph/package.json
+++ b/packages/smoothui/components/contribution-graph/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/cursor-follow/package.json
+++ b/packages/smoothui/components/cursor-follow/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/dialog/package.json
+++ b/packages/smoothui/components/dialog/package.json
@@ -8,7 +8,7 @@
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "lucide-react": "^0.468.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "radix-ui": "latest"
   },
   "devDependencies": {

--- a/packages/smoothui/components/dot-morph-button/index.tsx
+++ b/packages/smoothui/components/dot-morph-button/index.tsx
@@ -67,7 +67,7 @@ export function DotMorphButton({
           shouldReduceMotion
             ? { duration: 0 }
             : {
-                type: "spring",
+                type: "spring" as const,
                 stiffness: 600,
                 damping: 22,
                 duration: 0.25,

--- a/packages/smoothui/components/dot-morph-button/package.json
+++ b/packages/smoothui/components/dot-morph-button/package.json
@@ -8,7 +8,7 @@
     "@repo/smooth-button": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/drawer/package.json
+++ b/packages/smoothui/components/drawer/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/dropdown-menu/package.json
+++ b/packages/smoothui/components/dropdown-menu/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/dynamic-island/index.tsx
+++ b/packages/smoothui/components/dynamic-island/index.tsx
@@ -241,7 +241,7 @@ export default function DynamicIsland({
             shouldReduceMotion
               ? { duration: 0 }
               : {
-                  type: "spring",
+                  type: "spring" as const,
                   bounce:
                     BOUNCE_VARIANTS[
                       variantKey as keyof typeof BOUNCE_VARIANTS
@@ -272,7 +272,7 @@ export default function DynamicIsland({
             }}
             key={view}
             transition={{
-              type: "spring",
+              type: "spring" as const,
               bounce:
                 BOUNCE_VARIANTS[variantKey as keyof typeof BOUNCE_VARIANTS] ??
                 DEFAULT_BOUNCE,

--- a/packages/smoothui/components/dynamic-island/package.json
+++ b/packages/smoothui/components/dynamic-island/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.545.0"
   },
   "devDependencies": {

--- a/packages/smoothui/components/expandable-cards/package.json
+++ b/packages/smoothui/components/expandable-cards/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.545.0"
   },
   "devDependencies": {

--- a/packages/smoothui/components/exposure-slider/package.json
+++ b/packages/smoothui/components/exposure-slider/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/figma-comment/index.tsx
+++ b/packages/smoothui/components/figma-comment/index.tsx
@@ -134,7 +134,7 @@ export default function FigmaComment({
           shouldReduceMotion
             ? { duration: 0 }
             : {
-                type: "spring",
+                type: "spring" as const,
                 stiffness: 550,
                 damping: 45,
                 mass: 0.7,
@@ -166,7 +166,7 @@ export default function FigmaComment({
             shouldReduceMotion
               ? { duration: 0 }
               : {
-                  type: "spring",
+                  type: "spring" as const,
                   stiffness: 300,
                   damping: 25,
                   duration: 0.25,
@@ -240,7 +240,7 @@ export default function FigmaComment({
                 width: `${width}px`,
               }}
               transition={
-                shouldReduceMotion
+                (shouldReduceMotion
                   ? { duration: 0 }
                   : (isExiting: boolean) => ({
                       opacity: {
@@ -253,7 +253,7 @@ export default function FigmaComment({
                         ease: BLUR_EASE,
                         delay: isExiting ? 0 : CONTENT_DELAY,
                       },
-                    })
+                    })) as import("motion/react").Transition
               }
             >
               {/* Attribution */}

--- a/packages/smoothui/components/figma-comment/package.json
+++ b/packages/smoothui/components/figma-comment/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/form/index.tsx
+++ b/packages/smoothui/components/form/index.tsx
@@ -422,7 +422,7 @@ export function FormMessage({ className, children }: FormMessageProps) {
               shouldReduceMotion
                 ? DURATION_INSTANT
                 : {
-                    type: "spring",
+                    type: "spring" as const,
                     stiffness: 300,
                     damping: 20,
                     duration: 0.25,
@@ -436,7 +436,7 @@ export function FormMessage({ className, children }: FormMessageProps) {
                 shouldReduceMotion
                   ? DURATION_INSTANT
                   : {
-                      type: "spring",
+                      type: "spring" as const,
                       stiffness: 400,
                       damping: 15,
                       duration: 0.2,

--- a/packages/smoothui/components/form/package.json
+++ b/packages/smoothui/components/form/package.json
@@ -8,7 +8,7 @@
     "lucide-react": "^0.545.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/github-stars-animation/package.json
+++ b/packages/smoothui/components/github-stars-animation/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.555.0"
   },
   "devDependencies": {

--- a/packages/smoothui/components/glow-hover-card/package.json
+++ b/packages/smoothui/components/glow-hover-card/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/grid-loader/package.json
+++ b/packages/smoothui/components/grid-loader/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/image-metadata-preview/index.tsx
+++ b/packages/smoothui/components/image-metadata-preview/index.tsx
@@ -132,7 +132,7 @@ export default function ImageMetadataPreview({
               transition={
                 shouldReduceMotion
                   ? { duration: 0 }
-                  : { type: "spring", duration: 0.25, bounce: 0 }
+                  : { type: "spring" as const, duration: 0.25, bounce: 0 }
               }
             >
               <div className="flex flex-col items-start" ref={elementRef}>

--- a/packages/smoothui/components/image-metadata-preview/package.json
+++ b/packages/smoothui/components/image-metadata-preview/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.545.0",
     "react-use-measure": "^2.1.0"
   },

--- a/packages/smoothui/components/infinite-slider/package.json
+++ b/packages/smoothui/components/infinite-slider/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "react-use-measure": "^2.1.0"
   },
   "devDependencies": {

--- a/packages/smoothui/components/interactive-image-selector/index.tsx
+++ b/packages/smoothui/components/interactive-image-selector/index.tsx
@@ -238,7 +238,7 @@ export default function InteractiveImageSelector({
               layout
               onClick={() => handleImageClick(img.id)}
               transition={{
-                type: "spring",
+                type: "spring" as const,
                 stiffness: 300,
                 damping: 25,
                 duration: isResetting ? RESET_ANIMATION_DURATION : undefined,

--- a/packages/smoothui/components/interactive-image-selector/package.json
+++ b/packages/smoothui/components/interactive-image-selector/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.545.0"
   },
   "devDependencies": {

--- a/packages/smoothui/components/job-listing-component/index.tsx
+++ b/packages/smoothui/components/job-listing-component/index.tsx
@@ -175,7 +175,7 @@ export default function JobListingComponent({
                 shouldReduceMotion
                   ? { duration: 0 }
                   : {
-                      type: "spring",
+                      type: "spring" as const,
                       duration: 0.25,
                       bounce: 0.1,
                       layout: {
@@ -268,7 +268,7 @@ export default function JobListingComponent({
                 shouldReduceMotion
                   ? { duration: 0 }
                   : {
-                      type: "spring",
+                      type: "spring" as const,
                       duration: 0.25,
                       bounce: 0.1,
                       layout: {

--- a/packages/smoothui/components/job-listing-component/package.json
+++ b/packages/smoothui/components/job-listing-component/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "usehooks-ts": "^1.0.0"
   },
   "devDependencies": {

--- a/packages/smoothui/components/magnetic-button/package.json
+++ b/packages/smoothui/components/magnetic-button/package.json
@@ -9,7 +9,7 @@
     "class-variance-authority": "^0.7.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/notification-badge/index.tsx
+++ b/packages/smoothui/components/notification-badge/index.tsx
@@ -61,7 +61,7 @@ const AnimatedCount = ({
           exit={{ y: direction * -12, opacity: 0 }}
           initial={{ y: direction * 12, opacity: 0 }}
           key={value}
-          transition={{ type: "spring", duration: 0.3, bounce: 0.1 }}
+          transition={{ type: "spring" as const, duration: 0.3, bounce: 0.1 }}
         >
           {displayValue}
         </motion.span>
@@ -140,7 +140,7 @@ const NotificationBadge = ({
           transition={
             shouldReduceMotion
               ? { duration: 0 }
-              : { type: "spring", duration: 0.25, bounce: 0.2 }
+              : { type: "spring" as const, duration: 0.25, bounce: 0.2 }
           }
         >
           {variant === "count" && (

--- a/packages/smoothui/components/notification-badge/package.json
+++ b/packages/smoothui/components/notification-badge/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/pagination/package.json
+++ b/packages/smoothui/components/pagination/package.json
@@ -8,7 +8,7 @@
     "@repo/smooth-button": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.474.0"
   },
   "devDependencies": {

--- a/packages/smoothui/components/phototab/index.tsx
+++ b/packages/smoothui/components/phototab/index.tsx
@@ -113,7 +113,7 @@ export default function Phototab({
                 shouldReduceMotion
                   ? { duration: 0 }
                   : {
-                      type: "spring",
+                      type: "spring" as const,
                       stiffness: 400,
                       damping: 40,
                       duration: 0.25,

--- a/packages/smoothui/components/phototab/package.json
+++ b/packages/smoothui/components/phototab/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "@radix-ui/react-tabs": "^1.1.2"
   },
   "devDependencies": {

--- a/packages/smoothui/components/power-off-slide/index.tsx
+++ b/packages/smoothui/components/power-off-slide/index.tsx
@@ -102,7 +102,7 @@ export default function PowerOffSlide({
               transition={
                 shouldReduceMotion
                   ? { duration: 0 }
-                  : { type: "spring", duration: 0.25 }
+                  : { type: "spring" as const, duration: 0.25 }
               }
             >
               <Power className="text-red-600" size={32} />

--- a/packages/smoothui/components/power-off-slide/package.json
+++ b/packages/smoothui/components/power-off-slide/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.545.0"
   },
   "devDependencies": {

--- a/packages/smoothui/components/product-card/package.json
+++ b/packages/smoothui/components/product-card/package.json
@@ -8,7 +8,7 @@
     "@repo/smooth-button": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/radio-group/package.json
+++ b/packages/smoothui/components/radio-group/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "radix-ui": "^1.4.2"
   },
   "devDependencies": {

--- a/packages/smoothui/components/reveal-text/package.json
+++ b/packages/smoothui/components/reveal-text/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/reviews-carousel/index.tsx
+++ b/packages/smoothui/components/reviews-carousel/index.tsx
@@ -56,7 +56,7 @@ function ReviewCard({
         y,
         scale,
         transition: {
-          type: "spring",
+          type: "spring" as const,
           stiffness: 250,
           damping: 20,
           mass: 0.5,

--- a/packages/smoothui/components/reviews-carousel/package.json
+++ b/packages/smoothui/components/reviews-carousel/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.555.0"
   },
   "devDependencies": {

--- a/packages/smoothui/components/rich-popover/index.tsx
+++ b/packages/smoothui/components/rich-popover/index.tsx
@@ -144,7 +144,7 @@ export default function RichTooltip({
               shouldReduceMotion
                 ? { duration: 0 }
                 : {
-                    type: "spring",
+                    type: "spring" as const,
                     stiffness: 500,
                     damping: 30,
                     duration: 0.2,

--- a/packages/smoothui/components/rich-popover/package.json
+++ b/packages/smoothui/components/rich-popover/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.545.0",
     "@radix-ui/react-popover": "1.1.15"
   },

--- a/packages/smoothui/components/scroll-reveal-paragraph/package.json
+++ b/packages/smoothui/components/scroll-reveal-paragraph/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/scrollable-card-stack/index.tsx
+++ b/packages/smoothui/components/scrollable-card-stack/index.tsx
@@ -354,7 +354,7 @@ const ScrollableCardStack: React.FC<ScrollableCardStackProps> = ({
                 shouldReduceMotion
                   ? { duration: 0 }
                   : {
-                      type: "spring",
+                      type: "spring" as const,
                       stiffness: 250,
                       damping: 20,
                       mass: 0.5,
@@ -367,7 +367,7 @@ const ScrollableCardStack: React.FC<ScrollableCardStackProps> = ({
                   : {
                       scale: transform.scale * HOVER_SCALE_MULTIPLIER,
                       transition: {
-                        type: "spring",
+                        type: "spring" as const,
                         stiffness: 250,
                         damping: 20,
                         mass: 0.5,
@@ -486,7 +486,7 @@ const ScrollableCardStack: React.FC<ScrollableCardStackProps> = ({
               }}
               role="tab"
               transition={{
-                type: "spring",
+                type: "spring" as const,
                 stiffness: 250,
                 damping: 20,
                 mass: 0.5,

--- a/packages/smoothui/components/scrollable-card-stack/package.json
+++ b/packages/smoothui/components/scrollable-card-stack/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/scrubber/package.json
+++ b/packages/smoothui/components/scrubber/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/searchable-dropdown/index.tsx
+++ b/packages/smoothui/components/searchable-dropdown/index.tsx
@@ -238,7 +238,7 @@ export default function SearchableDropdown({
               shouldReduceMotion
                 ? { duration: 0 }
                 : {
-                    type: "spring",
+                    type: "spring" as const,
                     stiffness: 400,
                     damping: 30,
                     mass: 0.8,
@@ -260,7 +260,7 @@ export default function SearchableDropdown({
                   shouldReduceMotion
                     ? { duration: 0 }
                     : {
-                        type: "spring",
+                        type: "spring" as const,
                         stiffness: 400,
                         damping: 25,
                         delay: 0.05,
@@ -295,7 +295,7 @@ export default function SearchableDropdown({
                       initial={{ opacity: 0 }}
                       onClick={handleClearSearch}
                       transition={{
-                        type: "spring",
+                        type: "spring" as const,
                         stiffness: 400,
                         damping: 25,
                       }}
@@ -344,7 +344,7 @@ export default function SearchableDropdown({
                         shouldReduceMotion
                           ? { duration: 0 }
                           : {
-                              type: "spring",
+                              type: "spring" as const,
                               stiffness: 400,
                               damping: 28,
                               mass: 0.6,
@@ -385,7 +385,7 @@ export default function SearchableDropdown({
                               shouldReduceMotion
                                 ? { duration: 0 }
                                 : {
-                                    type: "spring",
+                                    type: "spring" as const,
                                     stiffness: 400,
                                     damping: 25,
                                     mass: 0.5,
@@ -423,7 +423,7 @@ export default function SearchableDropdown({
                       shouldReduceMotion
                         ? { duration: 0 }
                         : {
-                            type: "spring",
+                            type: "spring" as const,
                             stiffness: 400,
                             damping: 25,
                             duration: 0.2,
@@ -463,7 +463,7 @@ export default function SearchableDropdown({
               shouldReduceMotion
                 ? { duration: 0 }
                 : {
-                    type: "spring",
+                    type: "spring" as const,
                     stiffness: 400,
                     damping: 25,
                     duration: 0.2,

--- a/packages/smoothui/components/searchable-dropdown/package.json
+++ b/packages/smoothui/components/searchable-dropdown/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.545.0"
   },
   "devDependencies": {

--- a/packages/smoothui/components/select/index.tsx
+++ b/packages/smoothui/components/select/index.tsx
@@ -331,7 +331,7 @@ export default function Select({
                     shouldReduceMotion
                       ? DURATION_INSTANT
                       : {
-                          type: "spring",
+                          type: "spring" as const,
                           stiffness: 300,
                           damping: 20,
                           duration: 0.2,
@@ -486,7 +486,7 @@ export default function Select({
             transition={
               shouldReduceMotion
                 ? DURATION_INSTANT
-                : { type: "spring", duration: 0.25, bounce: 0.05 }
+                : { type: "spring" as const, duration: 0.25, bounce: 0.05 }
             }
           >
             <ChevronDown className="size-4 opacity-50" />

--- a/packages/smoothui/components/select/package.json
+++ b/packages/smoothui/components/select/package.json
@@ -8,7 +8,7 @@
     "lucide-react": "^0.545.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/social-selector/index.tsx
+++ b/packages/smoothui/components/social-selector/index.tsx
@@ -152,7 +152,7 @@ export default function SocialSelector({
                 shouldReduceMotion
                   ? { duration: 0 }
                   : {
-                      type: "spring",
+                      type: "spring" as const,
                       stiffness: 500,
                       damping: 30,
                       duration: 0.25,

--- a/packages/smoothui/components/social-selector/package.json
+++ b/packages/smoothui/components/social-selector/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/packages/smoothui/components/user-account-avatar/index.tsx
+++ b/packages/smoothui/components/user-account-avatar/index.tsx
@@ -150,7 +150,7 @@ export default function UserAccountAvatar({
                     shouldReduceMotion
                       ? { duration: 0 }
                       : {
-                          type: "spring",
+                          type: "spring" as const,
                           stiffness: 300,
                           damping: 30,
                           duration: 0.4,
@@ -205,7 +205,7 @@ export default function UserAccountAvatar({
             transition={
               shouldReduceMotion
                 ? { duration: 0 }
-                : { type: "spring", duration: 0.25, bounce: 0 }
+                : { type: "spring" as const, duration: 0.25, bounce: 0 }
             }
           >
             <div
@@ -257,7 +257,7 @@ export default function UserAccountAvatar({
                     transition={
                       shouldReduceMotion
                         ? { duration: 0 }
-                        : { type: "spring", duration: 0.25, bounce: 0 }
+                        : { type: "spring" as const, duration: 0.25, bounce: 0 }
                     }
                   >
                     {renderEditProfile()}
@@ -309,7 +309,7 @@ export default function UserAccountAvatar({
                     transition={
                       shouldReduceMotion
                         ? { duration: 0 }
-                        : { type: "spring", duration: 0.25, bounce: 0 }
+                        : { type: "spring" as const, duration: 0.25, bounce: 0 }
                     }
                   >
                     {renderLastOrders()}

--- a/packages/smoothui/components/user-account-avatar/package.json
+++ b/packages/smoothui/components/user-account-avatar/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0",
+    "motion": "^12.23.25",
     "lucide-react": "^0.545.0",
     "@radix-ui/react-popover": "1.1.15"
   },

--- a/packages/smoothui/components/wave-text/package.json
+++ b/packages/smoothui/components/wave-text/package.json
@@ -7,7 +7,7 @@
     "@repo/shadcn-ui": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
-    "motion": "^11.15.0"
+    "motion": "^12.23.25"
   },
   "devDependencies": {
     "@repo/typescript-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   react: ^19.2.1
   react-dom: ^19.2.1
+  shiki: '>=4.0.0'
   glob: '>=10.5.0'
   '@types/react': ^19.2.7
   '@types/react-dom': ^19.2.3
@@ -58,8 +59,8 @@ importers:
         specifier: ^24.10.10
         version: 24.10.10
       esbuild:
-        specifier: ^0.27.3
-        version: 0.27.3
+        specifier: ^0.27.7
+        version: 0.27.7
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -122,22 +123,22 @@ importers:
         version: 0.2.1(motion@12.23.25(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       fumadocs-core:
         specifier: ^16.0.4
-        version: 16.0.4(@orama/core@1.2.13)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        version: 16.7.16(@mdx-js/mdx@3.1.1)(@orama/core@1.2.13)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@3.25.76)
       fumadocs-docgen:
         specifier: ^3.0.3
-        version: 3.0.3(fumadocs-core@16.0.4(@orama/core@1.2.13)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1))
+        version: 3.0.10(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/estree@1.0.8)(@types/hast@3.0.4)(@types/mdast@4.0.4)(fumadocs-core@16.7.16(@mdx-js/mdx@3.1.1)(@orama/core@1.2.13)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@3.25.76))(mdast-util-mdx@3.0.0)
       fumadocs-mdx:
         specifier: ^13.0.2
-        version: 13.0.2(fumadocs-core@16.0.4(@orama/core@1.2.13)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(vite@8.0.8(@types/node@24.9.1)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3))
+        version: 13.0.8(fumadocs-core@16.7.16(@mdx-js/mdx@3.1.1)(@orama/core@1.2.13)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@3.25.76))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(vite@8.0.8(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
       fumadocs-twoslash:
         specifier: ^3.1.9
-        version: 3.2.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.0.4(@orama/core@1.2.13)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(fumadocs-ui@16.0.4(@orama/core@1.2.13)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.17))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(shiki@3.14.0)(typescript@5.9.3)
+        version: 3.2.0(399142c5cb02b00195013fbef122baf5)
       fumadocs-typescript:
         specifier: ^4.0.12
-        version: 4.0.12(@types/react@19.2.7)(fumadocs-core@16.0.4(@orama/core@1.2.13)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(fumadocs-ui@16.0.4(@orama/core@1.2.13)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.17))(typescript@5.9.3)
+        version: 4.0.12(@types/react@19.2.7)(fumadocs-core@16.7.16(@mdx-js/mdx@3.1.1)(@orama/core@1.2.13)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@3.25.76))(fumadocs-ui@16.7.16(@tailwindcss/oxide@4.1.16)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.7.16(@mdx-js/mdx@3.1.1)(@orama/core@1.2.13)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@3.25.76))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.17))(typescript@5.9.3)
       fumadocs-ui:
         specifier: ^16.0.4
-        version: 16.0.4(@orama/core@1.2.13)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.17)
+        version: 16.7.16(@tailwindcss/oxide@4.1.16)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.7.16(@mdx-js/mdx@3.1.1)(@orama/core@1.2.13)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@3.25.76))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.17)
       glob:
         specifier: '>=10.5.0'
         version: 11.1.0
@@ -199,8 +200,8 @@ importers:
         specifier: ^3.8.5
         version: 3.8.5(@types/node@24.9.1)(typescript@5.9.3)
       shiki:
-        specifier: 3.14.0
-        version: 3.14.0
+        specifier: '>=4.0.0'
+        version: 4.0.2
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -361,10 +362,10 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.1
-        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.10.10)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.11.3(@types/node@24.10.10)(typescript@5.9.3))(yaml@2.8.3)
+        version: 3.2.4(@types/debug@4.1.13)(@types/node@24.10.10)(esbuild@0.27.7)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.11.3(@types/node@24.10.10)(typescript@5.9.3))(yaml@2.8.3)
       vitest-axe:
         specifier: ^1.0.0-pre.3
-        version: 1.0.0-pre.5(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.10.10)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.11.3(@types/node@24.10.10)(typescript@5.9.3))(yaml@2.8.3))
+        version: 1.0.0-pre.5(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.10.10)(esbuild@0.27.7)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.11.3(@types/node@24.10.10)(typescript@5.9.3))(yaml@2.8.3))
 
   packages/smoothui/blocks/ctas/cta-1:
     dependencies:
@@ -3922,314 +3923,314 @@ packages:
     peerDependencies:
       cosmiconfig: '>=6'
 
-  '@esbuild/aix-ppc64@0.25.11':
-    resolution: {integrity: sha512-Xt1dOL13m8u0WE8iplx9Ibbm+hFAO0GsU2P34UNoDGvZYkY8ifSiy6Zuc1lYxfG7svWE2fzqCUmFp5HCn51gJg==}
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/aix-ppc64@0.27.3':
-    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+  '@esbuild/aix-ppc64@0.27.7':
+    resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
-  '@esbuild/android-arm64@0.25.11':
-    resolution: {integrity: sha512-9slpyFBc4FPPz48+f6jyiXOx/Y4v34TUeDDXJpZqAWQn/08lKGeD8aDp9TMn9jDz2CiEuHwfhRmGBvpnd/PWIQ==}
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm64@0.27.3':
-    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+  '@esbuild/android-arm64@0.27.7':
+    resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
 
-  '@esbuild/android-arm@0.25.11':
-    resolution: {integrity: sha512-uoa7dU+Dt3HYsethkJ1k6Z9YdcHjTrSb5NUy66ZfZaSV8hEYGD5ZHbEMXnqLFlbBflLsl89Zke7CAdDJ4JI+Gg==}
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-arm@0.27.3':
-    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+  '@esbuild/android-arm@0.27.7':
+    resolution: {integrity: sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [android]
 
-  '@esbuild/android-x64@0.25.11':
-    resolution: {integrity: sha512-Sgiab4xBjPU1QoPEIqS3Xx+R2lezu0LKIEcYe6pftr56PqPygbB7+szVnzoShbx64MUupqoE0KyRlN7gezbl8g==}
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/android-x64@0.27.3':
-    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+  '@esbuild/android-x64@0.27.7':
+    resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
-  '@esbuild/darwin-arm64@0.25.11':
-    resolution: {integrity: sha512-VekY0PBCukppoQrycFxUqkCojnTQhdec0vevUL/EDOCnXd9LKWqD/bHwMPzigIJXPhC59Vd1WFIL57SKs2mg4w==}
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-arm64@0.27.3':
-    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+  '@esbuild/darwin-arm64@0.27.7':
+    resolution: {integrity: sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.25.11':
-    resolution: {integrity: sha512-+hfp3yfBalNEpTGp9loYgbknjR695HkqtY3d3/JjSRUyPg/xd6q+mQqIb5qdywnDxRZykIHs3axEqU6l1+oWEQ==}
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/darwin-x64@0.27.3':
-    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+  '@esbuild/darwin-x64@0.27.7':
+    resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
 
-  '@esbuild/freebsd-arm64@0.25.11':
-    resolution: {integrity: sha512-CmKjrnayyTJF2eVuO//uSjl/K3KsMIeYeyN7FyDBjsR3lnSJHaXlVoAK8DZa7lXWChbuOk7NjAc7ygAwrnPBhA==}
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-arm64@0.27.3':
-    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+  '@esbuild/freebsd-arm64@0.27.7':
+    resolution: {integrity: sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.25.11':
-    resolution: {integrity: sha512-Dyq+5oscTJvMaYPvW3x3FLpi2+gSZTCE/1ffdwuM6G1ARang/mb3jvjxs0mw6n3Lsw84ocfo9CrNMqc5lTfGOw==}
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/freebsd-x64@0.27.3':
-    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+  '@esbuild/freebsd-x64@0.27.7':
+    resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
 
-  '@esbuild/linux-arm64@0.25.11':
-    resolution: {integrity: sha512-Qr8AzcplUhGvdyUF08A1kHU3Vr2O88xxP0Tm8GcdVOUm25XYcMPp2YqSVHbLuXzYQMf9Bh/iKx7YPqECs6ffLA==}
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm64@0.27.3':
-    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+  '@esbuild/linux-arm64@0.27.7':
+    resolution: {integrity: sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [linux]
 
-  '@esbuild/linux-arm@0.25.11':
-    resolution: {integrity: sha512-TBMv6B4kCfrGJ8cUPo7vd6NECZH/8hPpBHHlYI3qzoYFvWu2AdTvZNuU/7hsbKWqu/COU7NIK12dHAAqBLLXgw==}
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-arm@0.27.3':
-    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+  '@esbuild/linux-arm@0.27.7':
+    resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.25.11':
-    resolution: {integrity: sha512-TmnJg8BMGPehs5JKrCLqyWTVAvielc615jbkOirATQvWWB1NMXY77oLMzsUjRLa0+ngecEmDGqt5jiDC6bfvOw==}
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-ia32@0.27.3':
-    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+  '@esbuild/linux-ia32@0.27.7':
+    resolution: {integrity: sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.25.11':
-    resolution: {integrity: sha512-DIGXL2+gvDaXlaq8xruNXUJdT5tF+SBbJQKbWy/0J7OhU8gOHOzKmGIlfTTl6nHaCOoipxQbuJi7O++ldrxgMw==}
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-loong64@0.27.3':
-    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+  '@esbuild/linux-loong64@0.27.7':
+    resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.25.11':
-    resolution: {integrity: sha512-Osx1nALUJu4pU43o9OyjSCXokFkFbyzjXb6VhGIJZQ5JZi8ylCQ9/LFagolPsHtgw6himDSyb5ETSfmp4rpiKQ==}
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-mips64el@0.27.3':
-    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+  '@esbuild/linux-mips64el@0.27.7':
+    resolution: {integrity: sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==}
     engines: {node: '>=18'}
     cpu: [mips64el]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.25.11':
-    resolution: {integrity: sha512-nbLFgsQQEsBa8XSgSTSlrnBSrpoWh7ioFDUmwo158gIm5NNP+17IYmNWzaIzWmgCxq56vfr34xGkOcZ7jX6CPw==}
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-ppc64@0.27.3':
-    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+  '@esbuild/linux-ppc64@0.27.7':
+    resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.25.11':
-    resolution: {integrity: sha512-HfyAmqZi9uBAbgKYP1yGuI7tSREXwIb438q0nqvlpxAOs3XnZ8RsisRfmVsgV486NdjD7Mw2UrFSw51lzUk1ww==}
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-riscv64@0.27.3':
-    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+  '@esbuild/linux-riscv64@0.27.7':
+    resolution: {integrity: sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.25.11':
-    resolution: {integrity: sha512-HjLqVgSSYnVXRisyfmzsH6mXqyvj0SA7pG5g+9W7ESgwA70AXYNpfKBqh1KbTxmQVaYxpzA/SvlB9oclGPbApw==}
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-s390x@0.27.3':
-    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+  '@esbuild/linux-s390x@0.27.7':
+    resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
 
-  '@esbuild/linux-x64@0.25.11':
-    resolution: {integrity: sha512-HSFAT4+WYjIhrHxKBwGmOOSpphjYkcswF449j6EjsjbinTZbp8PJtjsVK1XFJStdzXdy/jaddAep2FGY+wyFAQ==}
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/linux-x64@0.27.3':
-    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+  '@esbuild/linux-x64@0.27.7':
+    resolution: {integrity: sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
-  '@esbuild/netbsd-arm64@0.25.11':
-    resolution: {integrity: sha512-hr9Oxj1Fa4r04dNpWr3P8QKVVsjQhqrMSUzZzf+LZcYjZNqhA3IAfPQdEh1FLVUJSiu6sgAwp3OmwBfbFgG2Xg==}
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+  '@esbuild/netbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.25.11':
-    resolution: {integrity: sha512-u7tKA+qbzBydyj0vgpu+5h5AeudxOAGncb8N6C9Kh1N4n7wU1Xw1JDApsRjpShRpXRQlJLb9wY28ELpwdPcZ7A==}
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/netbsd-x64@0.27.3':
-    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+  '@esbuild/netbsd-x64@0.27.7':
+    resolution: {integrity: sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [netbsd]
 
-  '@esbuild/openbsd-arm64@0.25.11':
-    resolution: {integrity: sha512-Qq6YHhayieor3DxFOoYM1q0q1uMFYb7cSpLD2qzDSvK1NAvqFi8Xgivv0cFC6J+hWVw2teCYltyy9/m/14ryHg==}
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-arm64@0.27.3':
-    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+  '@esbuild/openbsd-arm64@0.27.7':
+    resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.25.11':
-    resolution: {integrity: sha512-CN+7c++kkbrckTOz5hrehxWN7uIhFFlmS/hqziSFVWpAzpWrQoAG4chH+nN3Be+Kzv/uuo7zhX716x3Sn2Jduw==}
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openbsd-x64@0.27.3':
-    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+  '@esbuild/openbsd-x64@0.27.7':
+    resolution: {integrity: sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [openbsd]
 
-  '@esbuild/openharmony-arm64@0.25.11':
-    resolution: {integrity: sha512-rOREuNIQgaiR+9QuNkbkxubbp8MSO9rONmwP5nKncnWJ9v5jQ4JxFnLu4zDSRPf3x4u+2VN4pM4RdyIzDty/wQ==}
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/openharmony-arm64@0.27.3':
-    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+  '@esbuild/openharmony-arm64@0.27.7':
+    resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
 
-  '@esbuild/sunos-x64@0.25.11':
-    resolution: {integrity: sha512-nq2xdYaWxyg9DcIyXkZhcYulC6pQ2FuCgem3LI92IwMgIZ69KHeY8T4Y88pcwoLIjbed8n36CyKoYRDygNSGhA==}
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/sunos-x64@0.27.3':
-    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+  '@esbuild/sunos-x64@0.27.7':
+    resolution: {integrity: sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [sunos]
 
-  '@esbuild/win32-arm64@0.25.11':
-    resolution: {integrity: sha512-3XxECOWJq1qMZ3MN8srCJ/QfoLpL+VaxD/WfNRm1O3B4+AZ/BnLVgFbUV3eiRYDMXetciH16dwPbbHqwe1uU0Q==}
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-arm64@0.27.3':
-    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+  '@esbuild/win32-arm64@0.27.7':
+    resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.25.11':
-    resolution: {integrity: sha512-3ukss6gb9XZ8TlRyJlgLn17ecsK4NSQTmdIXRASVsiS2sQ6zPPZklNJT5GR5tE/MUarymmy8kCEf5xPCNCqVOA==}
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-ia32@0.27.3':
-    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+  '@esbuild/win32-ia32@0.27.7':
+    resolution: {integrity: sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==}
     engines: {node: '>=18'}
     cpu: [ia32]
     os: [win32]
 
-  '@esbuild/win32-x64@0.25.11':
-    resolution: {integrity: sha512-D7Hpz6A2L4hzsRpPaCYkQnGOotdUpDzSGRIv9I+1ITdHROSFUWW95ZPZWQmGka1Fg7W3zFJowyn9WGwMJ0+KPA==}
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
 
-  '@esbuild/win32-x64@0.27.3':
-    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+  '@esbuild/win32-x64@0.27.7':
+    resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -4249,8 +4250,16 @@ packages:
   '@floating-ui/utils@0.2.8':
     resolution: {integrity: sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig==}
 
-  '@formatjs/intl-localematcher@0.6.2':
-    resolution: {integrity: sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==}
+  '@fumadocs/tailwind@0.0.5':
+    resolution: {integrity: sha512-ENKPWUDRmriccsrUDE4bDBq3FNr/ms3BP2rWlsAEMV1yP23pcCaan+ceGfeBUsAQjw7sj9Q3R4Kl3g/TCStPzQ==}
+    peerDependencies:
+      '@tailwindcss/oxide': ^4.0.0
+      tailwindcss: ^4.0.0
+    peerDependenciesMeta:
+      '@tailwindcss/oxide':
+        optional: true
+      tailwindcss:
+        optional: true
 
   '@hono/node-server@1.19.13':
     resolution: {integrity: sha512-TsQLe4i2gvoTtrHje625ngThGBySOgSK3Xo2XRYOdqGN1teR8+I7vchQC46uLJi8OF62YTYA3AhSpumtkhsaKQ==}
@@ -4480,6 +4489,12 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
+  '@napi-rs/wasm-runtime@1.1.4':
+    resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
   '@next/bundle-analyzer@16.2.4':
     resolution: {integrity: sha512-EAA9xTDv0P1IiUcZaASJJPkNDjRvL7OMTha6XN8MBzALYGfn7I52Mn7vRiyjVfNrtUPi2qiacY+eFVXe3lKCXA==}
 
@@ -4640,11 +4655,27 @@ packages:
     resolution: {integrity: sha512-scSmQBD8eANlMUOglxHrN1JdSW8tDghsPuS83otqealBiIeMukCQMOf/wc0JJjDXomqwNdEQFLXLGHrU6PGxuA==}
     engines: {node: '>= 20.0.0'}
 
+  '@orama/orama@3.1.18':
+    resolution: {integrity: sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==}
+    engines: {node: '>= 20.0.0'}
+
   '@orama/oramacore-events-parser@0.0.5':
     resolution: {integrity: sha512-yAuSwog+HQBAXgZ60TNKEwu04y81/09mpbYBCmz1RCxnr4ObNY2JnPZI7HmALbjAhLJ8t5p+wc2JHRK93ubO4w==}
 
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
+
+  '@oxc-transform/binding-android-arm-eabi@0.124.0':
+    resolution: {integrity: sha512-A7r8E94VSRnWlsquGXaW2rmpVcruNOTE4a/7+NCVOtlRUlbmd37bOfv0T47MLIN378uES7yldftCwcVMBG39ig==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-transform/binding-android-arm64@0.124.0':
+    resolution: {integrity: sha512-vfxxGti1ihWIOjgJOhS6HKIDqp7rszhmbTTgi81otUbJZ/1OWAMcKQyBvKb80hZabdvxU+dxzjGXottW2K/LMw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
 
   '@oxc-transform/binding-android-arm64@0.95.0':
     resolution: {integrity: sha512-eW+BCgRWOsMrDiz7FEV7BjAmaF9lGIc2ueGdRUYjRUMq4f5FSGS7gMBTYDxajdoIB3L5Gnksh1CWkIlgg95UVA==}
@@ -4652,10 +4683,22 @@ packages:
     cpu: [arm64]
     os: [android]
 
+  '@oxc-transform/binding-darwin-arm64@0.124.0':
+    resolution: {integrity: sha512-goa0sKt6dymRY9kUCA/EgXDJUQq0dj8Acedn7FkjV77RxYZjykexlAV+amM7FnuD3vGTiG5DfL3j4WKWFGnFKA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
   '@oxc-transform/binding-darwin-arm64@0.95.0':
     resolution: {integrity: sha512-OUUaYZVss8tyDZZ7TGr2vnH3+i3Ouwsx0frQRGkiePNatXxaJJ3NS5+Kwgi9hh3WryXaQz2hWji4AM2RHYE7Cg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-transform/binding-darwin-x64@0.124.0':
+    resolution: {integrity: sha512-fNzAFPbPPZDtoXlVwfXWaqp75bPdsNNqbCTnBSsT8qssQoo3Wy8H0fF1U+ltv/9z/UxkGwKow3X4LUaWiHacfw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [darwin]
 
   '@oxc-transform/binding-darwin-x64@0.95.0':
@@ -4664,14 +4707,32 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@oxc-transform/binding-freebsd-x64@0.124.0':
+    resolution: {integrity: sha512-GxMoOttUJBXjTYrpj0S24dpDSuTqUScgNmNHN9ICIh5uN4pTQ/2DI+tp8LX5170fZuvU2dpkZvhJT7hNthqWhA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
   '@oxc-transform/binding-freebsd-x64@0.95.0':
     resolution: {integrity: sha512-lNKrHKaDEm8pbKlVbn0rv2L97O0lbA0Tsrxx4GF/HhmdW+NgwGU1pMzZ4tB2QcylbqgKxOB+v9luebHyh1jfgA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.124.0':
+    resolution: {integrity: sha512-Tjhs7VKsFoyZ6+sYLJ4JeQuqxouTMTSdkxPeCPJuQ9TkAlA8Pz8JnlF3V0fxSLkQfz0lYSRvA6J9/RUO5r7+8Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
   '@oxc-transform/binding-linux-arm-gnueabihf@0.95.0':
     resolution: {integrity: sha512-+VWcLeeizI8IjU+V+o8AmzPuIMiTrGr0vrmXU3CEsV05MrywCuJU+f6ilPs3JBKno9VIwqvRpHB/z39sQabHWg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm-musleabihf@0.124.0':
+    resolution: {integrity: sha512-3GFThaQKrokWlz5PxclCwuYmNJpiqJ8pECShmaUJ0ACQlzlvXmXLdWy7ImfygGeqKIWq0N7Ps/+fH4gIrsaVRg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
@@ -4682,8 +4743,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@oxc-transform/binding-linux-arm64-gnu@0.124.0':
+    resolution: {integrity: sha512-dY4cbuDbKPEpbxRe85imTO7pRba83z/sAmcYPUtb6ZvOEI4cEY8h0nMI5YRmeZMBF5xXQ1a95fyiDf35f63keQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
   '@oxc-transform/binding-linux-arm64-gnu@0.95.0':
     resolution: {integrity: sha512-NLdrFuEHlmbiC1M1WESFV4luUcB/84GXi+cbnRXhgMjIW/CThRVJ989eTJy59QivkVlLcJSKTiKiKCt0O6TTlQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm64-musl@0.124.0':
+    resolution: {integrity: sha512-X5jBDOv7df39YNp9rq3oGo9SAWhtChJYxPnwHzm9FdvbQ6NmASxylipWXnKu6M025Dwpg/1bjiBbG9XuYhXBFA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
@@ -4694,10 +4767,34 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@oxc-transform/binding-linux-ppc64-gnu@0.124.0':
+    resolution: {integrity: sha512-e4oc7gBUPnroe+dhTT+mOtXkXcWkSZZojd4xDpMKAhy6hpKUVBotnudoEPIR7HAOXRmktlgx5ab2zSnYR2kydA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-riscv64-gnu@0.124.0':
+    resolution: {integrity: sha512-t+WUSyPoq0kobE+AKVHOHQMdijjA8RxhDwYSVgPHAF5c4mPwkD9EtZj1FyBNtRYgRuPQq8dWHGnNZXyFouNJ5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
   '@oxc-transform/binding-linux-riscv64-gnu@0.95.0':
     resolution: {integrity: sha512-tbH7LaClSmN3YFVo1UjMSe7D6gkb5f+CMIbj9i873UUZomVRmAjC4ygioObfzM+sj/tX0WoTXx5L1YOfQkHL6Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-riscv64-musl@0.124.0':
+    resolution: {integrity: sha512-jNApR8gnWbR2zYM+a04jve2xa7qi25zYYb7feTrpV98J+YJaiPVJhzoXHxnKQGKSj7oMt6n6YK1QQVG+LlVpjw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-s390x-gnu@0.124.0':
+    resolution: {integrity: sha512-SxLmO/ycauLKadwP9dvRpt8qRKZKaQER1OnvC6eY8hKXiN0EF+pL5QaPIIje7PV8sieRrrOcrSeKFBv+C6t0Ug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
     os: [linux]
 
   '@oxc-transform/binding-linux-s390x-gnu@0.95.0':
@@ -4706,8 +4803,20 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@oxc-transform/binding-linux-x64-gnu@0.124.0':
+    resolution: {integrity: sha512-TsPm58U1lq3rzhxegdMiy7ej0M3xKIxm+IHfgOg/n8g95fGT9D0E1sswTRBlAQtkXPnVfuqW8Hxf8t/4fCjqzw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
   '@oxc-transform/binding-linux-x64-gnu@0.95.0':
     resolution: {integrity: sha512-D5ULJ2uWipsTgfvHIvqmnGkCtB3Fyt2ZN7APRjVO+wLr+HtmnaWddKsLdrRWX/m/6nQ2xQdoQekdJrokYK9LtQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-x64-musl@0.124.0':
+    resolution: {integrity: sha512-nRg8/cItmAlKZD+jE5YqwDdvZ0GkvJAMavBshm0awhDn5RURWE5317QwDOvR3bZviRInv62C3eYMZdk0O64zPw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
@@ -4718,15 +4827,44 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@oxc-transform/binding-openharmony-arm64@0.124.0':
+    resolution: {integrity: sha512-NBDXwqbaYvjRy0wslzP/2V4L59r930htq4merS3HHBKI994J36zPZF6732bw6CUfUnXObe0qfOWPMmH+8f3ktw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-transform/binding-wasm32-wasi@0.124.0':
+    resolution: {integrity: sha512-iK+9DYYI/eqEWAMZ40b2ip5OiMv/BSyR0jCc5rLE1PAVUFyFHglxLv8sInZqFnkWpnlvlfTZy71GNDn6fq+xFQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
   '@oxc-transform/binding-wasm32-wasi@0.95.0':
     resolution: {integrity: sha512-tSo1EU4Whd1gXyae7cwSDouhppkuz6Jkd5LY8Uch9VKsHVSRhDLDW19Mq6VSwtyPxDPTJnJ2jYJWm+n8SYXiXQ==}
     engines: {node: '>=14.0.0'}
     cpu: [wasm32]
 
+  '@oxc-transform/binding-win32-arm64-msvc@0.124.0':
+    resolution: {integrity: sha512-GffpZFW5mBAIxbFoNrGagNqloFU2gAM+wFEuzGsPu2CmcZqsbKzbf5ydU3sUlEt0kxXqW9IYsZhXsa2fnkzMpw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
   '@oxc-transform/binding-win32-arm64-msvc@0.95.0':
     resolution: {integrity: sha512-6eaxlgj+J5n8zgJTSugqdPLBtKGRqvxYLcvHN8b+U9hVhF/2HG/JCOrcSYV/XgWGNPQiaRVzpR3hGhmFro9QTw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
+    os: [win32]
+
+  '@oxc-transform/binding-win32-ia32-msvc@0.124.0':
+    resolution: {integrity: sha512-S+GHzB7y62H0tZIMRC5NIuB247xb5DYhnha/KcIBCCmcxl8rg9bJOez5Kyfd2yfda2LjqPdrx6GalZmhj2wJgg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-transform/binding-win32-x64-msvc@0.124.0':
+    resolution: {integrity: sha512-zRQMSYNrqUJfbAKOPhFFqo0aiAA850/ZVyrDIGbbbCaF499OwdK6Odt7TRsy97hgEW1w73gKO4KV6Y/HZV42Zg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
     os: [win32]
 
   '@oxc-transform/binding-win32-x64-msvc@0.95.0':
@@ -5662,43 +5800,39 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
-  '@shikijs/core@3.14.0':
-    resolution: {integrity: sha512-qRSeuP5vlYHCNUIrpEBQFO7vSkR7jn7Kv+5X3FO/zBKVDGQbcnlScD3XhkrHi/R8Ltz0kEjvFR9Szp/XMRbFMw==}
-
   '@shikijs/core@4.0.2':
     resolution: {integrity: sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==}
     engines: {node: '>=20'}
 
-  '@shikijs/engine-javascript@3.14.0':
-    resolution: {integrity: sha512-3v1kAXI2TsWQuwv86cREH/+FK9Pjw3dorVEykzQDhwrZj0lwsHYlfyARaKmn6vr5Gasf8aeVpb8JkzeWspxOLQ==}
+  '@shikijs/engine-javascript@4.0.2':
+    resolution: {integrity: sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==}
+    engines: {node: '>=20'}
 
-  '@shikijs/engine-oniguruma@3.14.0':
-    resolution: {integrity: sha512-TNcYTYMbJyy+ZjzWtt0bG5y4YyMIWC2nyePz+CFMWqm+HnZZyy9SWMgo8Z6KBJVIZnx8XUXS8U2afO6Y0g1Oug==}
+  '@shikijs/engine-oniguruma@4.0.2':
+    resolution: {integrity: sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==}
+    engines: {node: '>=20'}
 
-  '@shikijs/langs@3.14.0':
-    resolution: {integrity: sha512-DIB2EQY7yPX1/ZH7lMcwrK5pl+ZkP/xoSpUzg9YC8R+evRCCiSQ7yyrvEyBsMnfZq4eBzLzBlugMyTAf13+pzg==}
+  '@shikijs/langs@4.0.2':
+    resolution: {integrity: sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==}
+    engines: {node: '>=20'}
 
   '@shikijs/primitive@4.0.2':
     resolution: {integrity: sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==}
     engines: {node: '>=20'}
 
-  '@shikijs/rehype@3.14.0':
-    resolution: {integrity: sha512-In2G6yvT0ZFDqNGbJumd7gEAwtxuaXuchCc0O3qOytIUTlpzs8/D0CQF3wktdfOB6B869eab6Z6EIJr4Td4hQQ==}
+  '@shikijs/themes@4.0.2':
+    resolution: {integrity: sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==}
+    engines: {node: '>=20'}
 
-  '@shikijs/themes@3.14.0':
-    resolution: {integrity: sha512-fAo/OnfWckNmv4uBoUu6dSlkcBc+SA1xzj5oUSaz5z3KqHtEbUypg/9xxgJARtM6+7RVm0Q6Xnty41xA1ma1IA==}
-
-  '@shikijs/transformers@3.14.0':
-    resolution: {integrity: sha512-i67zQnY9wLMMnKasonVW1L9fKneSLZDj1ePsA4o0AZWU4uUobmJY9baRDa36z+a9/g0aG76/2tybQvm4hrwxIQ==}
+  '@shikijs/transformers@4.0.2':
+    resolution: {integrity: sha512-1+L0gf9v+SdDXs08vjaLb3mBFa8U7u37cwcBQIv/HCocLwX69Tt6LpUCjtB+UUTvQxI7BnjZKhN/wMjhHBcJGg==}
+    engines: {node: '>=20'}
 
   '@shikijs/twoslash@4.0.2':
     resolution: {integrity: sha512-yHRudhirlMxOwDO6Q4OFU9hJMvUqNkY8hwtUfbaSEoG7A2cYicdO4c8fdDaDtyJ50HK7I8vTokrkIHTK3DCkLQ==}
     engines: {node: '>=20'}
     peerDependencies:
       typescript: '>=5.5.0'
-
-  '@shikijs/types@3.14.0':
-    resolution: {integrity: sha512-bQGgC6vrY8U/9ObG1Z/vTro+uclbjjD/uG58RvfxKZVD5p9Yc1ka3tVyEFy7BNJLzxuWyHH5NWynP9zZZS59eQ==}
 
   '@shikijs/types@4.0.2':
     resolution: {integrity: sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==}
@@ -6814,13 +6948,13 @@ packages:
   esast-util-from-js@2.0.1:
     resolution: {integrity: sha512-8Ja+rNJ0Lt56Pcf3TAmpBZjmx8ZcK5Ts4cAzIOjsjevg9oSXJnl6SUQ2EevU8tv3h6ZLWmoKL5H4fgWvdvfETw==}
 
-  esbuild@0.25.11:
-    resolution: {integrity: sha512-KohQwyzrKTQmhXDW1PjCv3Tyspn9n5GcY2RTDqeORIdIJY8yKIF7sTSopFmn/wpMPW4rdPXI0UE5LJLuq3bx0Q==}
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
     engines: {node: '>=18'}
     hasBin: true
 
-  esbuild@0.27.3:
-    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+  esbuild@0.27.7:
+    resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -7030,6 +7164,20 @@ packages:
       react-dom:
         optional: true
 
+  framer-motion@12.38.0:
+    resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^19.2.1
+      react-dom: ^19.2.1
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
   framesync@6.1.2:
     resolution: {integrity: sha512-jBTqhX6KaQVDyus8muwZbBeGGP0XgujBRbQ7gM7BRdS3CadCZIHiawyzYLnafYcvZIh5j8WE7cxZKFn7dXhu9g==}
 
@@ -7049,30 +7197,49 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
-  fumadocs-core@16.0.4:
-    resolution: {integrity: sha512-//cj4Z4tMbZGBs7OGnRSeHtQ8AolIwJjAdx+j/EpR21AZQ4Lbx2+qYNDAbVKQdbMYaIWiHrE/l0iHJJgWg+HQQ==}
+  fumadocs-core@16.7.16:
+    resolution: {integrity: sha512-OXZMJPS/HVAfCw8/VEgsOEQNWUXq7+U2v1A/DbKmI0Vbb08uPCUpbIqVSj4kmGr46L+Pa/PZgG596Z7iPhlbCg==}
     peerDependencies:
-      '@mixedbread/sdk': ^0.19.0
+      '@mdx-js/mdx': '*'
+      '@mixedbread/sdk': ^0.46.0
       '@orama/core': 1.x.x
+      '@oramacloud/client': 2.x.x
       '@tanstack/react-router': 1.x.x
+      '@types/estree-jsx': '*'
+      '@types/hast': '*'
+      '@types/mdast': '*'
       '@types/react': ^19.2.7
       algoliasearch: 5.x.x
+      flexsearch: '*'
       lucide-react: '*'
       next: 16.x.x
       react: ^19.2.1
       react-dom: ^19.2.1
       react-router: 7.x.x
-      waku: ^0.26.0
+      waku: ^0.26.0 || ^0.27.0 || ^1.0.0
+      zod: 4.x.x
     peerDependenciesMeta:
+      '@mdx-js/mdx':
+        optional: true
       '@mixedbread/sdk':
         optional: true
       '@orama/core':
         optional: true
+      '@oramacloud/client':
+        optional: true
       '@tanstack/react-router':
+        optional: true
+      '@types/estree-jsx':
+        optional: true
+      '@types/hast':
+        optional: true
+      '@types/mdast':
         optional: true
       '@types/react':
         optional: true
       algoliasearch:
+        optional: true
+      flexsearch:
         optional: true
       lucide-react:
         optional: true
@@ -7086,14 +7253,29 @@ packages:
         optional: true
       waku:
         optional: true
+      zod:
+        optional: true
 
-  fumadocs-docgen@3.0.3:
-    resolution: {integrity: sha512-FrGhl2qfGEE5w3iijgaRTVHWQpMOFkS83CF4NciZPhh8taXerkJXuCZdmkwkxtksi+HUdni3QDoV5z3SaTBnZw==}
+  fumadocs-docgen@3.0.10:
+    resolution: {integrity: sha512-64dSEHkYANohYbSz87YqxlpEQENfd/wI2Mf8Ra+HpIhnM7hmPQAh6SwZy4d+er0AYVNiF4Pq8j1oe9UIxV5lfA==}
     peerDependencies:
+      '@types/estree': '*'
+      '@types/hast': '*'
+      '@types/mdast': '*'
       fumadocs-core: ^15.7.2 || ^16.0.0
+      mdast-util-mdx: '*'
+    peerDependenciesMeta:
+      '@types/estree':
+        optional: true
+      '@types/hast':
+        optional: true
+      '@types/mdast':
+        optional: true
+      mdast-util-mdx:
+        optional: true
 
-  fumadocs-mdx@13.0.2:
-    resolution: {integrity: sha512-PLlpdDJze/Yy7phM6v9vyIcxDSGrfkUTkvhTiGHkLBft5bA171fAs+BzhiqwNCfR+4MfXMppfb7ffZV3sg6frA==}
+  fumadocs-mdx@13.0.8:
+    resolution: {integrity: sha512-UbUwH0iGvYbytnxhmfd7tWJKFK8L0mrbTAmrQYnpg6Wi/h8afNMJmbHBOzVcaEWJKeFipZ1CGDAsNA2fztwXNg==}
     hasBin: true
     peerDependencies:
       '@fumadocs/mdx-remote': ^1.4.0
@@ -7119,7 +7301,7 @@ packages:
       fumadocs-ui: ^16.7.16
       react: ^19.2.1
       react-dom: ^19.2.1
-      shiki: 4.x.x
+      shiki: '>=4.0.0'
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -7137,20 +7319,24 @@ packages:
       fumadocs-ui:
         optional: true
 
-  fumadocs-ui@16.0.4:
-    resolution: {integrity: sha512-OARKTC/+2Rkw3vE4ZUpN5jWXPjDju4VQBwBTgAP6QVZJgwD4nQt/mdZp9wtWRGD195acY13MaWAG0l4CxmjELA==}
+  fumadocs-ui@16.7.16:
+    resolution: {integrity: sha512-NFWH8GuVV0O6OQnGb0TCS6jsdgyB7/5phQm8YjtIkyjkxAkERwA76N5RYCpS27p41NdtWdQw4eFIEve1Aq9Siw==}
     peerDependencies:
+      '@takumi-rs/image-response': '*'
+      '@types/mdx': '*'
       '@types/react': ^19.2.7
+      fumadocs-core: 16.7.16
       next: 16.x.x
       react: ^19.2.1
       react-dom: ^19.2.1
-      tailwindcss: ^4.0.0
     peerDependenciesMeta:
+      '@takumi-rs/image-response':
+        optional: true
+      '@types/mdx':
+        optional: true
       '@types/react':
         optional: true
       next:
-        optional: true
-      tailwindcss:
         optional: true
 
   function-bind@1.1.2:
@@ -7313,6 +7499,9 @@ packages:
   hast-util-parse-selector@4.0.0:
     resolution: {integrity: sha512-wkQCkSYoOGCRKERFWcxMVMOcYE2K1AaNLU8DXS9arxnLOUEWbOXKXiJUNzEpqZ3JOKpnha3jkFrumEjVliDe7A==}
 
+  hast-util-raw@9.1.0:
+    resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
   hast-util-to-estree@3.1.3:
     resolution: {integrity: sha512-48+B/rJWAp0jamNbAAf9M7Uf//UVqAoMmgXhBdxTDJLGKY+LRnZ99qcG+Qjl5HfMpYNzS5v4EAwVEF34LeAj7w==}
 
@@ -7322,8 +7511,8 @@ packages:
   hast-util-to-jsx-runtime@2.3.6:
     resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
 
-  hast-util-to-string@3.0.1:
-    resolution: {integrity: sha512-XelQVTDWvqcl3axRfI0xSeoVKzyIFPwsAGSLIsKdJKQMXDYJS4WYrBNF/8J7RdhIcFI2BOHgAifggsvsxp/3+A==}
+  hast-util-to-parse5@8.0.1:
+    resolution: {integrity: sha512-MlWT6Pjt4CG9lFCjiz4BH7l9wmrMkfkJYCxFwKQic8+RTZgWPuWxwAfjJElsXkex7DJjfSJsQIt931ilUgmwdA==}
 
   hast-util-to-text@4.0.2:
     resolution: {integrity: sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A==}
@@ -7394,11 +7583,6 @@ packages:
   ignore@5.3.1:
     resolution: {integrity: sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==}
     engines: {node: '>= 4'}
-
-  image-size@2.0.2:
-    resolution: {integrity: sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==}
-    engines: {node: '>=16.x'}
-    hasBin: true
 
   immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
@@ -7920,9 +8104,6 @@ packages:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
     deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
-  lodash.merge@4.6.2:
-    resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
-
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
 
@@ -7989,6 +8170,11 @@ packages:
 
   lucide-react@0.555.0:
     resolution: {integrity: sha512-D8FvHUGbxWBRQM90NZeIyhAvkFfsh3u9ekrMvJ30Z6gnpBHS6HC6ldLg7tL45hwiIz/u66eKDtdA23gwwGsAHA==}
+    peerDependencies:
+      react: ^19.2.1
+
+  lucide-react@1.8.0:
+    resolution: {integrity: sha512-WuvlsjngSk7TnTBJ1hsCy3ql9V9VOdcPkd3PKcSmM34vJD8KG6molxz7m7zbYFgICwsanQWmJ13JlYs4Zp7Arw==}
     peerDependencies:
       react: ^19.2.1
 
@@ -8237,11 +8423,17 @@ packages:
   motion-dom@12.23.23:
     resolution: {integrity: sha512-n5yolOs0TQQBRUFImrRfs/+6X4p3Q4n1dUEqt/H58Vx7OW6RF+foWEgmTVDhIWJIMXOuNNL0apKH2S16en9eiA==}
 
+  motion-dom@12.38.0:
+    resolution: {integrity: sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==}
+
   motion-utils@11.18.1:
     resolution: {integrity: sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==}
 
   motion-utils@12.23.6:
     resolution: {integrity: sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==}
+
+  motion-utils@12.36.0:
+    resolution: {integrity: sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==}
 
   motion@11.18.2:
     resolution: {integrity: sha512-JLjvFDuFr42NFtcVoMAyC2sEjnpA8xpy6qWPyzQvCloznAyQ8FIXioxWfHiLtgYhoVpfUqSWpn1h9++skj9+Wg==}
@@ -8259,6 +8451,20 @@ packages:
 
   motion@12.23.25:
     resolution: {integrity: sha512-Fk5Y1kcgxYiTYOUjmwfXQAP7tP+iGqw/on1UID9WEL/6KpzxPr9jY2169OsjgZvXJdpraKXy0orkjaCVIl5fgQ==}
+    peerDependencies:
+      '@emotion/is-prop-valid': '*'
+      react: ^19.2.1
+      react-dom: ^19.2.1
+    peerDependenciesMeta:
+      '@emotion/is-prop-valid':
+        optional: true
+      react:
+        optional: true
+      react-dom:
+        optional: true
+
+  motion@12.38.0:
+    resolution: {integrity: sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
       react: ^19.2.1
@@ -8416,8 +8622,8 @@ packages:
   oniguruma-parser@0.12.1:
     resolution: {integrity: sha512-8Unqkvk1RYc6yq2WBYRj4hdnsAxVze8i7iPfQr8e4uSP3tRv0rpZcbGUDvxfQQcdwHt/e9PrMvGCsa8OqG9X3w==}
 
-  oniguruma-to-es@4.3.3:
-    resolution: {integrity: sha512-rPiZhzC3wXwE59YQMRDodUwwT9FZ9nNBwQQfsd1wfdtlKEyCdRV0avrTcSZ5xlIvGRVPd/cx6ZN45ECmS39xvg==}
+  oniguruma-to-es@4.3.5:
+    resolution: {integrity: sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ==}
 
   open@11.0.0:
     resolution: {integrity: sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==}
@@ -8437,6 +8643,10 @@ packages:
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
+
+  oxc-transform@0.124.0:
+    resolution: {integrity: sha512-uxVsQFZAaMv4cL3ijc1tx0WczUoBJBbwIFbtTf2QOdRww1s12Ib8dGc5Og63Fh4tmHt9ajYu+9BjxCRSL0b9/g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
 
   oxc-transform@0.95.0:
     resolution: {integrity: sha512-SmS5aThb5K0SoUZgzGbikNBjrGHfOY4X5TEqBlaZb1uy5YgXbUSbpakpZJ13yW36LNqy8Im5+y+sIk5dlzpZ/w==}
@@ -8714,12 +8924,6 @@ packages:
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
 
-  react-medium-image-zoom@5.4.0:
-    resolution: {integrity: sha512-BsE+EnFVQzFIlyuuQrZ9iTwyKpKkqdFZV1ImEQN573QPqGrIUuNni7aF+sZwDcxlsuOMayCr6oO/PZR/yJnbRg==}
-    peerDependencies:
-      react: ^19.2.1
-      react-dom: ^19.2.1
-
   react-remove-scroll-bar@2.3.8:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
@@ -8732,6 +8936,16 @@ packages:
 
   react-remove-scroll@2.6.3:
     resolution: {integrity: sha512-pnAi91oOk8g8ABQKGF5/M9qxmmOPxaAnopyTHYfqYEwJhyFrbbBtHuSgtKEoH0jpcxx5o3hXqH1mNd9/Oi+8iQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      '@types/react': ^19.2.7
+      react: ^19.2.1
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
     engines: {node: '>=10'}
     peerDependencies:
       '@types/react': ^19.2.7
@@ -8836,8 +9050,8 @@ packages:
   regex-utilities@2.3.0:
     resolution: {integrity: sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==}
 
-  regex@6.0.1:
-    resolution: {integrity: sha512-uorlqlzAKjKQZ5P+kTJr3eeJGSVroLKoHmquUj4zHWuR+hEyNqlXsSKlYYF5F4NI6nl7tWCs0apKJ0lmfsXAPA==}
+  regex@6.1.0:
+    resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
 
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
@@ -8845,6 +9059,9 @@ packages:
 
   rehype-katex@7.0.1:
     resolution: {integrity: sha512-OiM2wrZ/wuhKkigASodFoo8wimG3H12LWQaH8qSPVJn9apWKFSH3YOCtbKpBorTVw/eI7cuT21XBbvwEswbIOA==}
+
+  rehype-raw@7.0.0:
+    resolution: {integrity: sha512-/aE8hCfKlQeA8LmyeyQvQF3eBiLRGNlfBJEvWH7ivp9sBqs7TNqBL5X3v157rM4IFETqDnIOO+z5M/biZbo9Ww==}
 
   rehype-recma@1.0.0:
     resolution: {integrity: sha512-lqA4rGUf1JmacCNWWZx0Wv1dHqMwxzsDWYMTowuplHF3xH0N/MmrZ/G3BDZnzAkRmxDadujCjaKM2hqYdCBOGw==}
@@ -9018,8 +9235,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  shiki@3.14.0:
-    resolution: {integrity: sha512-J0yvpLI7LSig3Z3acIuDLouV5UCKQqu8qOArwMx+/yPVC3WRMgrP67beaG8F+j4xfEWE0eVC4GeBCIXeOPra1g==}
+  shiki@4.0.2:
+    resolution: {integrity: sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==}
+    engines: {node: '>=20'}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -9274,19 +9492,16 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
-  tinyexec@1.0.1:
-    resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
-
-  tinyexec@1.0.2:
-    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
-    engines: {node: '>=18'}
-
   tinyexec@1.1.1:
     resolution: {integrity: sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==}
     engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  tinyglobby@0.2.16:
+    resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
 
   tinypool@1.1.1:
@@ -9619,6 +9834,9 @@ packages:
   vfile-message@4.0.2:
     resolution: {integrity: sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw==}
 
+  vfile-message@4.0.3:
+    resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
 
@@ -9903,7 +10121,7 @@ snapshots:
       ansis: 4.1.0
       fzf: 0.5.2
       package-manager-detector: 1.3.0
-      tinyexec: 1.0.2
+      tinyexec: 1.1.1
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -10367,164 +10585,164 @@ snapshots:
       lodash.get: 4.4.2
       make-error: 1.3.6
       ts-node: 9.1.1(typescript@5.9.3)
-      tslib: 2.8.1
+      tslib: 2.1.0
     transitivePeerDependencies:
       - typescript
 
-  '@esbuild/aix-ppc64@0.25.11':
+  '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/aix-ppc64@0.27.3':
+  '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
-  '@esbuild/android-arm64@0.25.11':
+  '@esbuild/android-arm64@0.25.12':
     optional: true
 
-  '@esbuild/android-arm64@0.27.3':
+  '@esbuild/android-arm64@0.27.7':
     optional: true
 
-  '@esbuild/android-arm@0.25.11':
+  '@esbuild/android-arm@0.25.12':
     optional: true
 
-  '@esbuild/android-arm@0.27.3':
+  '@esbuild/android-arm@0.27.7':
     optional: true
 
-  '@esbuild/android-x64@0.25.11':
+  '@esbuild/android-x64@0.25.12':
     optional: true
 
-  '@esbuild/android-x64@0.27.3':
+  '@esbuild/android-x64@0.27.7':
     optional: true
 
-  '@esbuild/darwin-arm64@0.25.11':
+  '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-arm64@0.27.3':
+  '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
-  '@esbuild/darwin-x64@0.25.11':
+  '@esbuild/darwin-x64@0.25.12':
     optional: true
 
-  '@esbuild/darwin-x64@0.27.3':
+  '@esbuild/darwin-x64@0.27.7':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.25.11':
+  '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-arm64@0.27.3':
+  '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
-  '@esbuild/freebsd-x64@0.25.11':
+  '@esbuild/freebsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/freebsd-x64@0.27.3':
+  '@esbuild/freebsd-x64@0.27.7':
     optional: true
 
-  '@esbuild/linux-arm64@0.25.11':
+  '@esbuild/linux-arm64@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm64@0.27.3':
+  '@esbuild/linux-arm64@0.27.7':
     optional: true
 
-  '@esbuild/linux-arm@0.25.11':
+  '@esbuild/linux-arm@0.25.12':
     optional: true
 
-  '@esbuild/linux-arm@0.27.3':
+  '@esbuild/linux-arm@0.27.7':
     optional: true
 
-  '@esbuild/linux-ia32@0.25.11':
+  '@esbuild/linux-ia32@0.25.12':
     optional: true
 
-  '@esbuild/linux-ia32@0.27.3':
+  '@esbuild/linux-ia32@0.27.7':
     optional: true
 
-  '@esbuild/linux-loong64@0.25.11':
+  '@esbuild/linux-loong64@0.25.12':
     optional: true
 
-  '@esbuild/linux-loong64@0.27.3':
+  '@esbuild/linux-loong64@0.27.7':
     optional: true
 
-  '@esbuild/linux-mips64el@0.25.11':
+  '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
-  '@esbuild/linux-mips64el@0.27.3':
+  '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
-  '@esbuild/linux-ppc64@0.25.11':
+  '@esbuild/linux-ppc64@0.25.12':
     optional: true
 
-  '@esbuild/linux-ppc64@0.27.3':
+  '@esbuild/linux-ppc64@0.27.7':
     optional: true
 
-  '@esbuild/linux-riscv64@0.25.11':
+  '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
-  '@esbuild/linux-riscv64@0.27.3':
+  '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
-  '@esbuild/linux-s390x@0.25.11':
+  '@esbuild/linux-s390x@0.25.12':
     optional: true
 
-  '@esbuild/linux-s390x@0.27.3':
+  '@esbuild/linux-s390x@0.27.7':
     optional: true
 
-  '@esbuild/linux-x64@0.25.11':
+  '@esbuild/linux-x64@0.25.12':
     optional: true
 
-  '@esbuild/linux-x64@0.27.3':
+  '@esbuild/linux-x64@0.27.7':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.25.11':
+  '@esbuild/netbsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-arm64@0.27.3':
+  '@esbuild/netbsd-arm64@0.27.7':
     optional: true
 
-  '@esbuild/netbsd-x64@0.25.11':
+  '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/netbsd-x64@0.27.3':
+  '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.25.11':
+  '@esbuild/openbsd-arm64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-arm64@0.27.3':
+  '@esbuild/openbsd-arm64@0.27.7':
     optional: true
 
-  '@esbuild/openbsd-x64@0.25.11':
+  '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
-  '@esbuild/openbsd-x64@0.27.3':
+  '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.25.11':
+  '@esbuild/openharmony-arm64@0.25.12':
     optional: true
 
-  '@esbuild/openharmony-arm64@0.27.3':
+  '@esbuild/openharmony-arm64@0.27.7':
     optional: true
 
-  '@esbuild/sunos-x64@0.25.11':
+  '@esbuild/sunos-x64@0.25.12':
     optional: true
 
-  '@esbuild/sunos-x64@0.27.3':
+  '@esbuild/sunos-x64@0.27.7':
     optional: true
 
-  '@esbuild/win32-arm64@0.25.11':
+  '@esbuild/win32-arm64@0.25.12':
     optional: true
 
-  '@esbuild/win32-arm64@0.27.3':
+  '@esbuild/win32-arm64@0.27.7':
     optional: true
 
-  '@esbuild/win32-ia32@0.25.11':
+  '@esbuild/win32-ia32@0.25.12':
     optional: true
 
-  '@esbuild/win32-ia32@0.27.3':
+  '@esbuild/win32-ia32@0.27.7':
     optional: true
 
-  '@esbuild/win32-x64@0.25.11':
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
-  '@esbuild/win32-x64@0.27.3':
+  '@esbuild/win32-x64@0.27.7':
     optional: true
 
   '@floating-ui/core@1.6.8':
@@ -10544,9 +10762,10 @@ snapshots:
 
   '@floating-ui/utils@0.2.8': {}
 
-  '@formatjs/intl-localematcher@0.6.2':
-    dependencies:
-      tslib: 2.8.1
+  '@fumadocs/tailwind@0.0.5(@tailwindcss/oxide@4.1.16)(tailwindcss@4.1.17)':
+    optionalDependencies:
+      '@tailwindcss/oxide': 4.1.16
+      tailwindcss: 4.1.17
 
   '@hono/node-server@1.19.13(hono@4.12.14)':
     dependencies:
@@ -10746,7 +10965,7 @@ snapshots:
       '@types/estree-jsx': 1.0.5
       '@types/hast': 3.0.4
       '@types/mdx': 2.0.13
-      acorn: 8.15.0
+      acorn: 8.16.0
       collapse-white-space: 2.1.0
       devlop: 1.1.0
       estree-util-is-identifier-name: 3.0.0
@@ -10755,7 +10974,7 @@ snapshots:
       hast-util-to-jsx-runtime: 2.3.6
       markdown-extensions: 2.0.0
       recma-build-jsx: 1.0.0
-      recma-jsx: 1.0.1(acorn@8.15.0)
+      recma-jsx: 1.0.1(acorn@8.16.0)
       recma-stringify: 1.0.0
       rehype-recma: 1.0.0
       remark-mdx: 3.1.1
@@ -10765,7 +10984,7 @@ snapshots:
       unified: 11.0.5
       unist-util-position-from-estree: 2.0.0
       unist-util-stringify-position: 4.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -10809,6 +11028,13 @@ snapshots:
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.3(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
       '@emnapi/core': 1.9.2
       '@emnapi/runtime': 1.9.2
@@ -10977,44 +11203,102 @@ snapshots:
 
   '@orama/orama@3.1.16': {}
 
+  '@orama/orama@3.1.18': {}
+
   '@orama/oramacore-events-parser@0.0.5': {}
 
   '@oxc-project/types@0.124.0': {}
 
+  '@oxc-transform/binding-android-arm-eabi@0.124.0':
+    optional: true
+
+  '@oxc-transform/binding-android-arm64@0.124.0':
+    optional: true
+
   '@oxc-transform/binding-android-arm64@0.95.0':
+    optional: true
+
+  '@oxc-transform/binding-darwin-arm64@0.124.0':
     optional: true
 
   '@oxc-transform/binding-darwin-arm64@0.95.0':
     optional: true
 
+  '@oxc-transform/binding-darwin-x64@0.124.0':
+    optional: true
+
   '@oxc-transform/binding-darwin-x64@0.95.0':
+    optional: true
+
+  '@oxc-transform/binding-freebsd-x64@0.124.0':
     optional: true
 
   '@oxc-transform/binding-freebsd-x64@0.95.0':
     optional: true
 
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.124.0':
+    optional: true
+
   '@oxc-transform/binding-linux-arm-gnueabihf@0.95.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm-musleabihf@0.124.0':
     optional: true
 
   '@oxc-transform/binding-linux-arm-musleabihf@0.95.0':
     optional: true
 
+  '@oxc-transform/binding-linux-arm64-gnu@0.124.0':
+    optional: true
+
   '@oxc-transform/binding-linux-arm64-gnu@0.95.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm64-musl@0.124.0':
     optional: true
 
   '@oxc-transform/binding-linux-arm64-musl@0.95.0':
     optional: true
 
+  '@oxc-transform/binding-linux-ppc64-gnu@0.124.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-riscv64-gnu@0.124.0':
+    optional: true
+
   '@oxc-transform/binding-linux-riscv64-gnu@0.95.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-riscv64-musl@0.124.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-s390x-gnu@0.124.0':
     optional: true
 
   '@oxc-transform/binding-linux-s390x-gnu@0.95.0':
     optional: true
 
+  '@oxc-transform/binding-linux-x64-gnu@0.124.0':
+    optional: true
+
   '@oxc-transform/binding-linux-x64-gnu@0.95.0':
     optional: true
 
+  '@oxc-transform/binding-linux-x64-musl@0.124.0':
+    optional: true
+
   '@oxc-transform/binding-linux-x64-musl@0.95.0':
+    optional: true
+
+  '@oxc-transform/binding-openharmony-arm64@0.124.0':
+    optional: true
+
+  '@oxc-transform/binding-wasm32-wasi@0.124.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
     optional: true
 
   '@oxc-transform/binding-wasm32-wasi@0.95.0':
@@ -11022,7 +11306,16 @@ snapshots:
       '@napi-rs/wasm-runtime': 1.0.7
     optional: true
 
+  '@oxc-transform/binding-win32-arm64-msvc@0.124.0':
+    optional: true
+
   '@oxc-transform/binding-win32-arm64-msvc@0.95.0':
+    optional: true
+
+  '@oxc-transform/binding-win32-ia32-msvc@0.124.0':
+    optional: true
+
+  '@oxc-transform/binding-win32-x64-msvc@0.124.0':
     optional: true
 
   '@oxc-transform/binding-win32-x64-msvc@0.95.0':
@@ -11192,7 +11485,7 @@ snapshots:
       aria-hidden: 1.2.4
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
-      react-remove-scroll: 2.6.3(@types/react@19.2.7)(react@19.2.1)
+      react-remove-scroll: 2.7.2(@types/react@19.2.7)(react@19.2.1)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -11916,13 +12209,6 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@shikijs/core@3.14.0':
-    dependencies:
-      '@shikijs/types': 3.14.0
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
-      hast-util-to-html: 9.0.5
-
   '@shikijs/core@4.0.2':
     dependencies:
       '@shikijs/primitive': 4.0.2
@@ -11931,20 +12217,20 @@ snapshots:
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
-  '@shikijs/engine-javascript@3.14.0':
+  '@shikijs/engine-javascript@4.0.2':
     dependencies:
-      '@shikijs/types': 3.14.0
+      '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
-      oniguruma-to-es: 4.3.3
+      oniguruma-to-es: 4.3.5
 
-  '@shikijs/engine-oniguruma@3.14.0':
+  '@shikijs/engine-oniguruma@4.0.2':
     dependencies:
-      '@shikijs/types': 3.14.0
+      '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/langs@3.14.0':
+  '@shikijs/langs@4.0.2':
     dependencies:
-      '@shikijs/types': 3.14.0
+      '@shikijs/types': 4.0.2
 
   '@shikijs/primitive@4.0.2':
     dependencies:
@@ -11952,23 +12238,14 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
-  '@shikijs/rehype@3.14.0':
+  '@shikijs/themes@4.0.2':
     dependencies:
-      '@shikijs/types': 3.14.0
-      '@types/hast': 3.0.4
-      hast-util-to-string: 3.0.1
-      shiki: 3.14.0
-      unified: 11.0.5
-      unist-util-visit: 5.0.0
+      '@shikijs/types': 4.0.2
 
-  '@shikijs/themes@3.14.0':
+  '@shikijs/transformers@4.0.2':
     dependencies:
-      '@shikijs/types': 3.14.0
-
-  '@shikijs/transformers@3.14.0':
-    dependencies:
-      '@shikijs/core': 3.14.0
-      '@shikijs/types': 3.14.0
+      '@shikijs/core': 4.0.2
+      '@shikijs/types': 4.0.2
 
   '@shikijs/twoslash@4.0.2(typescript@5.9.3)':
     dependencies:
@@ -11978,11 +12255,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
-
-  '@shikijs/types@3.14.0':
-    dependencies:
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
 
   '@shikijs/types@4.0.2':
     dependencies:
@@ -12266,14 +12538,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(msw@2.11.3(@types/node@24.10.10)(typescript@5.9.3))(vite@8.0.8(@types/node@24.10.10)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3))':
+  '@vitest/mocker@3.2.4(msw@2.11.3(@types/node@24.10.10)(typescript@5.9.3))(vite@8.0.8(@types/node@24.10.10)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       msw: 2.11.3(@types/node@24.10.10)(typescript@5.9.3)
-      vite: 8.0.8(@types/node@24.10.10)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@24.10.10)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -12311,6 +12583,10 @@ snapshots:
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
+
+  acorn-jsx@5.3.2(acorn@8.16.0):
+    dependencies:
+      acorn: 8.16.0
 
   acorn-walk@8.3.5:
     dependencies:
@@ -12475,9 +12751,9 @@ snapshots:
     dependencies:
       run-applescript: 7.1.0
 
-  bundle-require@5.1.0(esbuild@0.27.3):
+  bundle-require@5.1.0(esbuild@0.27.7):
     dependencies:
-      esbuild: 0.27.3
+      esbuild: 0.27.7
       load-tsconfig: 0.2.5
 
   bytes@3.1.2: {}
@@ -13005,67 +13281,67 @@ snapshots:
   esast-util-from-js@2.0.1:
     dependencies:
       '@types/estree-jsx': 1.0.5
-      acorn: 8.15.0
+      acorn: 8.16.0
       esast-util-from-estree: 2.0.0
-      vfile-message: 4.0.2
+      vfile-message: 4.0.3
 
-  esbuild@0.25.11:
+  esbuild@0.25.12:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.25.11
-      '@esbuild/android-arm': 0.25.11
-      '@esbuild/android-arm64': 0.25.11
-      '@esbuild/android-x64': 0.25.11
-      '@esbuild/darwin-arm64': 0.25.11
-      '@esbuild/darwin-x64': 0.25.11
-      '@esbuild/freebsd-arm64': 0.25.11
-      '@esbuild/freebsd-x64': 0.25.11
-      '@esbuild/linux-arm': 0.25.11
-      '@esbuild/linux-arm64': 0.25.11
-      '@esbuild/linux-ia32': 0.25.11
-      '@esbuild/linux-loong64': 0.25.11
-      '@esbuild/linux-mips64el': 0.25.11
-      '@esbuild/linux-ppc64': 0.25.11
-      '@esbuild/linux-riscv64': 0.25.11
-      '@esbuild/linux-s390x': 0.25.11
-      '@esbuild/linux-x64': 0.25.11
-      '@esbuild/netbsd-arm64': 0.25.11
-      '@esbuild/netbsd-x64': 0.25.11
-      '@esbuild/openbsd-arm64': 0.25.11
-      '@esbuild/openbsd-x64': 0.25.11
-      '@esbuild/openharmony-arm64': 0.25.11
-      '@esbuild/sunos-x64': 0.25.11
-      '@esbuild/win32-arm64': 0.25.11
-      '@esbuild/win32-ia32': 0.25.11
-      '@esbuild/win32-x64': 0.25.11
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
-  esbuild@0.27.3:
+  esbuild@0.27.7:
     optionalDependencies:
-      '@esbuild/aix-ppc64': 0.27.3
-      '@esbuild/android-arm': 0.27.3
-      '@esbuild/android-arm64': 0.27.3
-      '@esbuild/android-x64': 0.27.3
-      '@esbuild/darwin-arm64': 0.27.3
-      '@esbuild/darwin-x64': 0.27.3
-      '@esbuild/freebsd-arm64': 0.27.3
-      '@esbuild/freebsd-x64': 0.27.3
-      '@esbuild/linux-arm': 0.27.3
-      '@esbuild/linux-arm64': 0.27.3
-      '@esbuild/linux-ia32': 0.27.3
-      '@esbuild/linux-loong64': 0.27.3
-      '@esbuild/linux-mips64el': 0.27.3
-      '@esbuild/linux-ppc64': 0.27.3
-      '@esbuild/linux-riscv64': 0.27.3
-      '@esbuild/linux-s390x': 0.27.3
-      '@esbuild/linux-x64': 0.27.3
-      '@esbuild/netbsd-arm64': 0.27.3
-      '@esbuild/netbsd-x64': 0.27.3
-      '@esbuild/openbsd-arm64': 0.27.3
-      '@esbuild/openbsd-x64': 0.27.3
-      '@esbuild/openharmony-arm64': 0.27.3
-      '@esbuild/sunos-x64': 0.27.3
-      '@esbuild/win32-arm64': 0.27.3
-      '@esbuild/win32-ia32': 0.27.3
-      '@esbuild/win32-x64': 0.27.3
+      '@esbuild/aix-ppc64': 0.27.7
+      '@esbuild/android-arm': 0.27.7
+      '@esbuild/android-arm64': 0.27.7
+      '@esbuild/android-x64': 0.27.7
+      '@esbuild/darwin-arm64': 0.27.7
+      '@esbuild/darwin-x64': 0.27.7
+      '@esbuild/freebsd-arm64': 0.27.7
+      '@esbuild/freebsd-x64': 0.27.7
+      '@esbuild/linux-arm': 0.27.7
+      '@esbuild/linux-arm64': 0.27.7
+      '@esbuild/linux-ia32': 0.27.7
+      '@esbuild/linux-loong64': 0.27.7
+      '@esbuild/linux-mips64el': 0.27.7
+      '@esbuild/linux-ppc64': 0.27.7
+      '@esbuild/linux-riscv64': 0.27.7
+      '@esbuild/linux-s390x': 0.27.7
+      '@esbuild/linux-x64': 0.27.7
+      '@esbuild/netbsd-arm64': 0.27.7
+      '@esbuild/netbsd-x64': 0.27.7
+      '@esbuild/openbsd-arm64': 0.27.7
+      '@esbuild/openbsd-x64': 0.27.7
+      '@esbuild/openharmony-arm64': 0.27.7
+      '@esbuild/sunos-x64': 0.27.7
+      '@esbuild/win32-arm64': 0.27.7
+      '@esbuild/win32-ia32': 0.27.7
+      '@esbuild/win32-x64': 0.27.7
 
   escalade@3.2.0: {}
 
@@ -13306,6 +13582,15 @@ snapshots:
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
 
+  framer-motion@12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      motion-dom: 12.38.0
+      motion-utils: 12.36.0
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+
   framesync@6.1.2:
     dependencies:
       tslib: 2.4.0
@@ -13323,84 +13608,99 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@16.0.4(@orama/core@1.2.13)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+  fumadocs-core@16.7.16(@mdx-js/mdx@3.1.1)(@orama/core@1.2.13)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@3.25.76):
     dependencies:
-      '@formatjs/intl-localematcher': 0.6.2
-      '@orama/orama': 3.1.16
-      '@shikijs/rehype': 3.14.0
-      '@shikijs/transformers': 3.14.0
+      '@orama/orama': 3.1.18
+      '@shikijs/transformers': 4.0.2
+      estree-util-value-to-estree: 3.5.0
       github-slugger: 2.0.0
       hast-util-to-estree: 3.1.3
       hast-util-to-jsx-runtime: 2.3.6
-      image-size: 2.0.2
-      negotiator: 1.0.0
-      npm-to-yarn: 3.0.1
-      path-to-regexp: 8.4.0
+      mdast-util-mdx: 3.0.0
+      mdast-util-to-markdown: 2.1.2
       remark: 15.0.1
       remark-gfm: 4.0.1
       remark-rehype: 11.1.2
       scroll-into-view-if-needed: 3.1.0
-      shiki: 3.14.0
-      unist-util-visit: 5.0.0
+      shiki: 4.0.2
+      tinyglobby: 0.2.16
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
     optionalDependencies:
+      '@mdx-js/mdx': 3.1.1
       '@orama/core': 1.2.13
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
       '@types/react': 19.2.7
       lucide-react: 0.555.0(react@19.2.1)
       next: 16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
+      zod: 3.25.76
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-docgen@3.0.3(fumadocs-core@16.0.4(@orama/core@1.2.13)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)):
+  fumadocs-docgen@3.0.10(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/estree@1.0.8)(@types/hast@3.0.4)(@types/mdast@4.0.4)(fumadocs-core@16.7.16(@mdx-js/mdx@3.1.1)(@orama/core@1.2.13)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@3.25.76))(mdast-util-mdx@3.0.0):
     dependencies:
       estree-util-to-js: 2.0.0
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.0.4(@orama/core@1.2.13)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      fumadocs-core: 16.7.16(@mdx-js/mdx@3.1.1)(@orama/core@1.2.13)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@3.25.76)
       npm-to-yarn: 3.0.1
-      oxc-transform: 0.95.0
-      unist-util-visit: 5.0.0
+      oxc-transform: 0.124.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      unified: 11.0.5
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
       zod: 4.3.6
+    optionalDependencies:
+      '@types/estree': 1.0.8
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      mdast-util-mdx: 3.0.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
-  fumadocs-mdx@13.0.2(fumadocs-core@16.0.4(@orama/core@1.2.13)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(vite@8.0.8(@types/node@24.9.1)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3)):
+  fumadocs-mdx@13.0.8(fumadocs-core@16.7.16(@mdx-js/mdx@3.1.1)(@orama/core@1.2.13)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@3.25.76))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react@19.2.1)(vite@8.0.8(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)):
     dependencies:
       '@mdx-js/mdx': 3.1.1
       '@standard-schema/spec': 1.0.0
       chokidar: 4.0.3
-      esbuild: 0.25.11
+      esbuild: 0.25.12
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.0.4(@orama/core@1.2.13)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      fumadocs-core: 16.7.16(@mdx-js/mdx@3.1.1)(@orama/core@1.2.13)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@3.25.76)
       js-yaml: 4.1.1
-      lru-cache: 11.2.2
+      lru-cache: 11.2.5
       mdast-util-to-markdown: 2.1.2
       picocolors: 1.1.1
       picomatch: 4.0.4
       remark-mdx: 3.1.1
-      tinyexec: 1.0.1
-      tinyglobby: 0.2.15
+      tinyexec: 1.1.1
+      tinyglobby: 0.2.16
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
-      unist-util-visit: 5.0.0
+      unist-util-visit: 5.1.0
       zod: 4.3.6
     optionalDependencies:
       next: 16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react: 19.2.1
-      vite: 8.0.8(@types/node@24.9.1)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-twoslash@3.2.0(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.0.4(@orama/core@1.2.13)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(fumadocs-ui@16.0.4(@orama/core@1.2.13)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.17))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(shiki@3.14.0)(typescript@5.9.3):
+  fumadocs-twoslash@3.2.0(399142c5cb02b00195013fbef122baf5):
     dependencies:
       '@radix-ui/react-popover': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@shikijs/twoslash': 4.0.2(typescript@5.9.3)
-      fumadocs-core: 16.0.4(@orama/core@1.2.13)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      fumadocs-ui: 16.0.4(@orama/core@1.2.13)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.17)
+      fumadocs-core: 16.7.16(@mdx-js/mdx@3.1.1)(@orama/core@1.2.13)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@3.25.76)
+      fumadocs-ui: 16.7.16(@tailwindcss/oxide@4.1.16)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.7.16(@mdx-js/mdx@3.1.1)(@orama/core@1.2.13)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@3.25.76))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.17)
       mdast-util-from-markdown: 2.0.3
       mdast-util-gfm: 3.1.0
       mdast-util-to-hast: 13.2.1
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
-      shiki: 3.14.0
+      shiki: 4.0.2
       tailwind-merge: 3.5.0
       twoslash: 0.3.8(typescript@5.9.3)
     optionalDependencies:
@@ -13410,10 +13710,10 @@ snapshots:
       - supports-color
       - typescript
 
-  fumadocs-typescript@4.0.12(@types/react@19.2.7)(fumadocs-core@16.0.4(@orama/core@1.2.13)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(fumadocs-ui@16.0.4(@orama/core@1.2.13)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.17))(typescript@5.9.3):
+  fumadocs-typescript@4.0.12(@types/react@19.2.7)(fumadocs-core@16.7.16(@mdx-js/mdx@3.1.1)(@orama/core@1.2.13)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@3.25.76))(fumadocs-ui@16.7.16(@tailwindcss/oxide@4.1.16)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.7.16(@mdx-js/mdx@3.1.1)(@orama/core@1.2.13)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@3.25.76))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.17))(typescript@5.9.3):
     dependencies:
       estree-util-value-to-estree: 3.5.0
-      fumadocs-core: 16.0.4(@orama/core@1.2.13)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      fumadocs-core: 16.7.16(@mdx-js/mdx@3.1.1)(@orama/core@1.2.13)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@3.25.76)
       hast-util-to-estree: 3.1.3
       hast-util-to-jsx-runtime: 2.3.6
       remark: 15.0.1
@@ -13424,12 +13724,13 @@ snapshots:
       unist-util-visit: 5.0.0
     optionalDependencies:
       '@types/react': 19.2.7
-      fumadocs-ui: 16.0.4(@orama/core@1.2.13)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.17)
+      fumadocs-ui: 16.7.16(@tailwindcss/oxide@4.1.16)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.7.16(@mdx-js/mdx@3.1.1)(@orama/core@1.2.13)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@3.25.76))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.17)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-ui@16.0.4(@orama/core@1.2.13)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.17):
+  fumadocs-ui@16.7.16(@tailwindcss/oxide@4.1.16)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(fumadocs-core@16.7.16(@mdx-js/mdx@3.1.1)(@orama/core@1.2.13)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@3.25.76))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(tailwindcss@4.1.17):
     dependencies:
+      '@fumadocs/tailwind': 0.0.5(@tailwindcss/oxide@4.1.16)(tailwindcss@4.1.17)
       '@radix-ui/react-accordion': 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       '@radix-ui/react-dialog': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -13441,29 +13742,27 @@ snapshots:
       '@radix-ui/react-slot': 1.2.4(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-tabs': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       class-variance-authority: 0.7.1
-      fumadocs-core: 16.0.4(@orama/core@1.2.13)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      lodash.merge: 4.6.2
+      fumadocs-core: 16.7.16(@mdx-js/mdx@3.1.1)(@orama/core@1.2.13)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.7)(lucide-react@0.555.0(react@19.2.1))(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1))(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(zod@3.25.76)
+      lucide-react: 1.8.0(react@19.2.1)
+      motion: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       next-themes: 0.4.6(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      postcss-selector-parser: 7.1.0
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
-      react-medium-image-zoom: 5.4.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      react-remove-scroll: 2.7.2(@types/react@19.2.7)(react@19.2.1)
+      rehype-raw: 7.0.0
       scroll-into-view-if-needed: 3.1.0
-      tailwind-merge: 3.3.1
+      shiki: 4.0.2
+      tailwind-merge: 3.5.0
+      unist-util-visit: 5.1.0
     optionalDependencies:
+      '@types/mdx': 2.0.13
       '@types/react': 19.2.7
       next: 16.2.3(@babel/core@7.28.4)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
-      tailwindcss: 4.1.17
     transitivePeerDependencies:
-      - '@mixedbread/sdk'
-      - '@orama/core'
-      - '@tanstack/react-router'
+      - '@emotion/is-prop-valid'
+      - '@tailwindcss/oxide'
       - '@types/react-dom'
-      - algoliasearch
-      - lucide-react
-      - react-router
-      - supports-color
-      - waku
+      - tailwindcss
 
   function-bind@1.1.2: {}
 
@@ -13639,6 +13938,22 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.4
 
+  hast-util-raw@9.1.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.3.0
+      hast-util-from-parse5: 8.0.3
+      hast-util-to-parse5: 8.0.1
+      html-void-elements: 3.0.0
+      mdast-util-to-hast: 13.2.1
+      parse5: 7.3.0
+      unist-util-position: 5.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
+
   hast-util-to-estree@3.1.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -13694,9 +14009,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  hast-util-to-string@3.0.1:
+  hast-util-to-parse5@8.0.1:
     dependencies:
       '@types/hast': 3.0.4
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      property-information: 7.1.0
+      space-separated-tokens: 2.0.2
+      web-namespaces: 2.0.1
+      zwitch: 2.0.4
 
   hast-util-to-text@4.0.2:
     dependencies:
@@ -13775,8 +14096,6 @@ snapshots:
       safer-buffer: 2.1.2
 
   ignore@5.3.1: {}
-
-  image-size@2.0.2: {}
 
   immediate@3.0.6: {}
 
@@ -14222,8 +14541,6 @@ snapshots:
 
   lodash.get@4.4.2: {}
 
-  lodash.merge@4.6.2: {}
-
   lodash@4.18.1: {}
 
   log-symbols@4.1.0:
@@ -14283,6 +14600,10 @@ snapshots:
       react: 19.2.1
 
   lucide-react@0.555.0(react@19.2.1):
+    dependencies:
+      react: 19.2.1
+
+  lucide-react@1.8.0(react@19.2.1):
     dependencies:
       react: 19.2.1
 
@@ -14803,9 +15124,15 @@ snapshots:
     dependencies:
       motion-utils: 12.23.6
 
+  motion-dom@12.38.0:
+    dependencies:
+      motion-utils: 12.36.0
+
   motion-utils@11.18.1: {}
 
   motion-utils@12.23.6: {}
+
+  motion-utils@12.36.0: {}
 
   motion@11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
@@ -14818,6 +15145,14 @@ snapshots:
   motion@12.23.25(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
     dependencies:
       framer-motion: 12.23.25(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      tslib: 2.8.1
+    optionalDependencies:
+      react: 19.2.1
+      react-dom: 19.2.1(react@19.2.1)
+
+  motion@12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
+    dependencies:
+      framer-motion: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       tslib: 2.8.1
     optionalDependencies:
       react: 19.2.1
@@ -14954,7 +15289,7 @@ snapshots:
     dependencies:
       citty: 0.2.1
       pathe: 2.0.3
-      tinyexec: 1.0.2
+      tinyexec: 1.1.1
 
   object-assign@4.1.1: {}
 
@@ -14993,10 +15328,10 @@ snapshots:
 
   oniguruma-parser@0.12.1: {}
 
-  oniguruma-to-es@4.3.3:
+  oniguruma-to-es@4.3.5:
     dependencies:
       oniguruma-parser: 0.12.1
-      regex: 6.0.1
+      regex: 6.1.0
       regex-recursion: 6.0.2
 
   open@11.0.0:
@@ -15029,6 +15364,32 @@ snapshots:
       get-intrinsic: 1.3.0
       object-keys: 1.1.1
       safe-push-apply: 1.0.0
+
+  oxc-transform@0.124.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2):
+    optionalDependencies:
+      '@oxc-transform/binding-android-arm-eabi': 0.124.0
+      '@oxc-transform/binding-android-arm64': 0.124.0
+      '@oxc-transform/binding-darwin-arm64': 0.124.0
+      '@oxc-transform/binding-darwin-x64': 0.124.0
+      '@oxc-transform/binding-freebsd-x64': 0.124.0
+      '@oxc-transform/binding-linux-arm-gnueabihf': 0.124.0
+      '@oxc-transform/binding-linux-arm-musleabihf': 0.124.0
+      '@oxc-transform/binding-linux-arm64-gnu': 0.124.0
+      '@oxc-transform/binding-linux-arm64-musl': 0.124.0
+      '@oxc-transform/binding-linux-ppc64-gnu': 0.124.0
+      '@oxc-transform/binding-linux-riscv64-gnu': 0.124.0
+      '@oxc-transform/binding-linux-riscv64-musl': 0.124.0
+      '@oxc-transform/binding-linux-s390x-gnu': 0.124.0
+      '@oxc-transform/binding-linux-x64-gnu': 0.124.0
+      '@oxc-transform/binding-linux-x64-musl': 0.124.0
+      '@oxc-transform/binding-openharmony-arm64': 0.124.0
+      '@oxc-transform/binding-wasm32-wasi': 0.124.0(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+      '@oxc-transform/binding-win32-arm64-msvc': 0.124.0
+      '@oxc-transform/binding-win32-ia32-msvc': 0.124.0
+      '@oxc-transform/binding-win32-x64-msvc': 0.124.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   oxc-transform@0.95.0:
     optionalDependencies:
@@ -15350,11 +15711,6 @@ snapshots:
 
   react-is@18.3.1: {}
 
-  react-medium-image-zoom@5.4.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1):
-    dependencies:
-      react: 19.2.1
-      react-dom: 19.2.1(react@19.2.1)
-
   react-remove-scroll-bar@2.3.8(@types/react@19.2.7)(react@19.2.1):
     dependencies:
       react: 19.2.1
@@ -15364,6 +15720,17 @@ snapshots:
       '@types/react': 19.2.7
 
   react-remove-scroll@2.6.3(@types/react@19.2.7)(react@19.2.1):
+    dependencies:
+      react: 19.2.1
+      react-remove-scroll-bar: 2.3.8(@types/react@19.2.7)(react@19.2.1)
+      react-style-singleton: 2.2.3(@types/react@19.2.7)(react@19.2.1)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.2.7)(react@19.2.1)
+      use-sidecar: 1.1.3(@types/react@19.2.7)(react@19.2.1)
+    optionalDependencies:
+      '@types/react': 19.2.7
+
+  react-remove-scroll@2.7.2(@types/react@19.2.7)(react@19.2.1):
     dependencies:
       react: 19.2.1
       react-remove-scroll-bar: 2.3.8(@types/react@19.2.7)(react@19.2.1)
@@ -15463,10 +15830,10 @@ snapshots:
       estree-util-build-jsx: 3.0.1
       vfile: 6.0.3
 
-  recma-jsx@1.0.1(acorn@8.15.0):
+  recma-jsx@1.0.1(acorn@8.16.0):
     dependencies:
-      acorn: 8.15.0
-      acorn-jsx: 5.3.2(acorn@8.15.0)
+      acorn: 8.16.0
+      acorn-jsx: 5.3.2(acorn@8.16.0)
       estree-util-to-js: 2.0.0
       recma-parse: 1.0.0
       recma-stringify: 1.0.0
@@ -15508,7 +15875,7 @@ snapshots:
 
   regex-utilities@2.3.0: {}
 
-  regex@6.0.1:
+  regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
 
@@ -15529,6 +15896,12 @@ snapshots:
       hast-util-to-text: 4.0.2
       katex: 0.16.25
       unist-util-visit-parents: 6.0.1
+      vfile: 6.0.3
+
+  rehype-raw@7.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-raw: 9.1.0
       vfile: 6.0.3
 
   rehype-recma@1.0.0:
@@ -15872,14 +16245,14 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
-  shiki@3.14.0:
+  shiki@4.0.2:
     dependencies:
-      '@shikijs/core': 3.14.0
-      '@shikijs/engine-javascript': 3.14.0
-      '@shikijs/engine-oniguruma': 3.14.0
-      '@shikijs/langs': 3.14.0
-      '@shikijs/themes': 3.14.0
-      '@shikijs/types': 3.14.0
+      '@shikijs/core': 4.0.2
+      '@shikijs/engine-javascript': 4.0.2
+      '@shikijs/engine-oniguruma': 4.0.2
+      '@shikijs/langs': 4.0.2
+      '@shikijs/themes': 4.0.2
+      '@shikijs/types': 4.0.2
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
@@ -16147,13 +16520,14 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
-  tinyexec@1.0.1: {}
-
-  tinyexec@1.0.2: {}
-
   tinyexec@1.1.1: {}
 
   tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
@@ -16258,12 +16632,12 @@ snapshots:
 
   tsup@8.5.1(jiti@2.6.1)(postcss@8.5.9)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.3)
+      bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
       chokidar: 4.0.3
       consola: 3.4.2
       debug: 4.4.3
-      esbuild: 0.27.3
+      esbuild: 0.27.7
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
@@ -16517,10 +16891,15 @@ snapshots:
       '@types/unist': 3.0.3
       unist-util-stringify-position: 4.0.0
 
+  vfile-message@4.0.3:
+    dependencies:
+      '@types/unist': 3.0.3
+      unist-util-stringify-position: 4.0.0
+
   vfile@6.0.3:
     dependencies:
       '@types/unist': 3.0.3
-      vfile-message: 4.0.2
+      vfile-message: 4.0.3
 
   victory-vendor@36.9.2:
     dependencies:
@@ -16539,13 +16918,13 @@ snapshots:
       d3-time: 3.1.0
       d3-timer: 3.0.1
 
-  vite-node@3.2.4(@types/node@24.10.10)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3):
+  vite-node@3.2.4(@types/node@24.10.10)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 8.0.8(@types/node@24.10.10)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@24.10.10)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - '@vitejs/devtools'
@@ -16561,7 +16940,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@8.0.8(@types/node@24.10.10)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3):
+  vite@8.0.8(@types/node@24.10.10)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -16570,12 +16949,12 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.10.10
-      esbuild: 0.27.3
+      esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.6.1
       yaml: 2.8.3
 
-  vite@8.0.8(@types/node@24.9.1)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3):
+  vite@8.0.8(@types/node@24.9.1)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
@@ -16584,25 +16963,25 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.9.1
-      esbuild: 0.27.3
+      esbuild: 0.27.7
       fsevents: 2.3.3
       jiti: 2.6.1
       yaml: 2.8.3
     optional: true
 
-  vitest-axe@1.0.0-pre.5(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.10.10)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.11.3(@types/node@24.10.10)(typescript@5.9.3))(yaml@2.8.3)):
+  vitest-axe@1.0.0-pre.5(vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.10.10)(esbuild@0.27.7)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.11.3(@types/node@24.10.10)(typescript@5.9.3))(yaml@2.8.3)):
     dependencies:
       '@vitest/pretty-format': 3.2.4
       axe-core: 4.11.1
       chalk: 5.4.1
       lodash-es: 4.18.1
-      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@24.10.10)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.11.3(@types/node@24.10.10)(typescript@5.9.3))(yaml@2.8.3)
+      vitest: 3.2.4(@types/debug@4.1.13)(@types/node@24.10.10)(esbuild@0.27.7)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.11.3(@types/node@24.10.10)(typescript@5.9.3))(yaml@2.8.3)
 
-  vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.10.10)(esbuild@0.27.3)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.11.3(@types/node@24.10.10)(typescript@5.9.3))(yaml@2.8.3):
+  vitest@3.2.4(@types/debug@4.1.13)(@types/node@24.10.10)(esbuild@0.27.7)(jiti@2.6.1)(jsdom@26.1.0)(msw@2.11.3(@types/node@24.10.10)(typescript@5.9.3))(yaml@2.8.3):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(msw@2.11.3(@types/node@24.10.10)(typescript@5.9.3))(vite@8.0.8(@types/node@24.10.10)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/mocker': 3.2.4(msw@2.11.3(@types/node@24.10.10)(typescript@5.9.3))(vite@8.0.8(@types/node@24.10.10)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -16620,8 +16999,8 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 8.0.8(@types/node@24.10.10)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3)
-      vite-node: 3.2.4(@types/node@24.10.10)(esbuild@0.27.3)(jiti@2.6.1)(yaml@2.8.3)
+      vite: 8.0.8(@types/node@24.10.10)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@24.10.10)(esbuild@0.27.7)(jiti@2.6.1)(yaml@2.8.3)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.13

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1471,8 +1471,8 @@ importers:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -1505,8 +1505,8 @@ importers:
         specifier: ^0.7.1
         version: 0.7.1
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -1533,8 +1533,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -1561,8 +1561,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -1589,8 +1589,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -1623,8 +1623,8 @@ importers:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -1651,8 +1651,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -1679,8 +1679,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -1707,8 +1707,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -1738,8 +1738,8 @@ importers:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -1766,8 +1766,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -1794,8 +1794,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -1825,8 +1825,8 @@ importers:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -1859,8 +1859,8 @@ importers:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       popmotion:
         specifier: ^11.0.3
         version: 11.0.5
@@ -1893,8 +1893,8 @@ importers:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -1924,8 +1924,8 @@ importers:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -1955,8 +1955,8 @@ importers:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -1989,8 +1989,8 @@ importers:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2017,8 +2017,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2048,8 +2048,8 @@ importers:
         specifier: ^0.474.0
         version: 0.474.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2079,8 +2079,8 @@ importers:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2107,8 +2107,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       radix-ui:
         specifier: ^1.4.2
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -2141,8 +2141,8 @@ importers:
         specifier: workspace:*
         version: link:../smooth-button
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2175,8 +2175,8 @@ importers:
         specifier: ^0.469.0
         version: 0.469.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2203,8 +2203,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2231,8 +2231,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2259,8 +2259,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2290,8 +2290,8 @@ importers:
         specifier: ^0.468.0
         version: 0.468.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       radix-ui:
         specifier: latest
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -2324,8 +2324,8 @@ importers:
         specifier: workspace:*
         version: link:../smooth-button
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2352,8 +2352,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2380,8 +2380,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2411,8 +2411,8 @@ importers:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2442,8 +2442,8 @@ importers:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2470,8 +2470,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2498,8 +2498,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2529,8 +2529,8 @@ importers:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2560,8 +2560,8 @@ importers:
         specifier: ^0.555.0
         version: 0.555.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2588,8 +2588,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2644,8 +2644,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2675,8 +2675,8 @@ importers:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2706,8 +2706,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2740,8 +2740,8 @@ importers:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2768,8 +2768,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2805,8 +2805,8 @@ importers:
         specifier: ^0.7.1
         version: 0.7.1
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2833,8 +2833,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2895,8 +2895,8 @@ importers:
         specifier: ^0.474.0
         version: 0.474.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2926,8 +2926,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -2957,8 +2957,8 @@ importers:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -3013,8 +3013,8 @@ importers:
         specifier: workspace:*
         version: link:../smooth-button
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -3041,8 +3041,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       radix-ui:
         specifier: ^1.4.2
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
@@ -3072,8 +3072,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -3103,8 +3103,8 @@ importers:
         specifier: ^0.555.0
         version: 0.555.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -3137,8 +3137,8 @@ importers:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -3190,8 +3190,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -3218,8 +3218,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -3246,8 +3246,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -3277,8 +3277,8 @@ importers:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -3308,8 +3308,8 @@ importers:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -3417,8 +3417,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -3529,8 +3529,8 @@ importers:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.1)
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -3557,8 +3557,8 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       motion:
-        specifier: ^11.15.0
-        version: 11.18.2(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+        specifier: ^12.23.25
+        version: 12.38.0(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
       react:
         specifier: ^19.2.1
         version: 19.2.1


### PR DESCRIPTION
## Summary
fumadocs-core/ui 16.7 was pulled in after merging fumadocs-twoslash 3.2 (PR #36). Fixes 3 breaking changes + shiki version conflict.

## Changes
- `fumadocs-ui/provider` → `fumadocs-ui/contexts/search` (blog-float-nav.tsx)
- `DocsPage container={{}}` → `DocsPage className=""` (docs page)
- Remove MDX types JSX augmentation (no longer needed)
- Add `shiki >=4.0.0` pnpm override (resolve 3.x/4.x conflict)
- Add tuple type to animated-input easing array (Motion 12 type compat)

## Test plan
- [ ] CI green (Lint + Test + Build)
- [ ] Docs site renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development/build dependencies and package overrides.

* **Documentation**
  * Adjusted docs page layout class handling for more consistent styling.

* **Refactor**
  * Strengthened animation typing across UI components for more robust builds.
  * Small internal import and type cleanup to improve maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->