### PR TITLE
chore(deps): upgrade react-resizable-panels v3 to v4

### DIFF
--- a/apps/docs/components/preview/content.tsx
+++ b/apps/docs/components/preview/content.tsx
@@ -6,8 +6,10 @@ import {
   ResizablePanelGroup,
 } from "@repo/shadcn-ui/components/ui/resizable";
 import { cn } from "@repo/shadcn-ui/lib/utils";
-import type { ElementRef, ReactNode } from "react";
+import type { ReactNode } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
+// biome-ignore lint/style/useImportType: used as generic type parameter only
+import { type PanelImperativeHandle } from "react-resizable-panels";
 
 interface PreviewContentProps {
   blockPath?: string;
@@ -76,7 +78,7 @@ export const PreviewContent = ({
   blockPath,
   size = "desktop",
 }: PreviewContentProps) => {
-  const resizablePanelRef = useRef<ElementRef<typeof ResizablePanel>>(null);
+  const resizablePanelRef = useRef<PanelImperativeHandle | null>(null);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const blockIdRef = useRef<string | undefined>(blockPath);
   const [blockHeight, setBlockHeight] = useState<number>(
@@ -164,7 +166,7 @@ export const PreviewContent = ({
           "flex-1",
           type === "component" ? "size-full" : "h-auto w-full"
         )}
-        direction="horizontal"
+        orientation="horizontal"
       >
         <ResizablePanel
           className={cn(
@@ -186,7 +188,7 @@ export const PreviewContent = ({
           minSize={
             type === "block" ? BLOCK_PANEL_MIN_SIZE : COMPONENT_PANEL_MIN_SIZE
           }
-          ref={type === "block" ? resizablePanelRef : undefined}
+          panelRef={type === "block" ? resizablePanelRef : undefined}
         >
           {type === "block" && iframeSrc ? (
             <iframe

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -38,6 +38,7 @@
     "postcss-nested": "^7.0.2",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",
+    "react-resizable-panels": "^4.10.0",
     "react-use-measure": "^2.1.7",
     "rehype-katex": "^7.0.1",
     "remark": "^15.0.1",

--- a/packages/shadcn-ui/components/ui/resizable.tsx
+++ b/packages/shadcn-ui/components/ui/resizable.tsx
@@ -1,22 +1,25 @@
 "use client"
 
-import * as React from "react"
 import { GripVerticalIcon } from "lucide-react"
+import type * as React from "react"
 import * as ResizablePrimitive from "react-resizable-panels"
 
 import { cn } from "@repo/shadcn-ui/lib/utils"
 
 function ResizablePanelGroup({
   className,
+  orientation = "horizontal",
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelGroup>) {
+}: React.ComponentProps<typeof ResizablePrimitive.Group>) {
   return (
-    <ResizablePrimitive.PanelGroup
-      data-slot="resizable-panel-group"
+    <ResizablePrimitive.Group
       className={cn(
-        "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
+        "flex h-full w-full data-[orientation=vertical]:flex-col",
         className
       )}
+      data-orientation={orientation}
+      data-slot="resizable-panel-group"
+      orientation={orientation}
       {...props}
     />
   )
@@ -32,16 +35,16 @@ function ResizableHandle({
   withHandle,
   className,
   ...props
-}: React.ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+}: React.ComponentProps<typeof ResizablePrimitive.Separator> & {
   withHandle?: boolean
 }) {
   return (
-    <ResizablePrimitive.PanelResizeHandle
-      data-slot="resizable-handle"
+    <ResizablePrimitive.Separator
       className={cn(
-        "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:translate-x-0 data-[panel-group-direction=vertical]:after:-translate-y-1/2 [&[data-panel-group-direction=vertical]>div]:rotate-90",
+        "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden",
         className
       )}
+      data-slot="resizable-handle"
       {...props}
     >
       {withHandle && (
@@ -49,7 +52,7 @@ function ResizableHandle({
           <GripVerticalIcon className="size-2.5" />
         </div>
       )}
-    </ResizablePrimitive.PanelResizeHandle>
+    </ResizablePrimitive.Separator>
   )
 }
 

--- a/packages/shadcn-ui/package.json
+++ b/packages/shadcn-ui/package.json
@@ -18,7 +18,7 @@
     "react-day-picker": "9.14.0",
     "react-dom": "^19.2.0",
     "react-hook-form": "^7.65.0",
-    "react-resizable-panels": "^3.0.6",
+    "react-resizable-panels": "^4.10.0",
     "recharts": "^2.15.4",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,9 @@ importers:
       react-dom:
         specifier: ^19.2.1
         version: 19.2.5(react@19.2.5)
+      react-resizable-panels:
+        specifier: ^4.10.0
+        version: 4.10.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react-use-measure:
         specifier: ^2.1.7
         version: 2.1.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -303,8 +306,8 @@ importers:
         specifier: ^7.65.0
         version: 7.73.1(react@19.2.5)
       react-resizable-panels:
-        specifier: ^3.0.6
-        version: 3.0.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: ^4.10.0
+        version: 4.10.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       recharts:
         specifier: ^2.15.4
         version: 2.15.4(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -8846,8 +8849,8 @@ packages:
       '@types/react':
         optional: true
 
-  react-resizable-panels@3.0.6:
-    resolution: {integrity: sha512-b3qKHQ3MLqOgSS+FRYKapNkJZf5EQzuf6+RLiq1/IlTHw99YrZ2NJZLk4hQIzTnnIkRg2LUqyVinu6YWWpUYew==}
+  react-resizable-panels@4.10.0:
+    resolution: {integrity: sha512-frjewRQt7TCv/vCH1pJfjZ7RxAhr5pKuqVQtVgzFq/vherxBFOWyC3xMbryx5Ti2wylViGUFc93Etg4rB3E0UA==}
     peerDependencies:
       react: ^19.2.1
       react-dom: ^19.2.1
@@ -15431,7 +15434,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  react-resizable-panels@3.0.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  react-resizable-panels@4.10.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)


### PR DESCRIPTION
## Summary

Coordinated upgrade closing dependabot PR #60. `react-resizable-panels` v4 is an API rewrite — the library renamed its primitives and several prop names. Dependabot's straight bump failed CI for exactly this reason (`Export PanelGroup doesn't exist in target module. Did you mean to import Panel?`).

## Package bump

| Package | From | To | Type |
|---|---|---|---|
| `react-resizable-panels` | ^3.0.6 | **^4.10.0** | **major** |

`react-resizable-panels` also added as a direct dep in `apps/docs` — the consumer needs `PanelImperativeHandle` as a type import for its panel ref.

## Primitive renames (v3 -> v4)

| v3 | v4 |
|---|---|
| `ResizablePrimitive.PanelGroup` | `ResizablePrimitive.Group` |
| `ResizablePrimitive.PanelResizeHandle` | `ResizablePrimitive.Separator` |

The `Panel` primitive kept its name but its imperative ref API moved from `ref` to a dedicated `panelRef` prop.

## Prop renames (consumer-facing)

```diff
 <ResizablePanelGroup
-  direction="horizontal"
+  orientation="horizontal"
 >

 <ResizablePanel
-  ref={resizablePanelRef}
+  panelRef={resizablePanelRef}
 >
```

## Data attribute change

v3 exposed `data-panel-group-direction=...` on both `PanelGroup` and `PanelResizeHandle`, which our Tailwind selectors (`data-[panel-group-direction=vertical]:*`) relied on. v4 uses a different internal `data-orientation` scheme on the `Group` only.

The wrapper now forwards `data-orientation` itself. The vertical-orientation styles on the handle have been dropped since the only consumer in the repo (`PreviewContent`) uses `orientation="horizontal"`. Vertical styling can be re-added later if needed.

## Files changed

- `packages/shadcn-ui/package.json` — bump
- `packages/shadcn-ui/components/ui/resizable.tsx` — migrate wrapper to v4 primitives
- `apps/docs/package.json` — add `react-resizable-panels` as a direct dep for type import
- `apps/docs/components/preview/content.tsx` — `direction` -> `orientation`, `ref` -> `panelRef`, and use `PanelImperativeHandle` for the ref type
- `pnpm-lock.yaml` — regenerated

## Verification

- ✅ `pnpm build` — 2/2 tasks successful, all pages prerendered.
- ✅ `pnpm test` — 106/106 tests passing.
- ✅ Prerendered HTML (`apps/docs/.next/server/app/docs/blocks/hero.html`) contains the expected v4 primitives with correct data attributes:
  - 5x `data-slot="resizable-panel-group"`
  - 10x `data-slot="resizable-panel"`
  - 5x `data-slot="resizable-handle"`
  - `data-panel="true"` / `data-group="true"` / `data-separator="inactive"` (v4 internals)
  - 35x `data-orientation="horizontal"` (our forwarded attribute)

## Test plan
- [ ] CI: Lint, Test, Build all pass
- [ ] Vercel preview deploys cleanly
- [ ] Visit `/docs/blocks/hero` (or any block preview) and confirm the resizable handle drags correctly and the preview resizes

Closes #60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `orientation` prop to resizable panel components for improved layout flexibility.

* **Updates**
  * Upgraded resizable panels library to the latest version for enhanced stability and component behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->