### PR TITLE
feat(pages): introduce pages/ concept with 4 auth templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,7 @@ AGENT.md
 
 # internal planning docs (never committed)
 planning/
+drafts/
+
+# Node compile cache (runtime artifact)
+node-compile-cache/

--- a/apps/docs/app/(home)/docs/page.tsx
+++ b/apps/docs/app/(home)/docs/page.tsx
@@ -1,5 +1,5 @@
 import { cn } from "@repo/shadcn-ui/lib/utils";
-import { Library, Pencil } from "lucide-react";
+import { LayoutTemplate, Library, Pencil } from "lucide-react";
 import type { Metadata } from "next";
 import Link, { type LinkProps } from "next/link";
 
@@ -18,7 +18,7 @@ export default function DocsPage() {
       <p className="text-foreground/70 text-md">
         Portal to different sections of docs.
       </p>
-      <div className="mt-8 grid grid-cols-1 gap-4 text-start md:grid-cols-3">
+      <div className="mt-8 grid grid-cols-1 gap-4 text-start md:grid-cols-2 lg:grid-cols-4">
         {[
           {
             name: "Documentation",
@@ -37,6 +37,12 @@ export default function DocsPage() {
             description: "The library of SmoothUI blocks.",
             icon: <Pencil className="size-full" />,
             href: "/docs/blocks",
+          },
+          {
+            name: "Pages",
+            description: "Full-page templates — auth, dashboards, and more.",
+            icon: <LayoutTemplate className="size-full" />,
+            href: "/docs/pages",
           },
         ].map((item) => (
           <Item

--- a/apps/docs/content/docs/pages/auth.mdx
+++ b/apps/docs/content/docs/pages/auth.mdx
@@ -1,0 +1,50 @@
+---
+title: Authentication Pages
+description: Animated React authentication pages — full-page login, sign-up, OAuth, and passwordless magic link templates. Drop-in auth screens with spring animations, reduced-motion support, and accessible forms for your /login and /signup routes.
+---
+
+# Authentication Pages
+
+Full-page authentication templates for login, signup, and passwordless sign-in flows. Each page is a standalone screen designed for dedicated `/login` or `/signup` routes — no modals, no dialogs, just clean, animated auth pages inspired by modern products like Sana AI, Vercel, and Linear.
+
+All blocks include OAuth buttons, accessible form fields, spring-based entrance animations, and full `prefers-reduced-motion` support.
+
+## Centered Login
+
+A centered full-page login card with stacked OAuth buttons (Google, Apple, GitHub) and an email fallback. Ideal as a standalone `/login` route.
+
+<Preview path="login-1" type="block" className="not-prose" />
+
+### Installation
+
+<Installer packageName="login-1" />
+
+## Split-Screen Login
+
+A marketing-forward split-screen login with product preview, animated feature cards, and a testimonial on the right column. Responsive — collapses to a single column on mobile.
+
+<Preview path="login-2" type="block" className="not-prose" />
+
+### Installation
+
+<Installer packageName="login-2" />
+
+## Magic Link Sign-In
+
+A passwordless sign-in flow with a two-state email experience: input and sent confirmation. Animated crossfade between states with an accessible keyboard flow.
+
+<Preview path="magic-link" type="block" className="not-prose" />
+
+### Installation
+
+<Installer packageName="magic-link" />
+
+## Centered Sign Up
+
+A centered full-page signup card with OAuth, name/email/password fields, a live password strength hint, and terms consent. The submit button is disabled until the terms are accepted.
+
+<Preview path="signup-1" type="block" className="not-prose" />
+
+### Installation
+
+<Installer packageName="signup-1" />

--- a/apps/docs/content/docs/pages/auth.mdx
+++ b/apps/docs/content/docs/pages/auth.mdx
@@ -29,6 +29,26 @@ A marketing-forward split-screen login with product preview, animated feature ca
 
 <Installer packageName="login-2" />
 
+## Creative Login
+
+A split-screen creative login with a pastel gradient hero, iridescent SiriOrb, a compact OAuth grid, and a brand-gradient candy CTA. Designed for studios and creative SaaS.
+
+<Preview path="login-3" type="block" className="not-prose" />
+
+### Installation
+
+<Installer packageName="login-3" />
+
+## Editorial Login
+
+A split-screen editorial login with a dark-green brand column, an oversized wave-text headline, password-first form, and circular OAuth pill buttons. Inspired by modern fintech brand expression.
+
+<Preview path="login-4" type="block" className="not-prose" />
+
+### Installation
+
+<Installer packageName="login-4" />
+
 ## Magic Link Sign-In
 
 A passwordless sign-in flow with a two-state email experience: input and sent confirmation. Animated crossfade between states with an accessible keyboard flow.

--- a/apps/docs/content/docs/pages/meta.json
+++ b/apps/docs/content/docs/pages/meta.json
@@ -1,0 +1,7 @@
+{
+  "title": "Pages",
+  "description": "Full-page templates ready to drop into your app — authentication, dashboards, and more",
+  "icon": "LayoutTemplate",
+  "root": true,
+  "pages": ["---Authentication---", "auth"]
+}

--- a/apps/docs/examples/login-1.tsx
+++ b/apps/docs/examples/login-1.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import Login1 from "@repo/smoothui/pages/auth/login-1";
+
+const Example = () => (
+  <div className="h-full w-full">
+    <Login1 />
+  </div>
+);
+
+export default Example;

--- a/apps/docs/examples/login-2.tsx
+++ b/apps/docs/examples/login-2.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import Login2 from "@repo/smoothui/pages/auth/login-2";
+
+const Example = () => (
+  <div className="h-full w-full">
+    <Login2 />
+  </div>
+);
+
+export default Example;

--- a/apps/docs/examples/login-3.tsx
+++ b/apps/docs/examples/login-3.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import Login3 from "@repo/smoothui/pages/auth/login-3";
+
+const Example = () => (
+  <div className="h-full w-full">
+    <Login3 />
+  </div>
+);
+
+export default Example;

--- a/apps/docs/examples/login-4.tsx
+++ b/apps/docs/examples/login-4.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import Login4 from "@repo/smoothui/pages/auth/login-4";
+
+const Example = () => (
+  <div className="h-full w-full">
+    <Login4 />
+  </div>
+);
+
+export default Example;

--- a/apps/docs/examples/magic-link.tsx
+++ b/apps/docs/examples/magic-link.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import MagicLink from "@repo/smoothui/pages/auth/magic-link";
+
+const Example = () => (
+  <div className="h-full w-full">
+    <MagicLink />
+  </div>
+);
+
+export default Example;

--- a/apps/docs/examples/signup-1.tsx
+++ b/apps/docs/examples/signup-1.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import Signup1 from "@repo/smoothui/pages/auth/signup-1";
+
+const Example = () => (
+  <div className="h-full w-full">
+    <Signup1 />
+  </div>
+);
+
+export default Example;

--- a/packages/smoothui/blocks/index.ts
+++ b/packages/smoothui/blocks/index.ts
@@ -1,4 +1,6 @@
-// Export all UI blocks from their category packages
+// Export all UI blocks from their category packages.
+// Full-page auth/login/signup templates live in ../pages/ instead (not composable sections).
+
 export { default as Faq1 } from "./faqs/faq-1";
 export { default as Faq2 } from "./faqs/faq-2";
 export { default as Footer1 } from "./footers/footer-1";

--- a/packages/smoothui/pages/auth/index.ts
+++ b/packages/smoothui/pages/auth/index.ts
@@ -1,0 +1,4 @@
+export { default as Login1 } from "./login-1";
+export { default as Login2 } from "./login-2";
+export { default as MagicLink } from "./magic-link";
+export { default as Signup1 } from "./signup-1";

--- a/packages/smoothui/pages/auth/index.ts
+++ b/packages/smoothui/pages/auth/index.ts
@@ -1,4 +1,6 @@
 export { default as Login1 } from "./login-1";
 export { default as Login2 } from "./login-2";
+export { default as Login3 } from "./login-3";
+export { default as Login4 } from "./login-4";
 export { default as MagicLink } from "./magic-link";
 export { default as Signup1 } from "./signup-1";

--- a/packages/smoothui/pages/auth/login-1/index.tsx
+++ b/packages/smoothui/pages/auth/login-1/index.tsx
@@ -1,0 +1,170 @@
+"use client";
+
+import { Button } from "@repo/shadcn-ui/components/ui/button";
+import { Input } from "@repo/shadcn-ui/components/ui/input";
+import { Label } from "@repo/shadcn-ui/components/ui/label";
+import { Apple, Github, Globe, Hexagon } from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
+
+const SPRING = {
+  type: "spring" as const,
+  duration: 0.25,
+  bounce: 0.1,
+};
+
+const OAUTH_PROVIDERS = [
+  { name: "Google", Icon: Globe, label: "Continue with Google" },
+  { name: "Apple", Icon: Apple, label: "Continue with Apple" },
+  { name: "GitHub", Icon: Github, label: "Continue with GitHub" },
+] as const;
+
+export function Login1() {
+  const shouldReduceMotion = useReducedMotion();
+
+  const containerInitial = shouldReduceMotion
+    ? { opacity: 1 }
+    : { opacity: 0, y: 24 };
+  const containerAnimate = shouldReduceMotion
+    ? { opacity: 1 }
+    : { opacity: 1, y: 0 };
+  const containerTransition = shouldReduceMotion
+    ? { duration: 0 }
+    : { ...SPRING, staggerChildren: 0.05 };
+
+  const itemInitial = shouldReduceMotion
+    ? { opacity: 1 }
+    : { opacity: 0, y: 8 };
+  const itemAnimate = shouldReduceMotion
+    ? { opacity: 1 }
+    : { opacity: 1, y: 0 };
+  const itemTransition = shouldReduceMotion ? { duration: 0 } : SPRING;
+
+  return (
+    <section
+      aria-labelledby="login-1-heading"
+      className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-6 py-16"
+    >
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,var(--color-primary)/0.08,transparent_70%)]"
+      />
+      <motion.div
+        animate={containerAnimate}
+        className="relative w-full max-w-sm"
+        initial={containerInitial}
+        transition={containerTransition}
+      >
+        <div className="rounded-xl border border-border/60 bg-card/70 p-8 shadow-sm backdrop-blur">
+          <motion.div
+            animate={itemAnimate}
+            className="flex flex-col items-center text-center"
+            initial={itemInitial}
+            transition={itemTransition}
+          >
+            <span className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+              <Hexagon className="size-5" />
+            </span>
+            <h1
+              className="mt-5 font-semibold text-2xl tracking-tight"
+              id="login-1-heading"
+            >
+              Welcome back
+            </h1>
+            <p className="mt-2 text-foreground/60 text-sm">
+              Sign in to continue to SmoothUI
+            </p>
+          </motion.div>
+
+          <motion.div
+            animate={itemAnimate}
+            className="mt-8 flex flex-col gap-2"
+            initial={itemInitial}
+            transition={itemTransition}
+          >
+            {OAUTH_PROVIDERS.map(({ name, Icon, label }) => (
+              <Button
+                className="w-full justify-center gap-2"
+                key={name}
+                type="button"
+                variant="outline"
+              >
+                <Icon className="size-4" />
+                {label}
+              </Button>
+            ))}
+          </motion.div>
+
+          <motion.div
+            animate={itemAnimate}
+            className="my-6 flex items-center gap-3"
+            initial={itemInitial}
+            transition={itemTransition}
+          >
+            <span className="h-px flex-1 bg-border" />
+            <span className="text-foreground/50 text-xs uppercase tracking-wider">
+              or
+            </span>
+            <span className="h-px flex-1 bg-border" />
+          </motion.div>
+
+          <motion.form
+            animate={itemAnimate}
+            className="flex flex-col gap-4"
+            initial={itemInitial}
+            onSubmit={(event) => event.preventDefault()}
+            transition={itemTransition}
+          >
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="login-1-email">Email</Label>
+              <Input
+                autoComplete="email"
+                id="login-1-email"
+                name="email"
+                placeholder="you@example.com"
+                required
+                type="email"
+              />
+            </div>
+            <Button className="w-full" type="submit">
+              Continue with email
+            </Button>
+          </motion.form>
+
+          <motion.p
+            animate={itemAnimate}
+            className="mt-6 text-center text-foreground/60 text-sm"
+            initial={itemInitial}
+            transition={itemTransition}
+          >
+            Don&apos;t have an account?{" "}
+            <a
+              className="font-medium text-foreground underline underline-offset-4 hover:text-primary"
+              href="#signup"
+            >
+              Sign up
+            </a>
+          </motion.p>
+        </div>
+
+        <motion.p
+          animate={itemAnimate}
+          className="mt-6 text-balance text-center text-foreground/50 text-xs"
+          initial={itemInitial}
+          transition={itemTransition}
+        >
+          By continuing you agree to our{" "}
+          <a className="underline underline-offset-4" href="#terms">
+            Terms
+          </a>{" "}
+          and{" "}
+          <a className="underline underline-offset-4" href="#privacy">
+            Privacy Policy
+          </a>
+          .
+        </motion.p>
+      </motion.div>
+    </section>
+  );
+}
+
+export default Login1;

--- a/packages/smoothui/pages/auth/login-1/index.tsx
+++ b/packages/smoothui/pages/auth/login-1/index.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { Button } from "@repo/shadcn-ui/components/ui/button";
 import { Input } from "@repo/shadcn-ui/components/ui/input";
 import { Label } from "@repo/shadcn-ui/components/ui/label";
+import ScrambleHover from "@repo/smoothui/components/scramble-hover";
+import SiriOrb from "@repo/smoothui/components/siri-orb";
+import SmoothButton from "@repo/smoothui/components/smooth-button";
 import { Apple, Github, Globe, Hexagon } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 
@@ -44,34 +46,53 @@ export function Login1() {
       aria-labelledby="login-1-heading"
       className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-6 py-16"
     >
+      {/* Ambient orb hero — sits behind the card for atmospheric glow */}
       <div
         aria-hidden="true"
-        className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,var(--color-primary)/0.08,transparent_70%)]"
+        className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-60 blur-2xl dark:opacity-40"
+      >
+        <SiriOrb animationDuration={30} size="640px" />
+      </div>
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-gradient-to-b from-transparent via-background/30 to-background"
       />
+
       <motion.div
         animate={containerAnimate}
         className="relative w-full max-w-sm"
         initial={containerInitial}
         transition={containerTransition}
       >
-        <div className="rounded-xl border border-border/60 bg-card/70 p-8 shadow-sm backdrop-blur">
+        {/* Wordmark */}
+        <motion.div
+          animate={itemAnimate}
+          className="mb-6 flex items-center justify-center gap-2"
+          initial={itemInitial}
+          transition={itemTransition}
+        >
+          <span className="flex size-7 items-center justify-center rounded-md bg-gradient-to-br from-brand to-brand-secondary text-white shadow-sm">
+            <Hexagon className="size-4" />
+          </span>
+          <span className="font-semibold text-sm tracking-tight">SmoothUI</span>
+        </motion.div>
+
+        <div className="rounded-2xl border border-border/60 bg-background/80 p-8 shadow-black/5 shadow-xl backdrop-blur-xl">
           <motion.div
             animate={itemAnimate}
             className="flex flex-col items-center text-center"
             initial={itemInitial}
             transition={itemTransition}
           >
-            <span className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
-              <Hexagon className="size-5" />
-            </span>
             <h1
-              className="mt-5 font-semibold text-2xl tracking-tight"
+              className="font-semibold text-2xl tracking-tight"
               id="login-1-heading"
             >
-              Welcome back
+              Welcome back to{" "}
+              <ScrambleHover className="font-semibold">SmoothUI</ScrambleHover>
             </h1>
             <p className="mt-2 text-foreground/60 text-sm">
-              Sign in to continue to SmoothUI
+              Sign in to continue building beautiful interfaces
             </p>
           </motion.div>
 
@@ -82,7 +103,7 @@ export function Login1() {
             transition={itemTransition}
           >
             {OAUTH_PROVIDERS.map(({ name, Icon, label }) => (
-              <Button
+              <SmoothButton
                 className="w-full justify-center gap-2"
                 key={name}
                 type="button"
@@ -90,7 +111,7 @@ export function Login1() {
               >
                 <Icon className="size-4" />
                 {label}
-              </Button>
+              </SmoothButton>
             ))}
           </motion.div>
 
@@ -125,9 +146,14 @@ export function Login1() {
                 type="email"
               />
             </div>
-            <Button className="w-full" type="submit">
+            <SmoothButton
+              className="w-full"
+              size="lg"
+              type="submit"
+              variant="candy"
+            >
               Continue with email
-            </Button>
+            </SmoothButton>
           </motion.form>
 
           <motion.p

--- a/packages/smoothui/pages/auth/login-1/package.json
+++ b/packages/smoothui/pages/auth/login-1/package.json
@@ -6,6 +6,8 @@
   "dependencies": {
     "@repo/shadcn-ui": "workspace:*",
     "@repo/smooth-button": "workspace:*",
+    "@repo/siri-orb": "workspace:*",
+    "@repo/scramble-hover": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "motion": "^11.15.0",
@@ -27,14 +29,17 @@
       "auth",
       "centered",
       "full-page",
-      "email"
+      "email",
+      "ambient-orb",
+      "frosted-glass",
+      "candy-cta"
     ],
     "complexity": "moderate",
     "animationType": "spring",
     "useCases": [
       "Standalone /login route page for web apps",
-      "Centered login screen with OAuth providers",
-      "Email-based sign-in with social fallback"
+      "Centered login screen with ambient orb hero and frosted-glass card",
+      "Email-based sign-in with OAuth fallback and branded candy CTA"
     ],
     "compositionHints": [
       "Use as standalone /login route page",

--- a/packages/smoothui/pages/auth/login-1/package.json
+++ b/packages/smoothui/pages/auth/login-1/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@repo/login-1",
+  "description": "Centered full-page login with stacked OAuth buttons and email fallback",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@repo/shadcn-ui": "workspace:*",
+    "@repo/smooth-button": "workspace:*",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "motion": "^11.15.0",
+    "lucide-react": "^0.545.0"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.1",
+    "typescript": "^5.9.3"
+  },
+  "smoothui": {
+    "category": "authentication",
+    "tags": [
+      "authentication",
+      "login",
+      "sign-in",
+      "oauth",
+      "auth",
+      "centered",
+      "full-page",
+      "email"
+    ],
+    "complexity": "moderate",
+    "animationType": "spring",
+    "useCases": [
+      "Standalone /login route page for web apps",
+      "Centered login screen with OAuth providers",
+      "Email-based sign-in with social fallback"
+    ],
+    "compositionHints": [
+      "Use as standalone /login route page",
+      "Pair with signup-1 for a matching registration flow"
+    ],
+    "hasReducedMotion": true
+  }
+}

--- a/packages/smoothui/pages/auth/login-2/index.tsx
+++ b/packages/smoothui/pages/auth/login-2/index.tsx
@@ -1,15 +1,17 @@
 "use client";
 
-import { Button } from "@repo/shadcn-ui/components/ui/button";
 import { Input } from "@repo/shadcn-ui/components/ui/input";
 import { Label } from "@repo/shadcn-ui/components/ui/label";
+import GlowHover from "@repo/smoothui/components/glow-hover-card";
+import SmoothButton from "@repo/smoothui/components/smooth-button";
+import TypewriterText from "@repo/smoothui/components/typewriter-text";
 import {
   Apple,
   Github,
   Globe,
   Hexagon,
+  Rocket,
   Sparkles,
-  Waypoints,
   Zap,
 } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
@@ -26,23 +28,53 @@ const OAUTH_PROVIDERS = [
   { name: "GitHub", Icon: Github, label: "Continue with GitHub" },
 ] as const;
 
-const FEATURE_CARDS = [
+const SHOWCASE_GLOW_ITEMS = [
   {
-    Icon: Sparkles,
-    title: "Smooth animations",
-    description: "Spring-based motion tuned for every interaction.",
+    id: "glow-spring",
+    theme: { hue: 280, saturation: 70, lightness: 60 },
+    element: (
+      <div className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 p-4 text-white">
+        <span className="flex size-9 items-center justify-center rounded-md bg-white/10">
+          <Sparkles className="size-4" />
+        </span>
+        <div className="text-left">
+          <p className="font-medium text-sm">Spring-tuned motion</p>
+          <p className="text-white/60 text-xs">Feels right on every tap.</p>
+        </div>
+      </div>
+    ),
   },
   {
-    Icon: Waypoints,
-    title: "Composable blocks",
-    description: "Drop-in sections for marketing and product pages.",
+    id: "glow-ship",
+    theme: { hue: 200, saturation: 70, lightness: 60 },
+    element: (
+      <div className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 p-4 text-white">
+        <span className="flex size-9 items-center justify-center rounded-md bg-white/10">
+          <Rocket className="size-4" />
+        </span>
+        <div className="text-left">
+          <p className="font-medium text-sm">Ship in hours</p>
+          <p className="text-white/60 text-xs">Copy, paste, customize.</p>
+        </div>
+      </div>
+    ),
   },
   {
-    Icon: Zap,
-    title: "Ship in minutes",
-    description: "Copy, paste, customize. No design debt.",
+    id: "glow-a11y",
+    theme: { hue: 340, saturation: 70, lightness: 60 },
+    element: (
+      <div className="flex items-center gap-3 rounded-lg border border-white/10 bg-white/5 p-4 text-white">
+        <span className="flex size-9 items-center justify-center rounded-md bg-white/10">
+          <Zap className="size-4" />
+        </span>
+        <div className="text-left">
+          <p className="font-medium text-sm">Accessible by default</p>
+          <p className="text-white/60 text-xs">Reduced-motion respected.</p>
+        </div>
+      </div>
+    ),
   },
-] as const;
+];
 
 export function Login2() {
   const shouldReduceMotion = useReducedMotion();
@@ -73,7 +105,7 @@ export function Login2() {
               initial={initial}
               transition={item}
             >
-              <span className="flex size-8 items-center justify-center rounded-md bg-primary/10 text-primary">
+              <span className="flex size-8 items-center justify-center rounded-md bg-gradient-to-br from-brand to-brand-secondary text-white">
                 <Hexagon className="size-4" />
               </span>
               <span className="font-semibold text-sm tracking-tight">
@@ -88,13 +120,13 @@ export function Login2() {
               transition={item}
             >
               <h1
-                className="font-semibold text-2xl tracking-tight"
+                className="text-balance font-semibold text-4xl leading-[1.05] tracking-tight md:text-5xl"
                 id="login-2-heading"
               >
-                Sign in to your account
+                Welcome back.
               </h1>
-              <p className="mt-2 text-foreground/60 text-sm">
-                Welcome back. Enter your details to continue.
+              <p className="mt-3 text-foreground/60 text-sm">
+                The animated React toolkit teams love.
               </p>
             </motion.div>
 
@@ -105,7 +137,7 @@ export function Login2() {
               transition={item}
             >
               {OAUTH_PROVIDERS.map(({ name, Icon, label }) => (
-                <Button
+                <SmoothButton
                   className="w-full justify-center gap-2"
                   key={name}
                   type="button"
@@ -113,7 +145,7 @@ export function Login2() {
                 >
                   <Icon className="size-4" />
                   {label}
-                </Button>
+                </SmoothButton>
               ))}
             </motion.div>
 
@@ -167,9 +199,14 @@ export function Login2() {
                   type="password"
                 />
               </div>
-              <Button className="w-full" type="submit">
-                Sign in
-              </Button>
+              <SmoothButton
+                className="w-full"
+                size="lg"
+                type="submit"
+                variant="candy"
+              >
+                Continue with email
+              </SmoothButton>
             </motion.form>
 
             <motion.p
@@ -189,12 +226,15 @@ export function Login2() {
           </motion.div>
         </div>
 
-        <aside
-          aria-hidden="true"
-          className="relative hidden overflow-hidden bg-zinc-950 text-zinc-100 lg:block"
-        >
-          <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,rgba(99,102,241,0.25),transparent_60%)]" />
-          <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_bottom_left,rgba(236,72,153,0.18),transparent_55%)]" />
+        <aside className="relative hidden overflow-hidden bg-zinc-950 text-zinc-100 lg:block">
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,rgba(99,102,241,0.25),transparent_60%)]"
+          />
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 bg-[radial-gradient(ellipse_at_bottom_left,rgba(236,72,153,0.18),transparent_55%)]"
+          />
 
           <motion.div
             animate={animate}
@@ -210,34 +250,43 @@ export function Login2() {
             >
               <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-white/80 text-xs">
                 <Sparkles className="size-3" />
-                What&apos;s inside
+                Made with SmoothUI
               </span>
               <h2 className="mt-6 text-balance font-semibold text-3xl tracking-tight">
-                Build beautiful interfaces without the animation tax.
+                Ship animated UIs in hours, not weeks.
               </h2>
             </motion.div>
 
-            <div className="my-10 grid gap-3">
-              {FEATURE_CARDS.map(({ Icon, title, description }) => (
-                <motion.div
-                  animate={animate}
-                  className="rounded-xl border border-white/10 bg-white/5 p-4 backdrop-blur"
-                  initial={initial}
-                  key={title}
-                  transition={item}
-                >
-                  <div className="flex items-center gap-3">
-                    <span className="flex size-8 items-center justify-center rounded-md bg-white/10 text-white">
-                      <Icon className="size-4" />
-                    </span>
-                    <div>
-                      <p className="font-medium text-sm">{title}</p>
-                      <p className="text-white/60 text-xs">{description}</p>
-                    </div>
-                  </div>
-                </motion.div>
-              ))}
-            </div>
+            {/* Panel 1 — Glow-hover cards (cursor-tracked glow demo) */}
+            <motion.div
+              animate={animate}
+              className="my-10 space-y-6"
+              initial={initial}
+              transition={item}
+            >
+              <GlowHover
+                className="flex flex-col gap-2"
+                glowIntensity={0.25}
+                items={SHOWCASE_GLOW_ITEMS}
+                maskSize={320}
+              />
+
+              {/* Panel 2 — Typewriter tagline */}
+              <div className="rounded-xl border border-white/10 bg-white/5 p-5 backdrop-blur">
+                <p className="text-white/50 text-xs uppercase tracking-wider">
+                  Live preview
+                </p>
+                <p className="mt-2 font-medium text-base text-white">
+                  <TypewriterText loop speed={55}>
+                    Ship animated UIs in hours, not weeks.
+                  </TypewriterText>
+                  <span
+                    aria-hidden="true"
+                    className="ml-0.5 inline-block h-4 w-[2px] translate-y-0.5 animate-pulse bg-white/80"
+                  />
+                </p>
+              </div>
+            </motion.div>
 
             <motion.figure
               animate={animate}
@@ -246,8 +295,8 @@ export function Login2() {
               transition={item}
             >
               <blockquote className="text-pretty text-sm text-white/90 leading-relaxed">
-                &ldquo;SmoothUI shipped our auth UX in a weekend. It just felt
-                right from the first keystroke.&rdquo;
+                &ldquo;SmoothUI shipped our auth UX in a weekend, animations
+                included. It just felt right from the first keystroke.&rdquo;
               </blockquote>
               <figcaption className="mt-3 text-white/60 text-xs">
                 Alex Rivera, Staff Engineer at Meridian

--- a/packages/smoothui/pages/auth/login-2/index.tsx
+++ b/packages/smoothui/pages/auth/login-2/index.tsx
@@ -1,0 +1,263 @@
+"use client";
+
+import { Button } from "@repo/shadcn-ui/components/ui/button";
+import { Input } from "@repo/shadcn-ui/components/ui/input";
+import { Label } from "@repo/shadcn-ui/components/ui/label";
+import {
+  Apple,
+  Github,
+  Globe,
+  Hexagon,
+  Sparkles,
+  Waypoints,
+  Zap,
+} from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
+
+const SPRING = {
+  type: "spring" as const,
+  duration: 0.25,
+  bounce: 0.1,
+};
+
+const OAUTH_PROVIDERS = [
+  { name: "Google", Icon: Globe, label: "Continue with Google" },
+  { name: "Apple", Icon: Apple, label: "Continue with Apple" },
+  { name: "GitHub", Icon: Github, label: "Continue with GitHub" },
+] as const;
+
+const FEATURE_CARDS = [
+  {
+    Icon: Sparkles,
+    title: "Smooth animations",
+    description: "Spring-based motion tuned for every interaction.",
+  },
+  {
+    Icon: Waypoints,
+    title: "Composable blocks",
+    description: "Drop-in sections for marketing and product pages.",
+  },
+  {
+    Icon: Zap,
+    title: "Ship in minutes",
+    description: "Copy, paste, customize. No design debt.",
+  },
+] as const;
+
+export function Login2() {
+  const shouldReduceMotion = useReducedMotion();
+
+  const initial = shouldReduceMotion ? { opacity: 1 } : { opacity: 0, y: 16 };
+  const animate = shouldReduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 };
+  const stagger = shouldReduceMotion
+    ? { duration: 0 }
+    : { ...SPRING, staggerChildren: 0.06 };
+  const item = shouldReduceMotion ? { duration: 0 } : SPRING;
+
+  return (
+    <section
+      aria-labelledby="login-2-heading"
+      className="min-h-screen bg-background"
+    >
+      <div className="grid min-h-screen lg:grid-cols-2">
+        <div className="flex items-center justify-center px-6 py-16">
+          <motion.div
+            animate={animate}
+            className="w-full max-w-sm"
+            initial={initial}
+            transition={stagger}
+          >
+            <motion.div
+              animate={animate}
+              className="flex items-center gap-2"
+              initial={initial}
+              transition={item}
+            >
+              <span className="flex size-8 items-center justify-center rounded-md bg-primary/10 text-primary">
+                <Hexagon className="size-4" />
+              </span>
+              <span className="font-semibold text-sm tracking-tight">
+                SmoothUI
+              </span>
+            </motion.div>
+
+            <motion.div
+              animate={animate}
+              className="mt-10"
+              initial={initial}
+              transition={item}
+            >
+              <h1
+                className="font-semibold text-2xl tracking-tight"
+                id="login-2-heading"
+              >
+                Sign in to your account
+              </h1>
+              <p className="mt-2 text-foreground/60 text-sm">
+                Welcome back. Enter your details to continue.
+              </p>
+            </motion.div>
+
+            <motion.div
+              animate={animate}
+              className="mt-8 flex flex-col gap-2"
+              initial={initial}
+              transition={item}
+            >
+              {OAUTH_PROVIDERS.map(({ name, Icon, label }) => (
+                <Button
+                  className="w-full justify-center gap-2"
+                  key={name}
+                  type="button"
+                  variant="outline"
+                >
+                  <Icon className="size-4" />
+                  {label}
+                </Button>
+              ))}
+            </motion.div>
+
+            <motion.div
+              animate={animate}
+              className="my-6 flex items-center gap-3"
+              initial={initial}
+              transition={item}
+            >
+              <span className="h-px flex-1 bg-border" />
+              <span className="text-foreground/50 text-xs uppercase tracking-wider">
+                or
+              </span>
+              <span className="h-px flex-1 bg-border" />
+            </motion.div>
+
+            <motion.form
+              animate={animate}
+              className="flex flex-col gap-4"
+              initial={initial}
+              onSubmit={(event) => event.preventDefault()}
+              transition={item}
+            >
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="login-2-email">Email</Label>
+                <Input
+                  autoComplete="email"
+                  id="login-2-email"
+                  name="email"
+                  placeholder="you@example.com"
+                  required
+                  type="email"
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="login-2-password">Password</Label>
+                  <a
+                    className="text-foreground/60 text-xs underline-offset-4 hover:text-foreground hover:underline"
+                    href="#forgot"
+                  >
+                    Forgot password?
+                  </a>
+                </div>
+                <Input
+                  autoComplete="current-password"
+                  id="login-2-password"
+                  name="password"
+                  placeholder="Enter your password"
+                  required
+                  type="password"
+                />
+              </div>
+              <Button className="w-full" type="submit">
+                Sign in
+              </Button>
+            </motion.form>
+
+            <motion.p
+              animate={animate}
+              className="mt-6 text-center text-foreground/60 text-sm"
+              initial={initial}
+              transition={item}
+            >
+              New to SmoothUI?{" "}
+              <a
+                className="font-medium text-foreground underline underline-offset-4 hover:text-primary"
+                href="#signup"
+              >
+                Create an account
+              </a>
+            </motion.p>
+          </motion.div>
+        </div>
+
+        <aside
+          aria-hidden="true"
+          className="relative hidden overflow-hidden bg-zinc-950 text-zinc-100 lg:block"
+        >
+          <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_right,rgba(99,102,241,0.25),transparent_60%)]" />
+          <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_bottom_left,rgba(236,72,153,0.18),transparent_55%)]" />
+
+          <motion.div
+            animate={animate}
+            className="relative flex h-full flex-col justify-between p-12"
+            initial={initial}
+            transition={stagger}
+          >
+            <motion.div
+              animate={animate}
+              className="max-w-md"
+              initial={initial}
+              transition={item}
+            >
+              <span className="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-3 py-1 text-white/80 text-xs">
+                <Sparkles className="size-3" />
+                What&apos;s inside
+              </span>
+              <h2 className="mt-6 text-balance font-semibold text-3xl tracking-tight">
+                Build beautiful interfaces without the animation tax.
+              </h2>
+            </motion.div>
+
+            <div className="my-10 grid gap-3">
+              {FEATURE_CARDS.map(({ Icon, title, description }) => (
+                <motion.div
+                  animate={animate}
+                  className="rounded-xl border border-white/10 bg-white/5 p-4 backdrop-blur"
+                  initial={initial}
+                  key={title}
+                  transition={item}
+                >
+                  <div className="flex items-center gap-3">
+                    <span className="flex size-8 items-center justify-center rounded-md bg-white/10 text-white">
+                      <Icon className="size-4" />
+                    </span>
+                    <div>
+                      <p className="font-medium text-sm">{title}</p>
+                      <p className="text-white/60 text-xs">{description}</p>
+                    </div>
+                  </div>
+                </motion.div>
+              ))}
+            </div>
+
+            <motion.figure
+              animate={animate}
+              className="rounded-xl border border-white/10 bg-white/5 p-5 backdrop-blur"
+              initial={initial}
+              transition={item}
+            >
+              <blockquote className="text-pretty text-sm text-white/90 leading-relaxed">
+                &ldquo;SmoothUI shipped our auth UX in a weekend. It just felt
+                right from the first keystroke.&rdquo;
+              </blockquote>
+              <figcaption className="mt-3 text-white/60 text-xs">
+                Alex Rivera, Staff Engineer at Meridian
+              </figcaption>
+            </motion.figure>
+          </motion.div>
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+export default Login2;

--- a/packages/smoothui/pages/auth/login-2/package.json
+++ b/packages/smoothui/pages/auth/login-2/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@repo/login-2",
+  "description": "Split-screen full-page login with product preview and animated feature cards",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@repo/shadcn-ui": "workspace:*",
+    "@repo/smooth-button": "workspace:*",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "motion": "^11.15.0",
+    "lucide-react": "^0.545.0"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.1",
+    "typescript": "^5.9.3"
+  },
+  "smoothui": {
+    "category": "authentication",
+    "tags": [
+      "authentication",
+      "login",
+      "sign-in",
+      "oauth",
+      "auth",
+      "split-screen",
+      "full-page",
+      "testimonial"
+    ],
+    "complexity": "moderate",
+    "animationType": "spring",
+    "useCases": [
+      "Marketing-forward login page with product preview",
+      "Split-screen auth for SaaS products",
+      "Dedicated /login route with brand reinforcement"
+    ],
+    "compositionHints": [
+      "Use as standalone /login route page",
+      "Right column hides below lg breakpoint for mobile-first experience"
+    ],
+    "hasReducedMotion": true
+  }
+}

--- a/packages/smoothui/pages/auth/login-3/index.tsx
+++ b/packages/smoothui/pages/auth/login-3/index.tsx
@@ -1,0 +1,249 @@
+"use client";
+
+import { Canva, Descript, Duolingo, Faire, Ramp } from "@repo/blocks-shared";
+import { Input } from "@repo/shadcn-ui/components/ui/input";
+import { Label } from "@repo/shadcn-ui/components/ui/label";
+import SiriOrb from "@repo/smoothui/components/siri-orb";
+import SmoothButton from "@repo/smoothui/components/smooth-button";
+import { Apple, Github, Globe, Hexagon } from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
+
+const SPRING = {
+  type: "spring" as const,
+  duration: 0.25,
+  bounce: 0.1,
+};
+
+const OAUTH_PROVIDERS = [
+  { name: "Google", Icon: Globe, label: "Google" },
+  { name: "Apple", Icon: Apple, label: "Apple" },
+  { name: "GitHub", Icon: Github, label: "GitHub" },
+] as const;
+
+const CREATIVE_LOGOS = [
+  { name: "Canva", Logo: Canva },
+  { name: "Duolingo", Logo: Duolingo },
+  { name: "Ramp", Logo: Ramp },
+  { name: "Faire", Logo: Faire },
+  { name: "Descript", Logo: Descript },
+] as const;
+
+export function Login3() {
+  const shouldReduceMotion = useReducedMotion();
+
+  const initial = shouldReduceMotion ? { opacity: 1 } : { opacity: 0, y: 16 };
+  const animate = shouldReduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 };
+  const stagger = shouldReduceMotion
+    ? { duration: 0 }
+    : { ...SPRING, staggerChildren: 0.06 };
+  const item = shouldReduceMotion ? { duration: 0 } : SPRING;
+
+  return (
+    <section
+      aria-labelledby="login-3-heading"
+      className="min-h-screen bg-background"
+    >
+      <div className="grid min-h-screen lg:grid-cols-2">
+        {/* Form column — compact, card-less */}
+        <div className="flex items-center justify-center px-6 py-16 lg:px-12">
+          <motion.div
+            animate={animate}
+            className="w-full max-w-sm"
+            initial={initial}
+            transition={stagger}
+          >
+            <motion.div
+              animate={animate}
+              className="flex items-center gap-2"
+              initial={initial}
+              transition={item}
+            >
+              <span className="flex size-8 items-center justify-center rounded-md bg-gradient-to-br from-brand to-brand-secondary text-white">
+                <Hexagon className="size-4" />
+              </span>
+              <span className="font-semibold text-sm tracking-tight">
+                SmoothUI
+              </span>
+            </motion.div>
+
+            <motion.div
+              animate={animate}
+              className="mt-10"
+              initial={initial}
+              transition={item}
+            >
+              <h1
+                className="text-balance font-semibold text-4xl leading-[1.05] tracking-tight"
+                id="login-3-heading"
+              >
+                Welcome back{" "}
+                <span aria-hidden="true" className="inline-block">
+                  👋
+                </span>
+              </h1>
+              <p className="mt-3 text-foreground/60 text-sm">
+                Sign in and keep creating.
+              </p>
+            </motion.div>
+
+            <motion.div
+              animate={animate}
+              className="mt-8 grid grid-cols-3 gap-2"
+              initial={initial}
+              transition={item}
+            >
+              {OAUTH_PROVIDERS.map(({ name, Icon, label }) => (
+                <SmoothButton
+                  aria-label={`Continue with ${label}`}
+                  className="w-full justify-center gap-2"
+                  key={name}
+                  type="button"
+                  variant="outline"
+                >
+                  <Icon className="size-4" />
+                  <span className="text-xs">{label}</span>
+                </SmoothButton>
+              ))}
+            </motion.div>
+
+            <motion.div
+              animate={animate}
+              className="my-6 flex items-center gap-3"
+              initial={initial}
+              transition={item}
+            >
+              <span className="h-px flex-1 bg-border" />
+              <span className="text-foreground/50 text-xs uppercase tracking-wider">
+                or with email
+              </span>
+              <span className="h-px flex-1 bg-border" />
+            </motion.div>
+
+            <motion.form
+              animate={animate}
+              className="flex flex-col gap-4"
+              initial={initial}
+              onSubmit={(event) => event.preventDefault()}
+              transition={item}
+            >
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="login-3-email">Email</Label>
+                <Input
+                  autoComplete="email"
+                  id="login-3-email"
+                  name="email"
+                  placeholder="you@studio.com"
+                  required
+                  type="email"
+                />
+              </div>
+              <SmoothButton
+                className="w-full"
+                size="lg"
+                type="submit"
+                variant="candy"
+              >
+                Sign in with email
+              </SmoothButton>
+            </motion.form>
+
+            <motion.p
+              animate={animate}
+              className="mt-6 text-center text-foreground/60 text-sm"
+              initial={initial}
+              transition={item}
+            >
+              New to SmoothUI?{" "}
+              <a
+                className="font-medium text-foreground underline underline-offset-4 hover:text-primary"
+                href="#signup"
+              >
+                Sign up
+              </a>
+            </motion.p>
+          </motion.div>
+        </div>
+
+        {/* Pastel creative hero column */}
+        <aside className="relative hidden overflow-hidden bg-gradient-to-br from-violet-200 via-pink-100 to-amber-100 lg:block dark:from-violet-950 dark:via-pink-950 dark:to-amber-950">
+          {/* Ambient iridescent orb */}
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-0 flex items-center justify-center"
+          >
+            <div className="opacity-80 blur-sm">
+              <SiriOrb animationDuration={22} size="520px" />
+            </div>
+          </div>
+
+          {/* Subtle conic-gradient overlay for iridescent sheen */}
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-0 opacity-40 mix-blend-overlay"
+            style={{
+              background:
+                "conic-gradient(from 180deg at 50% 50%, #f472b6 0deg, #a78bfa 90deg, #fbbf24 180deg, #34d399 270deg, #f472b6 360deg)",
+            }}
+          />
+
+          <motion.div
+            animate={animate}
+            className="relative flex h-full flex-col justify-between p-12"
+            initial={initial}
+            transition={stagger}
+          >
+            <motion.div
+              animate={animate}
+              className="max-w-md"
+              initial={initial}
+              transition={item}
+            >
+              <span className="inline-flex items-center gap-2 rounded-full border border-white/40 bg-white/40 px-3 py-1 font-medium text-foreground/80 text-xs backdrop-blur-md dark:border-white/10 dark:bg-white/10 dark:text-white/80">
+                For creative teams
+              </span>
+            </motion.div>
+
+            <motion.div
+              animate={animate}
+              className="max-w-md"
+              initial={initial}
+              transition={item}
+            >
+              <h2 className="text-balance font-semibold text-4xl text-foreground/90 leading-[1.05] tracking-tight dark:text-white/90">
+                Animations that feel handcrafted.
+              </h2>
+              <p className="mt-4 text-foreground/70 text-sm dark:text-white/70">
+                Every component tuned with spring physics and reduced-motion
+                care — so your product feels alive without the jank.
+              </p>
+            </motion.div>
+
+            <motion.div
+              animate={animate}
+              className="max-w-md"
+              initial={initial}
+              transition={item}
+            >
+              <p className="text-foreground/60 text-xs uppercase tracking-wider dark:text-white/60">
+                Trusted by creative teams at
+              </p>
+              <div className="mt-3 flex flex-wrap items-center gap-x-6 gap-y-3 text-foreground/70 opacity-70 grayscale dark:text-white/70">
+                {CREATIVE_LOGOS.map(({ name, Logo }) => (
+                  <span
+                    aria-label={name}
+                    className="inline-flex h-5 items-center [&_svg]:h-5 [&_svg]:w-auto"
+                    key={name}
+                  >
+                    <Logo />
+                  </span>
+                ))}
+              </div>
+            </motion.div>
+          </motion.div>
+        </aside>
+      </div>
+    </section>
+  );
+}
+
+export default Login3;

--- a/packages/smoothui/pages/auth/login-3/package.json
+++ b/packages/smoothui/pages/auth/login-3/package.json
@@ -1,13 +1,13 @@
 {
-  "name": "@repo/login-2",
-  "description": "Split-screen full-page login with product preview and animated feature cards",
+  "name": "@repo/login-3",
+  "description": "Creative split-screen login with pastel gradient hero, iridescent orb, and branded OAuth grid",
   "version": "0.0.0",
   "private": true,
   "dependencies": {
     "@repo/shadcn-ui": "workspace:*",
     "@repo/smooth-button": "workspace:*",
-    "@repo/glow-hover-card": "workspace:*",
-    "@repo/typewriter-text": "workspace:*",
+    "@repo/siri-orb": "workspace:*",
+    "@repo/blocks-shared": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "motion": "^11.15.0",
@@ -29,18 +29,17 @@
       "auth",
       "split-screen",
       "full-page",
-      "testimonial",
-      "showcase",
-      "candy-cta",
-      "glow-hover",
-      "typewriter"
+      "creative",
+      "pastel",
+      "iridescent",
+      "candy-cta"
     ],
     "complexity": "moderate",
     "animationType": "spring",
     "useCases": [
-      "Marketing-forward login page with product preview",
-      "Split-screen auth for SaaS products",
-      "Dedicated /login route with brand reinforcement"
+      "Creative-first login page with pastel gradient hero",
+      "Split-screen auth for design studios and creative SaaS",
+      "Standalone /login route with iridescent ambient orb"
     ],
     "compositionHints": [
       "Use as standalone /login route page",

--- a/packages/smoothui/pages/auth/login-4/index.tsx
+++ b/packages/smoothui/pages/auth/login-4/index.tsx
@@ -1,0 +1,261 @@
+"use client";
+
+import { Checkbox } from "@repo/shadcn-ui/components/ui/checkbox";
+import { Input } from "@repo/shadcn-ui/components/ui/input";
+import { Label } from "@repo/shadcn-ui/components/ui/label";
+import SmoothButton from "@repo/smoothui/components/smooth-button";
+import WaveText from "@repo/smoothui/components/wave-text";
+import { Apple, Github, Globe, Hexagon, X } from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
+import { type FormEvent, useState } from "react";
+
+const SPRING = {
+  type: "spring" as const,
+  duration: 0.25,
+  bounce: 0.1,
+};
+
+const OAUTH_PROVIDERS = [
+  { name: "Google", Icon: Globe },
+  { name: "Apple", Icon: Apple },
+  { name: "GitHub", Icon: Github },
+] as const;
+
+export function Login4() {
+  const shouldReduceMotion = useReducedMotion();
+  const [rememberMe, setRememberMe] = useState(false);
+
+  const initial = shouldReduceMotion ? { opacity: 1 } : { opacity: 0, y: 16 };
+  const animate = shouldReduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 };
+  const stagger = shouldReduceMotion
+    ? { duration: 0 }
+    : { ...SPRING, staggerChildren: 0.06 };
+  const item = shouldReduceMotion ? { duration: 0 } : SPRING;
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+  };
+
+  return (
+    <section
+      aria-labelledby="login-4-heading"
+      className="min-h-screen bg-background"
+    >
+      <div className="grid min-h-screen lg:grid-cols-[45%_55%]">
+        {/* Editorial brand column */}
+        <aside className="relative hidden overflow-hidden bg-emerald-950 text-white lg:block">
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 bg-[radial-gradient(ellipse_at_top_left,rgba(16,185,129,0.25),transparent_60%)]"
+          />
+          <motion.div
+            animate={animate}
+            className="relative flex h-full flex-col justify-between p-12"
+            initial={initial}
+            transition={stagger}
+          >
+            <motion.div
+              animate={animate}
+              className="flex items-center gap-2"
+              initial={initial}
+              transition={item}
+            >
+              <span className="flex size-8 items-center justify-center rounded-md bg-white/10 text-white">
+                <Hexagon className="size-4" />
+              </span>
+              <span className="font-semibold text-sm tracking-tight">
+                SmoothUI
+              </span>
+            </motion.div>
+
+            <motion.div
+              animate={animate}
+              className="max-w-xl"
+              initial={initial}
+              transition={item}
+            >
+              <h2 className="text-balance font-semibold text-6xl uppercase leading-[0.95] tracking-tight md:text-7xl">
+                <WaveText amplitude={4} staggerDelay={0.04}>
+                  Build UI
+                </WaveText>
+                <br />
+                <span>that moves.</span>
+              </h2>
+              <p className="mt-6 max-w-sm text-pretty text-sm text-white/70 leading-relaxed">
+                Animated components. Typed. Tested. Yours.
+              </p>
+            </motion.div>
+
+            <motion.div
+              animate={animate}
+              className="flex items-center gap-6"
+              initial={initial}
+              transition={item}
+            >
+              <a
+                className="text-sm text-white/70 underline-offset-4 hover:text-white hover:underline"
+                href="#docs"
+              >
+                Read docs →
+              </a>
+              <a
+                className="text-sm text-white/70 underline-offset-4 hover:text-white hover:underline"
+                href="#get-kit"
+              >
+                Get the kit →
+              </a>
+            </motion.div>
+          </motion.div>
+        </aside>
+
+        {/* Form column */}
+        <div className="relative flex items-center justify-center bg-background px-6 py-16">
+          <button
+            aria-label="Close"
+            className="absolute top-6 right-6 inline-flex size-9 items-center justify-center rounded-full text-foreground/60 transition-colors hover:bg-accent hover:text-foreground"
+            type="button"
+          >
+            <X className="size-4" />
+          </button>
+
+          <motion.div
+            animate={animate}
+            className="w-full max-w-sm"
+            initial={initial}
+            transition={stagger}
+          >
+            <motion.div
+              animate={animate}
+              className="flex items-center gap-2 lg:hidden"
+              initial={initial}
+              transition={item}
+            >
+              <span className="flex size-8 items-center justify-center rounded-md bg-gradient-to-br from-brand to-brand-secondary text-white">
+                <Hexagon className="size-4" />
+              </span>
+              <span className="font-semibold text-sm tracking-tight">
+                SmoothUI
+              </span>
+            </motion.div>
+
+            <motion.div
+              animate={animate}
+              className="mt-8 lg:mt-0"
+              initial={initial}
+              transition={item}
+            >
+              <h1
+                className="font-semibold text-3xl tracking-tight"
+                id="login-4-heading"
+              >
+                Welcome back.
+              </h1>
+              <p className="mt-2 text-foreground/60 text-sm">
+                New to SmoothUI?{" "}
+                <a
+                  className="font-medium text-foreground underline underline-offset-4 hover:text-primary"
+                  href="#signup"
+                >
+                  Sign up
+                </a>
+              </p>
+            </motion.div>
+
+            <motion.form
+              animate={animate}
+              className="mt-8 flex flex-col gap-4"
+              initial={initial}
+              onSubmit={handleSubmit}
+              transition={item}
+            >
+              <div className="flex flex-col gap-2">
+                <Label htmlFor="login-4-email">Email</Label>
+                <Input
+                  autoComplete="email"
+                  id="login-4-email"
+                  name="email"
+                  placeholder="you@example.com"
+                  required
+                  type="email"
+                />
+              </div>
+              <div className="flex flex-col gap-2">
+                <div className="flex items-center justify-between">
+                  <Label htmlFor="login-4-password">Password</Label>
+                  <a
+                    className="text-foreground/60 text-xs underline-offset-4 hover:text-foreground hover:underline"
+                    href="#forgot"
+                  >
+                    Trouble logging in?
+                  </a>
+                </div>
+                <Input
+                  autoComplete="current-password"
+                  id="login-4-password"
+                  name="password"
+                  placeholder="Enter your password"
+                  required
+                  type="password"
+                />
+              </div>
+
+              <label
+                className="flex cursor-pointer items-center gap-2 text-foreground/70 text-sm"
+                htmlFor="login-4-remember"
+              >
+                <Checkbox
+                  checked={rememberMe}
+                  id="login-4-remember"
+                  onCheckedChange={(checked) => setRememberMe(checked === true)}
+                />
+                <span>Remember me for 30 days</span>
+              </label>
+
+              <SmoothButton
+                className="w-full"
+                size="lg"
+                type="submit"
+                variant="candy"
+              >
+                Log in
+              </SmoothButton>
+            </motion.form>
+
+            <motion.div
+              animate={animate}
+              className="my-6 flex items-center gap-3"
+              initial={initial}
+              transition={item}
+            >
+              <span className="h-px flex-1 bg-border" />
+              <span className="text-foreground/50 text-xs uppercase tracking-wider">
+                Or log in with
+              </span>
+              <span className="h-px flex-1 bg-border" />
+            </motion.div>
+
+            <motion.div
+              animate={animate}
+              className="flex items-center justify-center gap-3"
+              initial={initial}
+              transition={item}
+            >
+              {OAUTH_PROVIDERS.map(({ name, Icon }) => (
+                <button
+                  aria-label={`Log in with ${name}`}
+                  className="inline-flex size-12 items-center justify-center rounded-full border border-input bg-background text-foreground/70 shadow-xs transition-colors hover:bg-accent hover:text-foreground"
+                  key={name}
+                  type="button"
+                >
+                  <Icon className="size-5" />
+                </button>
+              ))}
+            </motion.div>
+          </motion.div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default Login4;

--- a/packages/smoothui/pages/auth/login-4/package.json
+++ b/packages/smoothui/pages/auth/login-4/package.json
@@ -1,13 +1,12 @@
 {
-  "name": "@repo/login-2",
-  "description": "Split-screen full-page login with product preview and animated feature cards",
+  "name": "@repo/login-4",
+  "description": "Editorial split-screen login with dark green brand column, wave-text headline, and circular OAuth pills",
   "version": "0.0.0",
   "private": true,
   "dependencies": {
     "@repo/shadcn-ui": "workspace:*",
     "@repo/smooth-button": "workspace:*",
-    "@repo/glow-hover-card": "workspace:*",
-    "@repo/typewriter-text": "workspace:*",
+    "@repo/wave-text": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "motion": "^11.15.0",
@@ -29,22 +28,20 @@
       "auth",
       "split-screen",
       "full-page",
-      "testimonial",
-      "showcase",
-      "candy-cta",
-      "glow-hover",
-      "typewriter"
+      "editorial",
+      "wave-text",
+      "candy-cta"
     ],
     "complexity": "moderate",
     "animationType": "spring",
     "useCases": [
-      "Marketing-forward login page with product preview",
-      "Split-screen auth for SaaS products",
-      "Dedicated /login route with brand reinforcement"
+      "Editorial-brand login page with dark-green hero column",
+      "Password-first auth with circular OAuth pill buttons",
+      "Standalone /login route with bold typographic headline"
     ],
     "compositionHints": [
       "Use as standalone /login route page",
-      "Right column hides below lg breakpoint for mobile-first experience"
+      "Left column hides below lg breakpoint for mobile-first experience"
     ],
     "hasReducedMotion": true
   }

--- a/packages/smoothui/pages/auth/magic-link/index.tsx
+++ b/packages/smoothui/pages/auth/magic-link/index.tsx
@@ -1,8 +1,11 @@
 "use client";
 
-import { Button } from "@repo/shadcn-ui/components/ui/button";
 import { Input } from "@repo/shadcn-ui/components/ui/input";
 import { Label } from "@repo/shadcn-ui/components/ui/label";
+import MagneticButton from "@repo/smoothui/components/magnetic-button";
+import SiriOrb from "@repo/smoothui/components/siri-orb";
+import SmoothButton from "@repo/smoothui/components/smooth-button";
+import TypewriterText from "@repo/smoothui/components/typewriter-text";
 import { ArrowLeft, Hexagon, Mail, MailCheck } from "lucide-react";
 import { AnimatePresence, motion, useReducedMotion } from "motion/react";
 import { type FormEvent, useState } from "react";
@@ -57,7 +60,7 @@ export function MagicLink() {
       />
 
       <div className="relative w-full max-w-sm">
-        <div className="rounded-xl border border-border/60 bg-card/70 p-8 shadow-sm backdrop-blur">
+        <div className="relative overflow-hidden rounded-2xl border border-border/60 bg-background/80 p-8 shadow-black/5 shadow-xl backdrop-blur-xl">
           <AnimatePresence initial={false} mode="wait">
             {view === "input" ? (
               <motion.div
@@ -73,7 +76,7 @@ export function MagicLink() {
                   initial={initial}
                   transition={item}
                 >
-                  <span className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                  <span className="flex size-10 items-center justify-center rounded-lg bg-gradient-to-br from-brand to-brand-secondary text-white shadow-sm">
                     <Hexagon className="size-5" />
                   </span>
                   <h1
@@ -107,10 +110,15 @@ export function MagicLink() {
                       value={email}
                     />
                   </div>
-                  <Button className="w-full gap-2" type="submit">
+                  <SmoothButton
+                    className="w-full gap-2"
+                    size="lg"
+                    type="submit"
+                    variant="candy"
+                  >
                     <Mail className="size-4" />
                     Send magic link
-                  </Button>
+                  </SmoothButton>
                 </motion.form>
 
                 <motion.p
@@ -138,13 +146,20 @@ export function MagicLink() {
               >
                 <motion.div
                   animate={animate}
-                  className="flex flex-col items-center text-center"
+                  className="relative flex flex-col items-center text-center"
                   initial={initial}
                   transition={item}
                 >
+                  {/* Ambient halo behind the mail icon */}
+                  <div
+                    aria-hidden="true"
+                    className="pointer-events-none absolute inset-x-0 top-[-80px] flex items-center justify-center opacity-70 blur-2xl"
+                  >
+                    <SiriOrb animationDuration={18} size="240px" />
+                  </div>
                   <motion.span
                     animate={iconAnimate}
-                    className="flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary"
+                    className="relative flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary ring-1 ring-primary/20"
                     initial={iconInitial}
                     transition={
                       shouldReduceMotion
@@ -154,27 +169,29 @@ export function MagicLink() {
                   >
                     <MailCheck className="size-6" />
                   </motion.span>
-                  <h2 className="mt-5 font-semibold text-2xl tracking-tight">
+                  <h2 className="relative mt-5 font-semibold text-2xl tracking-tight">
                     Check your email
                   </h2>
-                  <p className="mt-2 text-balance text-foreground/60 text-sm">
-                    We sent a link to{" "}
-                    <span className="font-medium text-foreground">
-                      {email || "your inbox"}
-                    </span>
-                    . Click it to continue.
+                  <p className="relative mt-2 text-balance text-foreground/70 text-sm">
+                    <TypewriterText key={email} speed={24}>
+                      {`We just sent a secure link to ${email || "your inbox"}. Click it to continue.`}
+                    </TypewriterText>
                   </p>
                 </motion.div>
 
                 <motion.div
                   animate={animate}
-                  className="mt-8 flex flex-col gap-3"
+                  className="relative mt-8 flex flex-col gap-3"
                   initial={initial}
                   transition={item}
                 >
-                  <Button type="button" variant="outline">
+                  <MagneticButton
+                    className="w-full"
+                    type="button"
+                    variant="outline"
+                  >
                     Resend link
-                  </Button>
+                  </MagneticButton>
                   <button
                     className="inline-flex items-center justify-center gap-1 text-foreground/60 text-sm hover:text-foreground"
                     onClick={handleUseDifferentEmail}

--- a/packages/smoothui/pages/auth/magic-link/index.tsx
+++ b/packages/smoothui/pages/auth/magic-link/index.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { Button } from "@repo/shadcn-ui/components/ui/button";
+import { Input } from "@repo/shadcn-ui/components/ui/input";
+import { Label } from "@repo/shadcn-ui/components/ui/label";
+import { ArrowLeft, Hexagon, Mail, MailCheck } from "lucide-react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { type FormEvent, useState } from "react";
+
+const SPRING = {
+  type: "spring" as const,
+  duration: 0.25,
+  bounce: 0.1,
+};
+
+type ViewState = "input" | "sent";
+
+export function MagicLink() {
+  const shouldReduceMotion = useReducedMotion();
+  const [view, setView] = useState<ViewState>("input");
+  const [email, setEmail] = useState("");
+
+  const initial = shouldReduceMotion ? { opacity: 1 } : { opacity: 0, y: 24 };
+  const animate = shouldReduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 };
+  const exit = shouldReduceMotion
+    ? { opacity: 0, transition: { duration: 0 } }
+    : { opacity: 0, y: -16 };
+  const stagger = shouldReduceMotion
+    ? { duration: 0 }
+    : { ...SPRING, staggerChildren: 0.05 };
+  const item = shouldReduceMotion ? { duration: 0 } : SPRING;
+
+  const iconInitial = shouldReduceMotion
+    ? { opacity: 1, scale: 1 }
+    : { opacity: 0, scale: 0.85 };
+  const iconAnimate = shouldReduceMotion
+    ? { opacity: 1, scale: 1 }
+    : { opacity: 1, scale: 1 };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setView("sent");
+  };
+
+  const handleUseDifferentEmail = () => {
+    setView("input");
+  };
+
+  return (
+    <section
+      aria-labelledby="magic-link-heading"
+      className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-6 py-16"
+    >
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,var(--color-primary)/0.08,transparent_70%)]"
+      />
+
+      <div className="relative w-full max-w-sm">
+        <div className="rounded-xl border border-border/60 bg-card/70 p-8 shadow-sm backdrop-blur">
+          <AnimatePresence initial={false} mode="wait">
+            {view === "input" ? (
+              <motion.div
+                animate={animate}
+                exit={exit}
+                initial={initial}
+                key="input"
+                transition={stagger}
+              >
+                <motion.div
+                  animate={animate}
+                  className="flex flex-col items-center text-center"
+                  initial={initial}
+                  transition={item}
+                >
+                  <span className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                    <Hexagon className="size-5" />
+                  </span>
+                  <h1
+                    className="mt-5 font-semibold text-2xl tracking-tight"
+                    id="magic-link-heading"
+                  >
+                    Sign in with magic link
+                  </h1>
+                  <p className="mt-2 text-balance text-foreground/60 text-sm">
+                    Enter your email and we&apos;ll send you a secure link.
+                  </p>
+                </motion.div>
+
+                <motion.form
+                  animate={animate}
+                  className="mt-8 flex flex-col gap-4"
+                  initial={initial}
+                  onSubmit={handleSubmit}
+                  transition={item}
+                >
+                  <div className="flex flex-col gap-2">
+                    <Label htmlFor="magic-link-email">Email</Label>
+                    <Input
+                      autoComplete="email"
+                      id="magic-link-email"
+                      name="email"
+                      onChange={(event) => setEmail(event.target.value)}
+                      placeholder="you@example.com"
+                      required
+                      type="email"
+                      value={email}
+                    />
+                  </div>
+                  <Button className="w-full gap-2" type="submit">
+                    <Mail className="size-4" />
+                    Send magic link
+                  </Button>
+                </motion.form>
+
+                <motion.p
+                  animate={animate}
+                  className="mt-6 text-center text-foreground/60 text-sm"
+                  initial={initial}
+                  transition={item}
+                >
+                  Prefer password?{" "}
+                  <a
+                    className="font-medium text-foreground underline underline-offset-4 hover:text-primary"
+                    href="#signin"
+                  >
+                    Sign in
+                  </a>
+                </motion.p>
+              </motion.div>
+            ) : (
+              <motion.div
+                animate={animate}
+                exit={exit}
+                initial={initial}
+                key="sent"
+                transition={stagger}
+              >
+                <motion.div
+                  animate={animate}
+                  className="flex flex-col items-center text-center"
+                  initial={initial}
+                  transition={item}
+                >
+                  <motion.span
+                    animate={iconAnimate}
+                    className="flex size-12 items-center justify-center rounded-full bg-primary/10 text-primary"
+                    initial={iconInitial}
+                    transition={
+                      shouldReduceMotion
+                        ? { duration: 0 }
+                        : { ...SPRING, bounce: 0.1, duration: 0.3 }
+                    }
+                  >
+                    <MailCheck className="size-6" />
+                  </motion.span>
+                  <h2 className="mt-5 font-semibold text-2xl tracking-tight">
+                    Check your email
+                  </h2>
+                  <p className="mt-2 text-balance text-foreground/60 text-sm">
+                    We sent a link to{" "}
+                    <span className="font-medium text-foreground">
+                      {email || "your inbox"}
+                    </span>
+                    . Click it to continue.
+                  </p>
+                </motion.div>
+
+                <motion.div
+                  animate={animate}
+                  className="mt-8 flex flex-col gap-3"
+                  initial={initial}
+                  transition={item}
+                >
+                  <Button type="button" variant="outline">
+                    Resend link
+                  </Button>
+                  <button
+                    className="inline-flex items-center justify-center gap-1 text-foreground/60 text-sm hover:text-foreground"
+                    onClick={handleUseDifferentEmail}
+                    type="button"
+                  >
+                    <ArrowLeft className="size-3.5" />
+                    Use a different email
+                  </button>
+                </motion.div>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default MagicLink;

--- a/packages/smoothui/pages/auth/magic-link/package.json
+++ b/packages/smoothui/pages/auth/magic-link/package.json
@@ -1,0 +1,44 @@
+{
+  "name": "@repo/magic-link",
+  "description": "Passwordless full-page magic link sign-in with two-state email flow",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@repo/shadcn-ui": "workspace:*",
+    "@repo/smooth-button": "workspace:*",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "motion": "^11.15.0",
+    "lucide-react": "^0.545.0"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.1",
+    "typescript": "^5.9.3"
+  },
+  "smoothui": {
+    "category": "authentication",
+    "tags": [
+      "authentication",
+      "magic-link",
+      "passwordless",
+      "email",
+      "sign-in",
+      "auth",
+      "full-page"
+    ],
+    "complexity": "moderate",
+    "animationType": "spring",
+    "useCases": [
+      "Passwordless sign-in flow with email verification",
+      "Magic link request + confirmation screen",
+      "Modern auth UX without passwords"
+    ],
+    "compositionHints": [
+      "Use as standalone /login route page for passwordless flows",
+      "Pair with login-1 as the password-based alternative"
+    ],
+    "hasReducedMotion": true
+  }
+}

--- a/packages/smoothui/pages/auth/magic-link/package.json
+++ b/packages/smoothui/pages/auth/magic-link/package.json
@@ -6,6 +6,9 @@
   "dependencies": {
     "@repo/shadcn-ui": "workspace:*",
     "@repo/smooth-button": "workspace:*",
+    "@repo/siri-orb": "workspace:*",
+    "@repo/typewriter-text": "workspace:*",
+    "@repo/magnetic-button": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "motion": "^11.15.0",
@@ -26,7 +29,11 @@
       "email",
       "sign-in",
       "auth",
-      "full-page"
+      "full-page",
+      "ambient-orb",
+      "typewriter",
+      "magnetic-button",
+      "candy-cta"
     ],
     "complexity": "moderate",
     "animationType": "spring",

--- a/packages/smoothui/pages/auth/signup-1/index.tsx
+++ b/packages/smoothui/pages/auth/signup-1/index.tsx
@@ -1,9 +1,17 @@
 "use client";
 
-import { Button } from "@repo/shadcn-ui/components/ui/button";
+import {
+  Canva,
+  Descript,
+  Duolingo,
+  Faire,
+  Ramp,
+  Strava,
+} from "@repo/blocks-shared";
 import { Checkbox } from "@repo/shadcn-ui/components/ui/checkbox";
 import { Input } from "@repo/shadcn-ui/components/ui/input";
 import { Label } from "@repo/shadcn-ui/components/ui/label";
+import SmoothButton from "@repo/smoothui/components/smooth-button";
 import { Apple, Github, Globe, Hexagon } from "lucide-react";
 import { motion, useReducedMotion } from "motion/react";
 import { type FormEvent, useState } from "react";
@@ -20,34 +28,60 @@ const OAUTH_PROVIDERS = [
   { name: "GitHub", Icon: Github, label: "Continue with GitHub" },
 ] as const;
 
+const SOCIAL_PROOF_LOGOS = [
+  { name: "Canva", Logo: Canva },
+  { name: "Duolingo", Logo: Duolingo },
+  { name: "Ramp", Logo: Ramp },
+  { name: "Strava", Logo: Strava },
+  { name: "Faire", Logo: Faire },
+  { name: "Descript", Logo: Descript },
+] as const;
+
 const MIN_STRONG_PASSWORD_LENGTH = 10;
 const MIN_MEDIUM_PASSWORD_LENGTH = 6;
 
-const getPasswordHint = (password: string) => {
+const getPasswordStrength = (password: string) => {
   if (password.length === 0) {
     return {
       label: "Use at least 8 characters with a number or symbol.",
       tone: "muted" as const,
+      percent: 0,
     };
   }
   if (password.length >= MIN_STRONG_PASSWORD_LENGTH) {
-    return { label: "Strong password", tone: "strong" as const };
+    return { label: "Strong password", tone: "strong" as const, percent: 100 };
   }
   if (password.length >= MIN_MEDIUM_PASSWORD_LENGTH) {
     return {
       label: "Getting there — add a number or symbol.",
       tone: "medium" as const,
+      percent: 66,
     };
   }
-  return { label: "Too short — keep going.", tone: "weak" as const };
+  return {
+    label: "Too short — keep going.",
+    tone: "weak" as const,
+    percent: 33,
+  };
 };
 
-const TONE_CLASSES: Record<"muted" | "weak" | "medium" | "strong", string> = {
+const TEXT_TONE_CLASSES: Record<
+  "muted" | "weak" | "medium" | "strong",
+  string
+> = {
   muted: "text-foreground/50",
   weak: "text-destructive",
-  medium: "text-amber-600 dark:text-amber-400",
-  strong: "text-emerald-600 dark:text-emerald-400",
+  medium: "text-amber-500",
+  strong: "text-emerald-500",
 };
+
+const BAR_TONE_CLASSES: Record<"muted" | "weak" | "medium" | "strong", string> =
+  {
+    muted: "bg-border",
+    weak: "bg-destructive",
+    medium: "bg-amber-500",
+    strong: "bg-emerald-500",
+  };
 
 export function Signup1() {
   const shouldReduceMotion = useReducedMotion();
@@ -61,7 +95,7 @@ export function Signup1() {
     : { ...SPRING, staggerChildren: 0.05 };
   const item = shouldReduceMotion ? { duration: 0 } : SPRING;
 
-  const hint = getPasswordHint(password);
+  const strength = getPasswordStrength(password);
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -82,14 +116,14 @@ export function Signup1() {
         initial={initial}
         transition={stagger}
       >
-        <div className="rounded-xl border border-border/60 bg-card/70 p-8 shadow-sm backdrop-blur">
+        <div className="rounded-2xl border border-border/60 bg-background/80 p-8 shadow-black/5 shadow-xl backdrop-blur-xl">
           <motion.div
             animate={animate}
             className="flex flex-col items-center text-center"
             initial={initial}
             transition={item}
           >
-            <span className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+            <span className="flex size-10 items-center justify-center rounded-lg bg-gradient-to-br from-brand to-brand-secondary text-white shadow-sm">
               <Hexagon className="size-5" />
             </span>
             <h1
@@ -110,7 +144,7 @@ export function Signup1() {
             transition={item}
           >
             {OAUTH_PROVIDERS.map(({ name, Icon, label }) => (
-              <Button
+              <SmoothButton
                 className="w-full justify-center gap-2"
                 key={name}
                 type="button"
@@ -118,7 +152,7 @@ export function Signup1() {
               >
                 <Icon className="size-4" />
                 {label}
-              </Button>
+              </SmoothButton>
             ))}
           </motion.div>
 
@@ -176,8 +210,23 @@ export function Signup1() {
                 type="password"
                 value={password}
               />
-              <p className={`text-xs ${TONE_CLASSES[hint.tone]}`}>
-                {hint.label}
+              <div
+                aria-hidden="true"
+                className="h-1 w-full overflow-hidden rounded-full bg-border/60"
+              >
+                <motion.div
+                  animate={{ width: `${strength.percent}%` }}
+                  className={`h-full rounded-full ${BAR_TONE_CLASSES[strength.tone]}`}
+                  initial={{ width: 0 }}
+                  transition={
+                    shouldReduceMotion
+                      ? { duration: 0 }
+                      : { type: "spring", duration: 0.25, bounce: 0.1 }
+                  }
+                />
+              </div>
+              <p className={`text-xs ${TEXT_TONE_CLASSES[strength.tone]}`}>
+                {strength.label}
               </p>
             </div>
             <label
@@ -210,9 +259,15 @@ export function Signup1() {
                 .
               </span>
             </label>
-            <Button className="w-full" disabled={!acceptedTerms} type="submit">
+            <SmoothButton
+              className="w-full"
+              disabled={!acceptedTerms}
+              size="lg"
+              type="submit"
+              variant="candy"
+            >
               Create account
-            </Button>
+            </SmoothButton>
           </motion.form>
 
           <motion.p
@@ -230,6 +285,29 @@ export function Signup1() {
             </a>
           </motion.p>
         </div>
+
+        {/* Social proof strip — trusted-by logos */}
+        <motion.div
+          animate={animate}
+          className="mt-8"
+          initial={initial}
+          transition={item}
+        >
+          <p className="text-center text-foreground/50 text-xs uppercase tracking-wider">
+            Trusted by teams building at
+          </p>
+          <div className="mt-4 flex flex-wrap items-center justify-center gap-x-6 gap-y-3 text-foreground/60 opacity-70 grayscale transition-opacity hover:opacity-100">
+            {SOCIAL_PROOF_LOGOS.map(({ name, Logo }) => (
+              <span
+                aria-label={name}
+                className="inline-flex h-5 items-center [&_svg]:h-5 [&_svg]:w-auto"
+                key={name}
+              >
+                <Logo />
+              </span>
+            ))}
+          </div>
+        </motion.div>
       </motion.div>
     </section>
   );

--- a/packages/smoothui/pages/auth/signup-1/index.tsx
+++ b/packages/smoothui/pages/auth/signup-1/index.tsx
@@ -1,0 +1,238 @@
+"use client";
+
+import { Button } from "@repo/shadcn-ui/components/ui/button";
+import { Checkbox } from "@repo/shadcn-ui/components/ui/checkbox";
+import { Input } from "@repo/shadcn-ui/components/ui/input";
+import { Label } from "@repo/shadcn-ui/components/ui/label";
+import { Apple, Github, Globe, Hexagon } from "lucide-react";
+import { motion, useReducedMotion } from "motion/react";
+import { type FormEvent, useState } from "react";
+
+const SPRING = {
+  type: "spring" as const,
+  duration: 0.25,
+  bounce: 0.1,
+};
+
+const OAUTH_PROVIDERS = [
+  { name: "Google", Icon: Globe, label: "Continue with Google" },
+  { name: "Apple", Icon: Apple, label: "Continue with Apple" },
+  { name: "GitHub", Icon: Github, label: "Continue with GitHub" },
+] as const;
+
+const MIN_STRONG_PASSWORD_LENGTH = 10;
+const MIN_MEDIUM_PASSWORD_LENGTH = 6;
+
+const getPasswordHint = (password: string) => {
+  if (password.length === 0) {
+    return {
+      label: "Use at least 8 characters with a number or symbol.",
+      tone: "muted" as const,
+    };
+  }
+  if (password.length >= MIN_STRONG_PASSWORD_LENGTH) {
+    return { label: "Strong password", tone: "strong" as const };
+  }
+  if (password.length >= MIN_MEDIUM_PASSWORD_LENGTH) {
+    return {
+      label: "Getting there — add a number or symbol.",
+      tone: "medium" as const,
+    };
+  }
+  return { label: "Too short — keep going.", tone: "weak" as const };
+};
+
+const TONE_CLASSES: Record<"muted" | "weak" | "medium" | "strong", string> = {
+  muted: "text-foreground/50",
+  weak: "text-destructive",
+  medium: "text-amber-600 dark:text-amber-400",
+  strong: "text-emerald-600 dark:text-emerald-400",
+};
+
+export function Signup1() {
+  const shouldReduceMotion = useReducedMotion();
+  const [acceptedTerms, setAcceptedTerms] = useState(false);
+  const [password, setPassword] = useState("");
+
+  const initial = shouldReduceMotion ? { opacity: 1 } : { opacity: 0, y: 24 };
+  const animate = shouldReduceMotion ? { opacity: 1 } : { opacity: 1, y: 0 };
+  const stagger = shouldReduceMotion
+    ? { duration: 0 }
+    : { ...SPRING, staggerChildren: 0.05 };
+  const item = shouldReduceMotion ? { duration: 0 } : SPRING;
+
+  const hint = getPasswordHint(password);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+  };
+
+  return (
+    <section
+      aria-labelledby="signup-1-heading"
+      className="relative flex min-h-screen items-center justify-center overflow-hidden bg-background px-6 py-16"
+    >
+      <div
+        aria-hidden="true"
+        className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,var(--color-primary)/0.08,transparent_70%)]"
+      />
+      <motion.div
+        animate={animate}
+        className="relative w-full max-w-sm"
+        initial={initial}
+        transition={stagger}
+      >
+        <div className="rounded-xl border border-border/60 bg-card/70 p-8 shadow-sm backdrop-blur">
+          <motion.div
+            animate={animate}
+            className="flex flex-col items-center text-center"
+            initial={initial}
+            transition={item}
+          >
+            <span className="flex size-10 items-center justify-center rounded-lg bg-primary/10 text-primary">
+              <Hexagon className="size-5" />
+            </span>
+            <h1
+              className="mt-5 font-semibold text-2xl tracking-tight"
+              id="signup-1-heading"
+            >
+              Create your account
+            </h1>
+            <p className="mt-2 text-foreground/60 text-sm">
+              Start building with SmoothUI in seconds
+            </p>
+          </motion.div>
+
+          <motion.div
+            animate={animate}
+            className="mt-8 flex flex-col gap-2"
+            initial={initial}
+            transition={item}
+          >
+            {OAUTH_PROVIDERS.map(({ name, Icon, label }) => (
+              <Button
+                className="w-full justify-center gap-2"
+                key={name}
+                type="button"
+                variant="outline"
+              >
+                <Icon className="size-4" />
+                {label}
+              </Button>
+            ))}
+          </motion.div>
+
+          <motion.div
+            animate={animate}
+            className="my-6 flex items-center gap-3"
+            initial={initial}
+            transition={item}
+          >
+            <span className="h-px flex-1 bg-border" />
+            <span className="text-foreground/50 text-xs uppercase tracking-wider">
+              or
+            </span>
+            <span className="h-px flex-1 bg-border" />
+          </motion.div>
+
+          <motion.form
+            animate={animate}
+            className="flex flex-col gap-4"
+            initial={initial}
+            onSubmit={handleSubmit}
+            transition={item}
+          >
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="signup-1-name">Name</Label>
+              <Input
+                autoComplete="name"
+                id="signup-1-name"
+                name="name"
+                placeholder="Ada Lovelace"
+                required
+                type="text"
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="signup-1-email">Email</Label>
+              <Input
+                autoComplete="email"
+                id="signup-1-email"
+                name="email"
+                placeholder="you@example.com"
+                required
+                type="email"
+              />
+            </div>
+            <div className="flex flex-col gap-2">
+              <Label htmlFor="signup-1-password">Password</Label>
+              <Input
+                autoComplete="new-password"
+                id="signup-1-password"
+                name="password"
+                onChange={(event) => setPassword(event.target.value)}
+                placeholder="Choose a secure password"
+                required
+                type="password"
+                value={password}
+              />
+              <p className={`text-xs ${TONE_CLASSES[hint.tone]}`}>
+                {hint.label}
+              </p>
+            </div>
+            <label
+              className="flex cursor-pointer items-start gap-2 text-foreground/70 text-sm"
+              htmlFor="signup-1-terms"
+            >
+              <Checkbox
+                checked={acceptedTerms}
+                className="mt-0.5"
+                id="signup-1-terms"
+                onCheckedChange={(checked) =>
+                  setAcceptedTerms(checked === true)
+                }
+              />
+              <span>
+                I agree to the{" "}
+                <a
+                  className="font-medium text-foreground underline underline-offset-4"
+                  href="#terms"
+                >
+                  Terms
+                </a>{" "}
+                and{" "}
+                <a
+                  className="font-medium text-foreground underline underline-offset-4"
+                  href="#privacy"
+                >
+                  Privacy Policy
+                </a>
+                .
+              </span>
+            </label>
+            <Button className="w-full" disabled={!acceptedTerms} type="submit">
+              Create account
+            </Button>
+          </motion.form>
+
+          <motion.p
+            animate={animate}
+            className="mt-6 text-center text-foreground/60 text-sm"
+            initial={initial}
+            transition={item}
+          >
+            Already have an account?{" "}
+            <a
+              className="font-medium text-foreground underline underline-offset-4 hover:text-primary"
+              href="#signin"
+            >
+              Sign in
+            </a>
+          </motion.p>
+        </div>
+      </motion.div>
+    </section>
+  );
+}
+
+export default Signup1;

--- a/packages/smoothui/pages/auth/signup-1/package.json
+++ b/packages/smoothui/pages/auth/signup-1/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@repo/signup-1",
+  "description": "Centered full-page signup with OAuth, name/email/password fields, and terms consent",
+  "version": "0.0.0",
+  "private": true,
+  "dependencies": {
+    "@repo/shadcn-ui": "workspace:*",
+    "@repo/smooth-button": "workspace:*",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
+    "motion": "^11.15.0",
+    "lucide-react": "^0.545.0"
+  },
+  "devDependencies": {
+    "@repo/typescript-config": "workspace:*",
+    "@types/react": "^19.2.2",
+    "@types/react-dom": "^19.2.1",
+    "typescript": "^5.9.3"
+  },
+  "smoothui": {
+    "category": "authentication",
+    "tags": [
+      "authentication",
+      "signup",
+      "sign-up",
+      "register",
+      "registration",
+      "oauth",
+      "auth",
+      "full-page"
+    ],
+    "complexity": "moderate",
+    "animationType": "spring",
+    "useCases": [
+      "Standalone /signup route page for web apps",
+      "Account creation with OAuth and email/password",
+      "Registration flow with terms consent"
+    ],
+    "compositionHints": [
+      "Use as standalone /signup route page",
+      "Pair with login-1 for a matching sign-in flow"
+    ],
+    "hasReducedMotion": true
+  }
+}

--- a/packages/smoothui/pages/auth/signup-1/package.json
+++ b/packages/smoothui/pages/auth/signup-1/package.json
@@ -6,6 +6,7 @@
   "dependencies": {
     "@repo/shadcn-ui": "workspace:*",
     "@repo/smooth-button": "workspace:*",
+    "@repo/blocks-shared": "workspace:*",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "motion": "^11.15.0",
@@ -27,7 +28,10 @@
       "registration",
       "oauth",
       "auth",
-      "full-page"
+      "full-page",
+      "social-proof",
+      "candy-cta",
+      "password-strength"
     ],
     "complexity": "moderate",
     "animationType": "spring",

--- a/packages/smoothui/pages/index.ts
+++ b/packages/smoothui/pages/index.ts
@@ -4,5 +4,7 @@
 
 export { default as Login1 } from "./auth/login-1";
 export { default as Login2 } from "./auth/login-2";
+export { default as Login3 } from "./auth/login-3";
+export { default as Login4 } from "./auth/login-4";
 export { default as MagicLink } from "./auth/magic-link";
 export { default as Signup1 } from "./auth/signup-1";

--- a/packages/smoothui/pages/index.ts
+++ b/packages/smoothui/pages/index.ts
@@ -1,0 +1,8 @@
+// Export all full-page templates from their category packages
+// Pages are self-contained screens (not composable sections like blocks).
+// Future categories: dashboard, landing, settings, checkout...
+
+export { default as Login1 } from "./auth/login-1";
+export { default as Login2 } from "./auth/login-2";
+export { default as MagicLink } from "./auth/magic-link";
+export { default as Signup1 } from "./auth/signup-1";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3584,9 +3584,15 @@ importers:
 
   packages/smoothui/pages/auth/login-1:
     dependencies:
+      '@repo/scramble-hover':
+        specifier: workspace:*
+        version: link:../../../components/scramble-hover
       '@repo/shadcn-ui':
         specifier: workspace:*
         version: link:../../../../shadcn-ui
+      '@repo/siri-orb':
+        specifier: workspace:*
+        version: link:../../../components/siri-orb
       '@repo/smooth-button':
         specifier: workspace:*
         version: link:../../../components/smooth-button
@@ -3618,12 +3624,95 @@ importers:
 
   packages/smoothui/pages/auth/login-2:
     dependencies:
+      '@repo/glow-hover-card':
+        specifier: workspace:*
+        version: link:../../../components/glow-hover-card
       '@repo/shadcn-ui':
         specifier: workspace:*
         version: link:../../../../shadcn-ui
       '@repo/smooth-button':
         specifier: workspace:*
         version: link:../../../components/smooth-button
+      '@repo/typewriter-text':
+        specifier: workspace:*
+        version: link:../../../components/typewriter-text
+      lucide-react:
+        specifier: ^0.545.0
+        version: 0.545.0(react@19.2.5)
+      motion:
+        specifier: ^11.15.0
+        version: 11.18.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: ^19.2.1
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.1
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../../../../typescript-config
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  packages/smoothui/pages/auth/login-3:
+    dependencies:
+      '@repo/blocks-shared':
+        specifier: workspace:*
+        version: link:../../../blocks/shared
+      '@repo/shadcn-ui':
+        specifier: workspace:*
+        version: link:../../../../shadcn-ui
+      '@repo/siri-orb':
+        specifier: workspace:*
+        version: link:../../../components/siri-orb
+      '@repo/smooth-button':
+        specifier: workspace:*
+        version: link:../../../components/smooth-button
+      lucide-react:
+        specifier: ^0.545.0
+        version: 0.545.0(react@19.2.5)
+      motion:
+        specifier: ^11.15.0
+        version: 11.18.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: ^19.2.1
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.1
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../../../../typescript-config
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  packages/smoothui/pages/auth/login-4:
+    dependencies:
+      '@repo/shadcn-ui':
+        specifier: workspace:*
+        version: link:../../../../shadcn-ui
+      '@repo/smooth-button':
+        specifier: workspace:*
+        version: link:../../../components/smooth-button
+      '@repo/wave-text':
+        specifier: workspace:*
+        version: link:../../../components/wave-text
       lucide-react:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.5)
@@ -3652,12 +3741,21 @@ importers:
 
   packages/smoothui/pages/auth/magic-link:
     dependencies:
+      '@repo/magnetic-button':
+        specifier: workspace:*
+        version: link:../../../components/magnetic-button
       '@repo/shadcn-ui':
         specifier: workspace:*
         version: link:../../../../shadcn-ui
+      '@repo/siri-orb':
+        specifier: workspace:*
+        version: link:../../../components/siri-orb
       '@repo/smooth-button':
         specifier: workspace:*
         version: link:../../../components/smooth-button
+      '@repo/typewriter-text':
+        specifier: workspace:*
+        version: link:../../../components/typewriter-text
       lucide-react:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.5)
@@ -3686,6 +3784,9 @@ importers:
 
   packages/smoothui/pages/auth/signup-1:
     dependencies:
+      '@repo/blocks-shared':
+        specifier: workspace:*
+        version: link:../../../blocks/shared
       '@repo/shadcn-ui':
         specifier: workspace:*
         version: link:../../../../shadcn-ui

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3582,6 +3582,142 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  packages/smoothui/pages/auth/login-1:
+    dependencies:
+      '@repo/shadcn-ui':
+        specifier: workspace:*
+        version: link:../../../../shadcn-ui
+      '@repo/smooth-button':
+        specifier: workspace:*
+        version: link:../../../components/smooth-button
+      lucide-react:
+        specifier: ^0.545.0
+        version: 0.545.0(react@19.2.5)
+      motion:
+        specifier: ^11.15.0
+        version: 11.18.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: ^19.2.1
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.1
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../../../../typescript-config
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  packages/smoothui/pages/auth/login-2:
+    dependencies:
+      '@repo/shadcn-ui':
+        specifier: workspace:*
+        version: link:../../../../shadcn-ui
+      '@repo/smooth-button':
+        specifier: workspace:*
+        version: link:../../../components/smooth-button
+      lucide-react:
+        specifier: ^0.545.0
+        version: 0.545.0(react@19.2.5)
+      motion:
+        specifier: ^11.15.0
+        version: 11.18.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: ^19.2.1
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.1
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../../../../typescript-config
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  packages/smoothui/pages/auth/magic-link:
+    dependencies:
+      '@repo/shadcn-ui':
+        specifier: workspace:*
+        version: link:../../../../shadcn-ui
+      '@repo/smooth-button':
+        specifier: workspace:*
+        version: link:../../../components/smooth-button
+      lucide-react:
+        specifier: ^0.545.0
+        version: 0.545.0(react@19.2.5)
+      motion:
+        specifier: ^11.15.0
+        version: 11.18.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: ^19.2.1
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.1
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../../../../typescript-config
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
+  packages/smoothui/pages/auth/signup-1:
+    dependencies:
+      '@repo/shadcn-ui':
+        specifier: workspace:*
+        version: link:../../../../shadcn-ui
+      '@repo/smooth-button':
+        specifier: workspace:*
+        version: link:../../../components/smooth-button
+      lucide-react:
+        specifier: ^0.545.0
+        version: 0.545.0(react@19.2.5)
+      motion:
+        specifier: ^11.15.0
+        version: 11.18.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      react:
+        specifier: ^19.2.1
+        version: 19.2.5
+      react-dom:
+        specifier: ^19.2.1
+        version: 19.2.5(react@19.2.5)
+    devDependencies:
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../../../../typescript-config
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/typescript-config: {}
 
 packages:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,3 +4,4 @@ packages:
   - "packages/smoothui/components/*"
   - "packages/smoothui/blocks/*/*"
   - "packages/smoothui/blocks/shared"
+  - "packages/smoothui/pages/*/*"


### PR DESCRIPTION
## Summary

Introduces a new **`pages/`** concept in `packages/smoothui/`, sibling to `components/` and `blocks/`, for **full-page templates** that don't compose as sections. Ships the first category — **authentication** — with 4 drop-in login/signup screens.

**Why now:** shoogle.dev (our #2 traffic source at 381 visitors) just added an **Authentication** category that's mostly empty. First-mover advantage.

## The scaling model

```
packages/smoothui/
├── components/   atomic primitives (73 existing)
├── blocks/       composable sections (cta, hero, footer...) — unchanged
├── pages/        NEW: full-page templates (auth today, dashboard/landing next)
└── templates/    reserved: future PRO tier (multi-page bundles)
```

Pages **can compose blocks** via workspace refs — so a future `pages/landing/landing-1` will install `@repo/hero-1`, `@repo/cta-1`, `@repo/footer-1` etc. automatically through pnpm. The `templates/` tier (later) bundles multiple pages: _saas-starter_ = landing + auth + dashboard installed as one `npx shadcn add` command.

## The 4 auth pages

| Variant | Pattern | Inspired by |
|---|---|---|
| **`pages/auth/login-1`** | Centered card, stacked Google/Apple/GitHub OAuth + email fallback | ChatGPT, Perplexity, Gemini (full-page, not modal) |
| **`pages/auth/login-2`** | Split-screen: form + animated product preview + testimonial | Sana AI, Vercel, Linear |
| **`pages/auth/magic-link`** | Two-state passwordless: input → "Check your email" crossfade | Notion, Linear |
| **`pages/auth/signup-1`** | Name/email/password + live password strength + terms gating | Mirror of login-1 |

All `min-h-screen` full-page layouts — **no modals**. All respect `useReducedMotion`, use spring animations (`bounce: 0.1`, `duration: 0.25`), and ship with accessible form markup.

Design research sourced from **98 trending login screens on Mobbin** (Sana AI, GitBook, ChatGPT, Perplexity, Gemini, Vapi, Chatbase, Manus, etc.) — AI apps dominate the login trends right now.

## Integration

- `pnpm-workspace.yaml` — add `packages/smoothui/pages/*/*` glob
- `packages/smoothui/pages/index.ts` — barrel for page categories
- `apps/docs/content/docs/pages/{auth.mdx,meta.json}` — new Pages section with SEO-heavy frontmatter targeting login/signup/OAuth/passwordless/magic-link keywords
- `apps/docs/app/(home)/docs/page.tsx` — add 4th card ("Pages") to `/docs` portal
- `apps/docs/examples/{login-1,login-2,magic-link,signup-1}.tsx` — preview route stubs
- `.gitignore` — add `drafts/` + `node-compile-cache/` (local-only)

## Verification

- ✅ `pnpm build` — 2/2 tasks successful, all 4 previews prerendered at `/blocks/preview/{login-1,login-2,magic-link,signup-1}` (34-40KB each)
- ✅ `/docs/pages/auth` page prerendered with full MDX content
- ✅ `/docs` landing shows 4 cards now (Documentation, Components, Blocks, Pages)
- ✅ `pnpm test` — 106/106 tests pass
- ✅ HTML spot-checks: "Welcome back", "Sign in to your account", "Sign in with magic link", "Create your account", "Terms" all present in respective prerenders

## Test plan

- [ ] CI green (Lint, Test, Build, Vercel)
- [ ] Vercel preview: visit `/docs/pages/auth` and the 4 `/blocks/preview/*` routes
- [ ] Confirm `/docs` landing displays 4 cards responsively
- [ ] Check that `npx shadcn add @smoothui/login-1` resolves cleanly against the registry (post-merge, once live)

## Follow-ups (not in this PR)

- Submit `smoothui.dev` manually to shoogle.dev if their crawler misses the new `pages/` registry entries
- Consider `pages/dashboard/` and `pages/landing/` as next categories
- Reserve `@smoothui/saas-starter` as the first `templates/` bundle for the future PRO tier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added six full-page authentication templates: centered login, split-screen login, two creative/editorial login variants, passwordless magic-link sign‑in, and a centered sign‑up form. All include OAuth buttons, accessible inputs, spring-style entrance animations with reduced‑motion support; sign‑up includes password strength feedback and terms-gated submit.

* **Documentation**
  * Added a new "Pages" docs section with an Authentication page showcasing previews and installation guidance for the templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->