### PR TITLE
fix(deps): migrate pnpm overrides to pnpm-workspace.yaml

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,43 +66,6 @@
   },
   "packageManager": "pnpm@11.1.2",
   "type": "module",
-  "pnpm": {
-    "overrides": {
-      "react": "^19.2.1",
-      "react-dom": "^19.2.1",
-      "shiki": "^4.0.2",
-      "@shikijs/types": "^4.0.2",
-      "glob": ">=10.5.0",
-      "@types/react": "^19.2.7",
-      "@types/react-dom": "^19.2.3",
-      "csstype": "^3.2.3",
-      "lodash": ">=4.18.0",
-      "qs": ">=6.14.2",
-      "diff": ">=8.0.3",
-      "@isaacs/brace-expansion": ">=5.0.1",
-      "@modelcontextprotocol/sdk": ">=1.26.0",
-      "mdast-util-to-hast": ">=13.2.1",
-      "rollup": ">=4.59.0",
-      "minimatch": ">=10.2.3",
-      "ajv": ">=8.18.0",
-      "hono": ">=4.12.18",
-      "@hono/node-server": ">=1.19.13",
-      "fast-uri": ">=3.1.2",
-      "ip-address": ">=10.1.1",
-      "postcss@<8.5.10": ">=8.5.10",
-      "body-parser": ">=2.2.1",
-      "js-yaml": ">=4.1.1",
-      "@octokit/request": ">=8.4.1",
-      "@octokit/plugin-paginate-rest": ">=9.2.2",
-      "@octokit/request-error": ">=5.1.1",
-      "picomatch": ">=4.0.4",
-      "path-to-regexp": ">=8.4.0",
-      "brace-expansion": ">=5.0.5",
-      "yaml": ">=2.8.3",
-      "vite": ">=7.3.2",
-      "lodash-es": ">=4.18.0"
-    }
-  },
   "lint-staged": {
     "*.{ts,tsx,js,jsx}": [
       "biome check --write"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,41 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  react: ^19.2.1
+  react-dom: ^19.2.1
+  shiki: ^4.0.2
+  '@shikijs/types': ^4.0.2
+  glob: '>=10.5.0'
+  '@types/react': ^19.2.7
+  '@types/react-dom': ^19.2.3
+  csstype: ^3.2.3
+  lodash: '>=4.18.0'
+  qs: '>=6.14.2'
+  diff: '>=8.0.3'
+  '@isaacs/brace-expansion': '>=5.0.1'
+  '@modelcontextprotocol/sdk': '>=1.26.0'
+  mdast-util-to-hast: '>=13.2.1'
+  rollup: '>=4.59.0'
+  minimatch: '>=10.2.3'
+  ajv: '>=8.18.0'
+  hono: '>=4.12.18'
+  '@hono/node-server': '>=1.19.13'
+  fast-uri: '>=3.1.2'
+  ip-address: '>=10.1.1'
+  postcss@<8.5.10: '>=8.5.10'
+  body-parser: '>=2.2.1'
+  js-yaml: '>=4.1.1'
+  '@octokit/request': '>=8.4.1'
+  '@octokit/plugin-paginate-rest': '>=9.2.2'
+  '@octokit/request-error': '>=5.1.1'
+  picomatch: '>=4.0.4'
+  path-to-regexp: '>=8.4.0'
+  brace-expansion: '>=5.0.5'
+  yaml: '>=2.8.3'
+  vite: '>=7.3.2'
+  lodash-es: '>=4.18.0'
+
 importers:
 
   .:
@@ -109,7 +144,7 @@ importers:
         specifier: ^16.8.11
         version: 16.8.11(@tailwindcss/oxide@4.3.0)(@types/mdx@2.0.13)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(fumadocs-core@16.8.11(@mdx-js/mdx@3.1.1)(@orama/core@1.2.19)(@types/estree-jsx@1.0.5)(@types/hast@3.0.4)(@types/mdast@4.0.4)(@types/react@19.2.14)(lucide-react@0.555.0(react@19.2.6))(next@16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(zod@3.25.76))(next@16.2.6(@babel/core@7.29.0)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(tailwindcss@4.3.0)
       glob:
-        specifier: ^13.0.6
+        specifier: '>=10.5.0'
         version: 13.0.6
       jszip:
         specifier: ^3.10.1
@@ -206,7 +241,7 @@ importers:
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       postcss:
-        specifier: ^8.5.6
+        specifier: '>=8.5.10'
         version: 8.5.14
       tailwindcss:
         specifier: ^4.1.17
@@ -263,13 +298,13 @@ importers:
         specifier: latest
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-day-picker:
         specifier: 9.14.0
         version: 9.14.0(react@19.2.6)
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
       react-hook-form:
         specifier: ^7.65.0
@@ -297,10 +332,10 @@ importers:
         specifier: workspace:*
         version: link:../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
 
   packages/smoothui:
@@ -315,19 +350,19 @@ importers:
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       jsdom:
         specifier: ^29.0.2
         version: 29.1.1(@noble/hashes@1.8.0)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
       typescript:
         specifier: ^5.9.3
@@ -351,20 +386,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -385,20 +420,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -416,20 +451,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -447,20 +482,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -475,20 +510,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -506,20 +541,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -537,20 +572,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -565,20 +600,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -593,20 +628,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -624,20 +659,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -652,20 +687,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -683,20 +718,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -717,20 +752,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -748,20 +783,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -779,20 +814,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -810,20 +845,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -841,20 +876,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -872,20 +907,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -903,20 +938,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -931,20 +966,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -956,20 +991,20 @@ importers:
         specifier: workspace:*
         version: link:../../../../shadcn-ui
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -984,20 +1019,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1009,20 +1044,20 @@ importers:
         specifier: workspace:*
         version: link:../../../../shadcn-ui
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1037,20 +1072,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1068,20 +1103,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1099,20 +1134,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1130,20 +1165,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1170,20 +1205,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1198,20 +1233,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1229,20 +1264,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1260,20 +1295,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1291,20 +1326,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1322,20 +1357,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1356,20 +1391,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1390,20 +1425,20 @@ importers:
         specifier: ^11.15.0
         version: 11.18.2(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1415,20 +1450,20 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1446,20 +1481,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1480,20 +1515,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1508,20 +1543,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1536,20 +1571,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1564,20 +1599,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1598,20 +1633,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1626,20 +1661,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1654,20 +1689,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1682,20 +1717,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1713,20 +1748,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1741,20 +1776,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1769,20 +1804,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1800,20 +1835,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1837,20 +1872,20 @@ importers:
         specifier: ^11.0.3
         version: 11.0.5
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1868,20 +1903,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1899,20 +1934,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1930,10 +1965,10 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
       usehooks-ts:
         specifier: ^3.1.1
@@ -1943,10 +1978,10 @@ importers:
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1964,20 +1999,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -1992,20 +2027,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2023,20 +2058,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2054,20 +2089,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2085,20 +2120,20 @@ importers:
         specifier: ^1.4.2
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2116,20 +2151,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2150,20 +2185,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2178,20 +2213,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2206,20 +2241,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2234,20 +2269,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2268,20 +2303,20 @@ importers:
         specifier: latest
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2299,20 +2334,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2327,20 +2362,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2355,20 +2390,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2386,20 +2421,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2417,20 +2452,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2445,20 +2480,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2473,20 +2508,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2504,20 +2539,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2535,20 +2570,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2563,20 +2598,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2591,20 +2626,20 @@ importers:
         specifier: ^3.12.0
         version: 3.15.0
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2619,20 +2654,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2650,10 +2685,10 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
       react-use-measure:
         specifier: ^2.1.0
@@ -2663,10 +2698,10 @@ importers:
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2681,10 +2716,10 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
       react-use-measure:
         specifier: ^2.1.0
@@ -2694,10 +2729,10 @@ importers:
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2715,20 +2750,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2743,10 +2778,10 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
       usehooks-ts:
         specifier: ^3.1.1
@@ -2756,10 +2791,10 @@ importers:
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2780,20 +2815,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2808,20 +2843,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2836,20 +2871,20 @@ importers:
         specifier: ^0.545.0
         version: 0.545.0(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2870,20 +2905,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2901,20 +2936,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2932,20 +2967,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2957,20 +2992,20 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -2988,20 +3023,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -3019,20 +3054,20 @@ importers:
         specifier: ^1.4.2
         version: 1.4.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -3047,20 +3082,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -3078,20 +3113,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -3112,20 +3147,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -3137,20 +3172,20 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -3165,20 +3200,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -3193,20 +3228,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -3221,20 +3256,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -3252,20 +3287,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -3283,20 +3318,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -3308,20 +3343,20 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -3333,20 +3368,20 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -3364,20 +3399,20 @@ importers:
         specifier: ^0.7.1
         version: 0.7.1
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -3392,20 +3427,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -3417,20 +3452,20 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -3442,10 +3477,10 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
       react-tweet:
         specifier: ^3.3.0
@@ -3455,10 +3490,10 @@ importers:
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -3470,20 +3505,20 @@ importers:
         specifier: workspace:*
         version: link:../../../shadcn-ui
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -3504,20 +3539,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -3532,20 +3567,20 @@ importers:
         specifier: ^12.23.25
         version: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6
       react-dom:
-        specifier: ^19.2.0
+        specifier: ^19.2.1
         version: 19.2.6(react@19.2.6)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
         version: link:../../../typescript-config
       '@types/react':
-        specifier: ^19.2.2
+        specifier: ^19.2.7
         version: 19.2.14
       '@types/react-dom':
-        specifier: ^19.2.1
+        specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.14)
       typescript:
         specifier: ^5.9.3
@@ -4206,8 +4241,8 @@ packages:
   '@floating-ui/react-dom@2.1.8':
     resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
     peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
+      react: ^19.2.1
+      react-dom: ^19.2.1
 
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
@@ -4227,7 +4262,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: '>=4.12.18'
 
   '@hookform/resolvers@5.2.2':
     resolution: {integrity: sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==}
@@ -4552,8 +4587,9 @@ packages:
   '@octokit/core@3.6.0':
     resolution: {integrity: sha512-7RKRKuA4xTjMhY+eG3jthb3hlZCsOwg3rztWh75Xc+ShDWOfDDATWbeZpAHBNRpm4Tv9WgBMOy1zEJYXG6NJ7Q==}
 
-  '@octokit/endpoint@6.0.12':
-    resolution: {integrity: sha512-lF3puPwkQWGfkMClXb4k/eUT/nZKQfxinRWJrdZaJO85Dqwo/G0yOC434Jr2ojwafWJMYqFGFa5ms4jJUgujdA==}
+  '@octokit/endpoint@11.0.3':
+    resolution: {integrity: sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==}
+    engines: {node: '>= 20'}
 
   '@octokit/graphql@4.8.0':
     resolution: {integrity: sha512-0gv+qLSBLKF0z8TKaSKTsS39scVKF9dbMxJpj3U0vC7wjNWFuIpL/z76Qe2fiuCbDRcJSavkXsVtMS6/dtQQsg==}
@@ -4561,13 +4597,17 @@ packages:
   '@octokit/openapi-types@12.11.0':
     resolution: {integrity: sha512-VsXyi8peyRq9PqIz/tpqiL2w3w80OgVMwBHltTml3LmVvXiphgeqmY9mvBw9Wu7e0QWk/fqD37ux8yP5uVekyQ==}
 
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
   '@octokit/plugin-enterprise-compatibility@1.3.0':
     resolution: {integrity: sha512-h34sMGdEOER/OKrZJ55v26ntdHb9OPfR1fwOx6Q4qYyyhWA104o11h9tFxnS/l41gED6WEI41Vu2G2zHDVC5lQ==}
 
-  '@octokit/plugin-paginate-rest@2.21.3':
-    resolution: {integrity: sha512-aCZTEf0y2h3OLbrgKkrfFdjRL6eSOo8komneVQJnYecAxIej7Bafor2xhuDJOIFau4pk0i/P28/XgtbyPF0ZHw==}
+  '@octokit/plugin-paginate-rest@14.0.0':
+    resolution: {integrity: sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==}
+    engines: {node: '>= 20'}
     peerDependencies:
-      '@octokit/core': '>=2'
+      '@octokit/core': '>=6'
 
   '@octokit/plugin-request-log@1.0.4':
     resolution: {integrity: sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==}
@@ -4587,14 +4627,19 @@ packages:
     peerDependencies:
       '@octokit/core': ^3.5.0
 
-  '@octokit/request-error@2.1.0':
-    resolution: {integrity: sha512-1VIvgXxs9WHSjicsRwq8PlR2LR2x6DwsJAaFgzdi0JfJoGSO8mYI/cHJQ+9FbN21aa+DrgNLnwObmyeSC8Rmpg==}
+  '@octokit/request-error@7.1.0':
+    resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
+    engines: {node: '>= 20'}
 
-  '@octokit/request@5.6.3':
-    resolution: {integrity: sha512-bFJl0I1KVc9jYTe9tdGGpAMPy32dLBXXo1dS/YwSCTL/2nd9XeHsY616RE3HPXDVk+a+dBuzyz5YdlXwcDTr2A==}
+  '@octokit/request@10.0.9':
+    resolution: {integrity: sha512-o8Bi3f608eyM+7BmBiUWxFsdjLb3/ym1cQek5LZOv9KkZcxRrHCPhhRzm6xjO6HVZ85ItD6+sTsjxo821SVa/A==}
+    engines: {node: '>= 20'}
 
   '@octokit/rest@18.12.0':
     resolution: {integrity: sha512-gDPiOHlyGavxr72y0guQEhLsemgVjwRePayJ+FcKc2SJqKUbxbkvf5kAZEWA/MKvsfYlQAMVzNJE3ezQcxMJ2Q==}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
 
   '@octokit/types@6.41.0':
     resolution: {integrity: sha512-eJ2jbzjdijiL3B4PrSQaSjuF2sPEQPVCPzBvTHJD9Nz+9dw2SGH4K4xeQJ77YfTq5bRQ+bD8wT11JbeDPmxmGg==}
@@ -4890,10 +4935,10 @@ packages:
   '@radix-ui/react-accessible-icon@1.1.7':
     resolution: {integrity: sha512-XM+E4WXl0OqUJFovy6GjmxxFyx9opfCAIUku4dlKRd5YEPqt4kALOkQOp0Of6reHuUkJuiPBEc5k0o4z4lTC8A==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -4903,10 +4948,10 @@ packages:
   '@radix-ui/react-accordion@1.2.12':
     resolution: {integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -4916,10 +4961,10 @@ packages:
   '@radix-ui/react-alert-dialog@1.1.15':
     resolution: {integrity: sha512-oTVLkEw5GpdRe29BqJ0LSDFWI3qu0vR1M0mUkOQWDIUnY/QIkLpgDMWuKxP94c2NAC2LGcgVhG1ImF3jkZ5wXw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -4929,10 +4974,10 @@ packages:
   '@radix-ui/react-arrow@1.1.7':
     resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -4942,10 +4987,10 @@ packages:
   '@radix-ui/react-aspect-ratio@1.1.7':
     resolution: {integrity: sha512-Yq6lvO9HQyPwev1onK1daHCHqXVLzPhSVjmsNjCa2Zcxy2f7uJD2itDtxknv6FzAKCwD1qQkeVDmX/cev13n/g==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -4955,10 +5000,10 @@ packages:
   '@radix-ui/react-avatar@1.1.10':
     resolution: {integrity: sha512-V8piFfWapM5OmNCXTzVQY+E1rDa53zY+MQ4Y7356v4fFz6vqCyUtIz2rUD44ZEdwg78/jKmMJHj07+C/Z/rcog==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -4968,10 +5013,10 @@ packages:
   '@radix-ui/react-checkbox@1.3.3':
     resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -4981,10 +5026,10 @@ packages:
   '@radix-ui/react-collapsible@1.1.12':
     resolution: {integrity: sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -4994,10 +5039,10 @@ packages:
   '@radix-ui/react-collection@1.1.7':
     resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5007,8 +5052,8 @@ packages:
   '@radix-ui/react-compose-refs@1.1.2':
     resolution: {integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==}
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5016,10 +5061,10 @@ packages:
   '@radix-ui/react-context-menu@2.2.16':
     resolution: {integrity: sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5029,8 +5074,8 @@ packages:
   '@radix-ui/react-context@1.1.2':
     resolution: {integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==}
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5038,10 +5083,10 @@ packages:
   '@radix-ui/react-dialog@1.1.15':
     resolution: {integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5051,8 +5096,8 @@ packages:
   '@radix-ui/react-direction@1.1.1':
     resolution: {integrity: sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==}
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5060,10 +5105,10 @@ packages:
   '@radix-ui/react-dismissable-layer@1.1.11':
     resolution: {integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5073,10 +5118,10 @@ packages:
   '@radix-ui/react-dropdown-menu@2.1.16':
     resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5086,8 +5131,8 @@ packages:
   '@radix-ui/react-focus-guards@1.1.3':
     resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5095,10 +5140,10 @@ packages:
   '@radix-ui/react-focus-scope@1.1.7':
     resolution: {integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5108,10 +5153,10 @@ packages:
   '@radix-ui/react-form@0.1.8':
     resolution: {integrity: sha512-QM70k4Zwjttifr5a4sZFts9fn8FzHYvQ5PiB19O2HsYibaHSVt9fH9rzB0XZo/YcM+b7t/p7lYCT/F5eOeF5yQ==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5121,10 +5166,10 @@ packages:
   '@radix-ui/react-hover-card@1.1.15':
     resolution: {integrity: sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5134,13 +5179,13 @@ packages:
   '@radix-ui/react-icons@1.3.2':
     resolution: {integrity: sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==}
     peerDependencies:
-      react: ^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc
+      react: ^19.2.1
 
   '@radix-ui/react-id@1.1.1':
     resolution: {integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==}
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5148,10 +5193,10 @@ packages:
   '@radix-ui/react-label@2.1.7':
     resolution: {integrity: sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5161,10 +5206,10 @@ packages:
   '@radix-ui/react-menu@2.1.16':
     resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5174,10 +5219,10 @@ packages:
   '@radix-ui/react-menubar@1.1.16':
     resolution: {integrity: sha512-EB1FktTz5xRRi2Er974AUQZWg2yVBb1yjip38/lgwtCVRd3a+maUoGHN/xs9Yv8SY8QwbSEb+YrxGadVWbEutA==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5187,10 +5232,10 @@ packages:
   '@radix-ui/react-navigation-menu@1.2.14':
     resolution: {integrity: sha512-YB9mTFQvCOAQMHU+C/jVl96WmuWeltyUEpRJJky51huhds5W2FQr1J8D/16sQlf0ozxkPK8uF3niQMdUwZPv5w==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5200,10 +5245,10 @@ packages:
   '@radix-ui/react-one-time-password-field@0.1.8':
     resolution: {integrity: sha512-ycS4rbwURavDPVjCb5iS3aG4lURFDILi6sKI/WITUMZ13gMmn/xGjpLoqBAalhJaDk8I3UbCM5GzKHrnzwHbvg==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5213,10 +5258,10 @@ packages:
   '@radix-ui/react-password-toggle-field@0.1.3':
     resolution: {integrity: sha512-/UuCrDBWravcaMix4TdT+qlNdVwOM1Nck9kWx/vafXsdfj1ChfhOdfi3cy9SGBpWgTXwYCuboT/oYpJy3clqfw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5226,10 +5271,10 @@ packages:
   '@radix-ui/react-popover@1.1.15':
     resolution: {integrity: sha512-kr0X2+6Yy/vJzLYJUPCZEc8SfQcf+1COFoAqauJm74umQhta9M7lNJHP7QQS3vkvcGLQUbWpMzwrXYwrYztHKA==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5239,10 +5284,10 @@ packages:
   '@radix-ui/react-popper@1.2.8':
     resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5252,10 +5297,10 @@ packages:
   '@radix-ui/react-portal@1.1.9':
     resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5265,10 +5310,10 @@ packages:
   '@radix-ui/react-presence@1.1.5':
     resolution: {integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5278,10 +5323,10 @@ packages:
   '@radix-ui/react-primitive@2.1.3':
     resolution: {integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5291,10 +5336,10 @@ packages:
   '@radix-ui/react-primitive@2.1.4':
     resolution: {integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5304,10 +5349,10 @@ packages:
   '@radix-ui/react-progress@1.1.7':
     resolution: {integrity: sha512-vPdg/tF6YC/ynuBIJlk1mm7Le0VgW6ub6J2UWnTQ7/D23KXcPI1qy+0vBkgKgd38RCMJavBXpB83HPNFMTb0Fg==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5317,10 +5362,10 @@ packages:
   '@radix-ui/react-radio-group@1.3.8':
     resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5330,10 +5375,10 @@ packages:
   '@radix-ui/react-roving-focus@1.1.11':
     resolution: {integrity: sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5343,10 +5388,10 @@ packages:
   '@radix-ui/react-scroll-area@1.2.10':
     resolution: {integrity: sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5356,10 +5401,10 @@ packages:
   '@radix-ui/react-select@2.2.6':
     resolution: {integrity: sha512-I30RydO+bnn2PQztvo25tswPH+wFBjehVGtmagkU78yMdwTwVf12wnAOF+AeP8S2N8xD+5UPbGhkUfPyvT+mwQ==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5369,10 +5414,10 @@ packages:
   '@radix-ui/react-separator@1.1.7':
     resolution: {integrity: sha512-0HEb8R9E8A+jZjvmFCy/J4xhbXy3TV+9XSnGJ3KvTtjlIUy/YQ/p6UYZvi7YbeoeXdyU9+Y3scizK6hkY37baA==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5382,10 +5427,10 @@ packages:
   '@radix-ui/react-slider@1.3.6':
     resolution: {integrity: sha512-JPYb1GuM1bxfjMRlNLE+BcmBC8onfCi60Blk7OBqi2MLTFdS+8401U4uFjnwkOr49BLmXxLC6JHkvAsx5OJvHw==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5395,8 +5440,8 @@ packages:
   '@radix-ui/react-slot@1.2.3':
     resolution: {integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==}
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5404,8 +5449,8 @@ packages:
   '@radix-ui/react-slot@1.2.4':
     resolution: {integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==}
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5413,10 +5458,10 @@ packages:
   '@radix-ui/react-switch@1.2.6':
     resolution: {integrity: sha512-bByzr1+ep1zk4VubeEVViV592vu2lHE2BZY5OnzehZqOOgogN80+mNtCqPkhn2gklJqOpxWgPoYTSnhBCqpOXQ==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5426,10 +5471,10 @@ packages:
   '@radix-ui/react-tabs@1.1.13':
     resolution: {integrity: sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5439,10 +5484,10 @@ packages:
   '@radix-ui/react-toast@1.2.15':
     resolution: {integrity: sha512-3OSz3TacUWy4WtOXV38DggwxoqJK4+eDkNMl5Z/MJZaoUPaP4/9lf81xXMe1I2ReTAptverZUpbPY4wWwWyL5g==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5452,10 +5497,10 @@ packages:
   '@radix-ui/react-toggle-group@1.1.11':
     resolution: {integrity: sha512-5umnS0T8JQzQT6HbPyO7Hh9dgd82NmS36DQr+X/YJ9ctFNCiiQd6IJAYYZ33LUwm8M+taCz5t2ui29fHZc4Y6Q==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5465,10 +5510,10 @@ packages:
   '@radix-ui/react-toggle@1.1.10':
     resolution: {integrity: sha512-lS1odchhFTeZv3xwHH31YPObmJn8gOg7Lq12inrr0+BH/l3Tsq32VfjqH1oh80ARM3mlkfMic15n0kg4sD1poQ==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5478,10 +5523,10 @@ packages:
   '@radix-ui/react-toolbar@1.1.11':
     resolution: {integrity: sha512-4ol06/1bLoFu1nwUqzdD4Y5RZ9oDdKeiHIsntug54Hcr1pgaHiPqHFEaXI1IFP/EsOfROQZ8Mig9VTIRza6Tjg==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5491,10 +5536,10 @@ packages:
   '@radix-ui/react-tooltip@1.2.8':
     resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5504,8 +5549,8 @@ packages:
   '@radix-ui/react-use-callback-ref@1.1.1':
     resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5513,8 +5558,8 @@ packages:
   '@radix-ui/react-use-controllable-state@1.2.2':
     resolution: {integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==}
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5522,8 +5567,8 @@ packages:
   '@radix-ui/react-use-effect-event@0.0.2':
     resolution: {integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==}
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5531,8 +5576,8 @@ packages:
   '@radix-ui/react-use-escape-keydown@1.1.1':
     resolution: {integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==}
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5540,8 +5585,8 @@ packages:
   '@radix-ui/react-use-is-hydrated@0.1.0':
     resolution: {integrity: sha512-U+UORVEq+cTnRIaostJv9AGdV3G6Y+zbVd+12e18jQ5A3c0xL03IhnHuiU4UV69wolOQp5GfR58NW/EgdQhwOA==}
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5549,8 +5594,8 @@ packages:
   '@radix-ui/react-use-layout-effect@1.1.1':
     resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5558,8 +5603,8 @@ packages:
   '@radix-ui/react-use-previous@1.1.1':
     resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5567,8 +5612,8 @@ packages:
   '@radix-ui/react-use-rect@1.1.1':
     resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5576,8 +5621,8 @@ packages:
   '@radix-ui/react-use-size@1.1.1':
     resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5585,10 +5630,10 @@ packages:
   '@radix-ui/react-visually-hidden@1.2.3':
     resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -5901,10 +5946,10 @@ packages:
     engines: {node: '>=18'}
     peerDependencies:
       '@testing-library/dom': ^10.0.0
-      '@types/react': ^18.0.0 || ^19.0.0
-      '@types/react-dom': ^18.0.0 || ^19.0.0
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -6040,7 +6085,7 @@ packages:
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
-      '@types/react': ^19.2.0
+      '@types/react': ^19.2.7
 
   '@types/react@19.2.14':
     resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
@@ -6074,7 +6119,7 @@ packages:
       '@remix-run/react': ^2
       '@sveltejs/kit': ^1 || ^2
       next: '>= 13'
-      react: ^18 || ^19 || ^19.0.0-rc
+      react: ^19.2.1
       svelte: '>= 4'
       vue: ^3
       vue-router: ^4
@@ -6100,7 +6145,7 @@ packages:
       '@sveltejs/kit': ^1 || ^2
       next: '>= 13'
       nuxt: '>= 3'
-      react: ^18 || ^19 || ^19.0.0-rc
+      react: ^19.2.1
       svelte: '>= 4'
       vue: ^3
       vue-router: ^4
@@ -6127,7 +6172,7 @@ packages:
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
     peerDependencies:
       msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+      vite: '>=7.3.2'
     peerDependenciesMeta:
       msw:
         optional: true
@@ -6181,7 +6226,7 @@ packages:
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
-      ajv: ^8.0.0
+      ajv: '>=8.18.0'
     peerDependenciesMeta:
       ajv:
         optional: true
@@ -6446,8 +6491,8 @@ packages:
   cmdk@1.1.1:
     resolution: {integrity: sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg==}
     peerDependencies:
-      react: ^18 || ^19 || ^19.0.0-rc
-      react-dom: ^18 || ^19 || ^19.0.0-rc
+      react: ^19.2.1
+      react-dom: ^19.2.1
 
   code-block-writer@13.0.3:
     resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
@@ -6732,19 +6777,15 @@ packages:
     resolution: {integrity: sha512-92bDj/dHqWDa/OIgogxwUxli7XSWYkibd+rCOXlNKzHawjX98+B1oF4+3cXXOqsKzro2cL0ItZ5Vhmm9hfCDXw==}
     peerDependencies:
       motion: '>=11.0.0'
-      react: '>=18.0.0'
-      react-dom: '>=18.0.0'
+      react: ^19.2.1
+      react-dom: ^19.2.1
 
   dialkit@0.2.2:
     resolution: {integrity: sha512-uISIFKHuZp6cRk8vFHRSrcIK3JUH3/g7JKn4Tms/xjUJYAEB1aKh/GR9ytNN6e2hOjsKs6tOF60wjXCrlJ4zhg==}
     peerDependencies:
       motion: '>=11.0.0'
-      react: '>=18.0.0'
-      react-dom: '>=18.0.0'
-
-  diff@4.0.4:
-    resolution: {integrity: sha512-X07nttJQkwkfKfvTPG/KSnE2OMdcUCao6+eXF3wmnIQRn2aPAHH3VxDbDOdegkd6JbPsXqShpvEOHfAT+nCNwQ==}
-    engines: {node: '>=0.3.1'}
+      react: ^19.2.1
+      react-dom: ^19.2.1
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
@@ -6787,7 +6828,7 @@ packages:
   embla-carousel-react@8.6.0:
     resolution: {integrity: sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react: ^19.2.1
 
   embla-carousel-reactive-utils@8.6.0:
     resolution: {integrity: sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==}
@@ -6979,6 +7020,9 @@ packages:
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
 
+  fast-content-type-parse@3.0.0:
+    resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -7012,7 +7056,7 @@ packages:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
     peerDependencies:
-      picomatch: ^3 || ^4
+      picomatch: '>=4.0.4'
     peerDependenciesMeta:
       picomatch:
         optional: true
@@ -7063,8 +7107,8 @@ packages:
     resolution: {integrity: sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@emotion/is-prop-valid':
         optional: true
@@ -7077,8 +7121,8 @@ packages:
     resolution: {integrity: sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@emotion/is-prop-valid':
         optional: true
@@ -7117,13 +7161,13 @@ packages:
       '@types/estree-jsx': '*'
       '@types/hast': '*'
       '@types/mdast': '*'
-      '@types/react': '*'
+      '@types/react': ^19.2.7
       algoliasearch: 5.x.x
       flexsearch: '*'
       lucide-react: '*'
       next: 16.x.x
-      react: ^19.2.0
-      react-dom: ^19.2.0
+      react: ^19.2.1
+      react-dom: ^19.2.1
       react-router: 7.x.x
       waku: '*'
       zod: 4.x.x
@@ -7189,12 +7233,12 @@ packages:
     peerDependencies:
       '@types/mdast': '*'
       '@types/mdx': '*'
-      '@types/react': '*'
+      '@types/react': ^19.2.7
       fumadocs-core: ^15.0.0 || ^16.0.0
       mdast-util-directive: '*'
       next: ^15.3.0 || ^16.0.0
-      react: ^19.2.0
-      vite: 6.x.x || 7.x.x || 8.x.x
+      react: ^19.2.1
+      vite: '>=7.3.2'
     peerDependenciesMeta:
       '@types/mdast':
         optional: true
@@ -7214,12 +7258,12 @@ packages:
   fumadocs-twoslash@3.2.0:
     resolution: {integrity: sha512-hzoxc2HR9dw2z5T1NNLYCbMY1DFiSF71+X2KJS4t/BalRyiBxpCcP9zAyzofba07YkrGhZ6xW3B105EcpNI2Vw==}
     peerDependencies:
-      '@types/react': '*'
+      '@types/react': ^19.2.7
       fumadocs-core: ^16.7.16
       fumadocs-ui: ^16.7.16
-      react: ^19.2.0
-      react-dom: ^19.2.0
-      shiki: 4.x.x
+      react: ^19.2.1
+      react-dom: ^19.2.1
+      shiki: ^4.0.2
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -7230,11 +7274,11 @@ packages:
       '@types/estree': '*'
       '@types/hast': '*'
       '@types/mdast': '*'
-      '@types/react': '*'
+      '@types/react': ^19.2.7
       fumadocs-core: ^16.7.0
       fumadocs-ui: ^16.7.0
-      react: ^19.2.0
-      react-dom: ^19.2.0
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/estree':
         optional: true
@@ -7252,11 +7296,11 @@ packages:
     peerDependencies:
       '@takumi-rs/image-response': '*'
       '@types/mdx': '*'
-      '@types/react': '*'
+      '@types/react': ^19.2.7
       fumadocs-core: 16.8.11
       next: 16.x.x
-      react: ^19.2.0
-      react-dom: ^19.2.0
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@takumi-rs/image-response':
         optional: true
@@ -7518,8 +7562,8 @@ packages:
   input-otp@1.4.2:
     resolution: {integrity: sha512-l3jWwYNvrEa6NTCt7BECfCm48GvwuZzkoeG3gBL2w4CHeOXW3eKFmf9UNYkNfYc3mxMrthMnxjIE07MT0zLBQA==}
     peerDependencies:
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react: ^19.2.1
+      react-dom: ^19.2.1
 
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
@@ -7792,6 +7836,9 @@ packages:
   json-schema-typed@8.0.2:
     resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
+  json-with-bigint@3.5.8:
+    resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -7971,37 +8018,37 @@ packages:
   lucide-react@0.468.0:
     resolution: {integrity: sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==}
     peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
+      react: ^19.2.1
 
   lucide-react@0.469.0:
     resolution: {integrity: sha512-28vvUnnKQ/dBwiCQtwJw7QauYnE7yd2Cyp4tTTJpvglX4EMpbflcdBgrgToX2j71B3YvugK/NH3BGUk+E/p/Fw==}
     peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.1
 
   lucide-react@0.474.0:
     resolution: {integrity: sha512-CmghgHkh0OJNmxGKWc0qfPJCYHASPMVSyGY8fj3xgk4v84ItqDg64JNKFZn5hC6E0vHi6gxnbCgwhyVB09wQtA==}
     peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.1
 
   lucide-react@0.545.0:
     resolution: {integrity: sha512-7r1/yUuflQDSt4f1bpn5ZAocyIxcTyVyBBChSVtBKn5M+392cPmI5YJMWOJKk/HUWGm5wg83chlAZtCcGbEZtw==}
     peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.1
 
   lucide-react@0.548.0:
     resolution: {integrity: sha512-63b16z63jM9yc1MwxajHeuu0FRZFsDtljtDjYm26Kd86UQ5HQzu9ksEtoUUw4RBuewodw/tGFmvipePvRsKeDA==}
     peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.1
 
   lucide-react@0.555.0:
     resolution: {integrity: sha512-D8FvHUGbxWBRQM90NZeIyhAvkFfsh3u9ekrMvJ30Z6gnpBHS6HC6ldLg7tL45hwiIz/u66eKDtdA23gwwGsAHA==}
     peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.1
 
   lucide-react@1.16.0:
     resolution: {integrity: sha512-dYwyPzb4MEKpGUmNYk3WKWPnMrHs3FKM+q94kAnJrcDIqqn1hq2xY8scaS2ovsOCM5D51ey2gaRG3PBb1vgoYQ==}
     peerDependencies:
-      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.1
 
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
@@ -8255,8 +8302,8 @@ packages:
     resolution: {integrity: sha512-JLjvFDuFr42NFtcVoMAyC2sEjnpA8xpy6qWPyzQvCloznAyQ8FIXioxWfHiLtgYhoVpfUqSWpn1h9++skj9+Wg==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@emotion/is-prop-valid':
         optional: true
@@ -8269,8 +8316,8 @@ packages:
     resolution: {integrity: sha512-uYfXzeHlgThchzwz5Te47dlv5JOUC7OB4rjJ/7XTUgtBZD8CchMN8qEJ4ZVsUmTyYA44zjV0fBwsiktRuFnn+w==}
     peerDependencies:
       '@emotion/is-prop-valid': '*'
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@emotion/is-prop-valid':
         optional: true
@@ -8318,8 +8365,8 @@ packages:
   next-themes@0.4.6:
     resolution: {integrity: sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==}
     peerDependencies:
-      react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react: ^19.2.1
+      react-dom: ^19.2.1
 
   next@16.2.6:
     resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
@@ -8329,8 +8376,8 @@ packages:
       '@opentelemetry/api': ^1.1.0
       '@playwright/test': ^1.51.1
       babel-plugin-react-compiler: '*'
-      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
-      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react: ^19.2.1
+      react-dom: ^19.2.1
       sass: ^1.3.0
     peerDependenciesMeta:
       '@opentelemetry/api':
@@ -8530,9 +8577,6 @@ packages:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
 
-  path-to-regexp@6.3.0:
-    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
-
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
@@ -8549,10 +8593,6 @@ packages:
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
-
-  picomatch@2.3.2:
-    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
-    engines: {node: '>=8.6'}
 
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
@@ -8589,9 +8629,9 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
+      postcss: '>=8.5.10'
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: '>=2.8.3'
     peerDependenciesMeta:
       jiti:
         optional: true
@@ -8606,15 +8646,11 @@ packages:
     resolution: {integrity: sha512-5osppouFc0VR9/VYzYxO03VaDa3e8F23Kfd6/9qcZTUI8P58GIYlArOET2Wq0ywSl2o2PjELhYOFI4W7l5QHKw==}
     engines: {node: '>=18.0'}
     peerDependencies:
-      postcss: ^8.2.14
+      postcss: '>=8.5.10'
 
   postcss-selector-parser@7.1.1:
     resolution: {integrity: sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==}
     engines: {node: '>=4'}
-
-  postcss@8.4.31:
-    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
@@ -8667,10 +8703,10 @@ packages:
   radix-ui@1.4.3:
     resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
     peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      '@types/react-dom': ^19.2.3
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -8693,18 +8729,18 @@ packages:
     resolution: {integrity: sha512-tBaoDWjPwe0M5pGrum4H0SR6Lyk+BO9oHnp9JbKpGKW2mlraNPgP9BMfsg5pWpwrssARmeqk7YBl2oXutZTaHA==}
     engines: {node: '>=18'}
     peerDependencies:
-      react: '>=16.8.0'
+      react: ^19.2.1
 
   react-dom@19.2.6:
     resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
     peerDependencies:
-      react: ^19.2.6
+      react: ^19.2.1
 
   react-hook-form@7.76.0:
     resolution: {integrity: sha512-eKtLGgFeSgkHqQD8J59AMZ9a4uD1D83iSIzt4YlTGD7liDen5rrjcUO1rVIGd9yC1gofryjtHbv+4ny4hkLWlw==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
-      react: ^16.8.0 || ^17 || ^18 || ^19
+      react: ^19.2.1
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -8719,8 +8755,8 @@ packages:
     resolution: {integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      '@types/react': ^19.2.7
+      react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -8729,8 +8765,8 @@ packages:
     resolution: {integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -8738,21 +8774,21 @@ packages:
   react-resizable-panels@4.11.1:
     resolution: {integrity: sha512-kA4w58V6wYdRLm2rg9pzroZwGlqBLul1FjMP0J8kqTo3zSHtjeH+LXmZaldCo6+HWqs1e5hOcPoajKXdOze37Q==}
     peerDependencies:
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
+      react: ^19.2.1
+      react-dom: ^19.2.1
 
   react-smooth@4.0.4:
     resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.1
+      react-dom: ^19.2.1
 
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -8760,20 +8796,20 @@ packages:
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
     peerDependencies:
-      react: '>=16.6.0'
-      react-dom: '>=16.6.0'
+      react: ^19.2.1
+      react-dom: ^19.2.1
 
   react-tweet@3.3.0:
     resolution: {integrity: sha512-gSIG2169ZK7UH6rBzuU+j1xnQbH3IlOTLEkuGrRiJJTMgETik+h+26yHyyVKrLkzwrOaYPk4K3OtEKycqKgNLw==}
     peerDependencies:
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
+      react: ^19.2.1
+      react-dom: ^19.2.1
 
   react-use-measure@2.1.7:
     resolution: {integrity: sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==}
     peerDependencies:
-      react: '>=16.13'
-      react-dom: '>=16.13'
+      react: ^19.2.1
+      react-dom: ^19.2.1
     peerDependenciesMeta:
       react-dom:
         optional: true
@@ -8804,8 +8840,8 @@ packages:
     resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
     engines: {node: '>=14'}
     peerDependencies:
-      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
-      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.1
+      react-dom: ^19.2.1
 
   recma-build-jsx@1.0.0:
     resolution: {integrity: sha512-8GtdyqaBcDfva+GUKDr3nev3VpKAhup1+RvkMvUxURHpW7QyIvk9F5wz7Vzo06CEMSilw6uArgRqhpiUcWp8ew==}
@@ -9059,8 +9095,8 @@ packages:
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
     peerDependencies:
-      react: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
-      react-dom: ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      react: ^19.2.1
+      react-dom: ^19.2.1
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -9185,7 +9221,7 @@ packages:
     peerDependencies:
       '@babel/core': '*'
       babel-plugin-macros: '*'
-      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+      react: ^19.2.1
     peerDependenciesMeta:
       '@babel/core':
         optional: true
@@ -9212,7 +9248,7 @@ packages:
   swr@2.4.1:
     resolution: {integrity: sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA==}
     peerDependencies:
-      react: ^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.1
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -9364,7 +9400,7 @@ packages:
     peerDependencies:
       '@microsoft/api-extractor': ^7.36.0
       '@swc/core': ^1
-      postcss: ^8.4.12
+      postcss: '>=8.5.10'
       typescript: '>=4.5.0'
     peerDependenciesMeta:
       '@microsoft/api-extractor':
@@ -9484,6 +9520,9 @@ packages:
   universal-user-agent@6.0.1:
     resolution: {integrity: sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==}
 
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -9508,8 +9547,8 @@ packages:
     resolution: {integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -9518,8 +9557,8 @@ packages:
     resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
     engines: {node: '>=10'}
     peerDependencies:
-      '@types/react': '*'
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+      '@types/react': ^19.2.7
+      react: ^19.2.1
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -9527,13 +9566,13 @@ packages:
   use-sync-external-store@1.6.0:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react: ^19.2.1
 
   usehooks-ts@3.1.1:
     resolution: {integrity: sha512-I4diPp9Cq6ieSUH2wu+fDAVQO43xwtulo+fKEidHUwZPnYImbtkTjzIJYcDcJqxgmX31GVqNFURodvcgHcW0pA==}
     engines: {node: '>=16.15.0'}
     peerDependencies:
-      react: ^16.8.0  || ^17 || ^18 || ^19 || ^19.0.0-rc
+      react: ^19.2.1
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -9552,8 +9591,8 @@ packages:
   vaul@1.1.2:
     resolution: {integrity: sha512-ZFkClGpWyI2WUQjdLJ/BaGuV6AVQiJ3uELGk3OYtP+B6yCO7Cmn9vPFXVJkRaGkOJu3m8bQMgtyzNHixULceQA==}
     peerDependencies:
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+      react: ^19.2.1
+      react-dom: ^19.2.1
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -9587,7 +9626,7 @@ packages:
       sugarss: ^5.0.0
       terser: ^5.16.0
       tsx: ^4.8.1
-      yaml: ^2.4.2
+      yaml: '>=2.8.3'
     peerDependenciesMeta:
       '@types/node':
         optional: true
@@ -9750,10 +9789,6 @@ packages:
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
-
-  yaml@1.10.3:
-    resolution: {integrity: sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==}
-    engines: {node: '>= 6'}
 
   yaml@2.9.0:
     resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
@@ -10694,39 +10729,36 @@ snapshots:
     dependencies:
       '@octokit/auth-token': 2.5.0
       '@octokit/graphql': 4.8.0
-      '@octokit/request': 5.6.3
-      '@octokit/request-error': 2.1.0
+      '@octokit/request': 10.0.9
+      '@octokit/request-error': 7.1.0
       '@octokit/types': 6.41.0
       before-after-hook: 2.2.3
       universal-user-agent: 6.0.1
-    transitivePeerDependencies:
-      - encoding
 
-  '@octokit/endpoint@6.0.12':
+  '@octokit/endpoint@11.0.3':
     dependencies:
-      '@octokit/types': 6.41.0
-      is-plain-object: 5.0.0
-      universal-user-agent: 6.0.1
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
 
   '@octokit/graphql@4.8.0':
     dependencies:
-      '@octokit/request': 5.6.3
+      '@octokit/request': 10.0.9
       '@octokit/types': 6.41.0
       universal-user-agent: 6.0.1
-    transitivePeerDependencies:
-      - encoding
 
   '@octokit/openapi-types@12.11.0': {}
 
+  '@octokit/openapi-types@27.0.0': {}
+
   '@octokit/plugin-enterprise-compatibility@1.3.0':
     dependencies:
-      '@octokit/request-error': 2.1.0
+      '@octokit/request-error': 7.1.0
       '@octokit/types': 6.41.0
 
-  '@octokit/plugin-paginate-rest@2.21.3(@octokit/core@3.6.0)':
+  '@octokit/plugin-paginate-rest@14.0.0(@octokit/core@3.6.0)':
     dependencies:
       '@octokit/core': 3.6.0
-      '@octokit/types': 6.41.0
+      '@octokit/types': 16.0.0
 
   '@octokit/plugin-request-log@1.0.4(@octokit/core@3.6.0)':
     dependencies:
@@ -10749,31 +10781,30 @@ snapshots:
       '@octokit/types': 6.41.0
       bottleneck: 2.19.5
 
-  '@octokit/request-error@2.1.0':
+  '@octokit/request-error@7.1.0':
     dependencies:
-      '@octokit/types': 6.41.0
-      deprecation: 2.3.1
-      once: 1.4.0
+      '@octokit/types': 16.0.0
 
-  '@octokit/request@5.6.3':
+  '@octokit/request@10.0.9':
     dependencies:
-      '@octokit/endpoint': 6.0.12
-      '@octokit/request-error': 2.1.0
-      '@octokit/types': 6.41.0
-      is-plain-object: 5.0.0
-      node-fetch: 2.6.7
-      universal-user-agent: 6.0.1
-    transitivePeerDependencies:
-      - encoding
+      '@octokit/endpoint': 11.0.3
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      content-type: 2.0.0
+      fast-content-type-parse: 3.0.0
+      json-with-bigint: 3.5.8
+      universal-user-agent: 7.0.3
 
   '@octokit/rest@18.12.0':
     dependencies:
       '@octokit/core': 3.6.0
-      '@octokit/plugin-paginate-rest': 2.21.3(@octokit/core@3.6.0)
+      '@octokit/plugin-paginate-rest': 14.0.0(@octokit/core@3.6.0)
       '@octokit/plugin-request-log': 1.0.4(@octokit/core@3.6.0)
       '@octokit/plugin-rest-endpoint-methods': 5.16.2(@octokit/core@3.6.0)
-    transitivePeerDependencies:
-      - encoding
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
 
   '@octokit/types@6.41.0':
     dependencies:
@@ -12481,7 +12512,7 @@ snapshots:
       import-fresh: 3.3.1
       parse-json: 5.2.0
       path-type: 4.0.0
-      yaml: 1.10.3
+      yaml: 2.9.0
 
   cosmiconfig@9.0.1(typescript@5.9.3):
     dependencies:
@@ -12651,8 +12682,6 @@ snapshots:
       motion: 12.38.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
-
-  diff@4.0.4: {}
 
   diff@8.0.4: {}
 
@@ -13025,6 +13054,8 @@ snapshots:
       - supports-color
 
   extend@3.0.2: {}
+
+  fast-content-type-parse@3.0.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -13886,6 +13917,8 @@ snapshots:
 
   json-schema-typed@8.0.2: {}
 
+  json-with-bigint@3.5.8: {}
+
   json5@2.2.3: {}
 
   jsonc-parser@3.3.1: {}
@@ -14546,7 +14579,7 @@ snapshots:
   micromatch@4.0.8:
     dependencies:
       braces: 3.0.3
-      picomatch: 2.3.2
+      picomatch: 4.0.4
 
   mime-db@1.54.0: {}
 
@@ -14618,7 +14651,7 @@ snapshots:
       headers-polyfill: 5.0.1
       is-node-process: 1.2.0
       outvariant: 1.4.3
-      path-to-regexp: 6.3.0
+      path-to-regexp: 8.4.2
       picocolors: 1.1.1
       rettime: 0.11.11
       statuses: 2.0.2
@@ -14657,7 +14690,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.10.30
       caniuse-lite: 1.0.30001792
-      postcss: 8.4.31
+      postcss: 8.5.14
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.6)
@@ -14902,8 +14935,6 @@ snapshots:
       lru-cache: 11.3.6
       minipass: 7.1.3
 
-  path-to-regexp@6.3.0: {}
-
   path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
@@ -14913,8 +14944,6 @@ snapshots:
   pathval@2.0.1: {}
 
   picocolors@1.1.1: {}
-
-  picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
 
@@ -14961,12 +14990,6 @@ snapshots:
     dependencies:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
-
-  postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.12
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.14:
     dependencies:
@@ -15948,7 +15971,7 @@ snapshots:
       acorn-walk: 8.3.5
       arg: 4.1.3
       create-require: 1.1.1
-      diff: 4.0.4
+      diff: 8.0.4
       make-error: 1.3.6
       typescript: 5.9.3
       v8-compile-cache-lib: 3.0.1
@@ -15958,7 +15981,7 @@ snapshots:
     dependencies:
       arg: 4.1.3
       create-require: 1.1.1
-      diff: 4.0.4
+      diff: 8.0.4
       make-error: 1.3.6
       source-map-support: 0.5.21
       typescript: 5.9.3
@@ -16147,6 +16170,8 @@ snapshots:
       unist-util-visit-parents: 6.0.2
 
   universal-user-agent@6.0.1: {}
+
+  universal-user-agent@7.0.3: {}
 
   universalify@2.0.1: {}
 
@@ -16450,8 +16475,6 @@ snapshots:
   y18n@5.0.8: {}
 
   yallist@3.1.1: {}
-
-  yaml@1.10.3: {}
 
   yaml@2.9.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,7 +4,43 @@ packages:
   - "packages/smoothui/components/*"
   - "packages/smoothui/blocks/*/*"
   - "packages/smoothui/blocks/shared"
+
 allowBuilds:
   esbuild: true
   msw: true
   sharp: true
+
+overrides:
+  react: "^19.2.1"
+  react-dom: "^19.2.1"
+  shiki: "^4.0.2"
+  "@shikijs/types": "^4.0.2"
+  glob: ">=10.5.0"
+  "@types/react": "^19.2.7"
+  "@types/react-dom": "^19.2.3"
+  csstype: "^3.2.3"
+  lodash: ">=4.18.0"
+  qs: ">=6.14.2"
+  diff: ">=8.0.3"
+  "@isaacs/brace-expansion": ">=5.0.1"
+  "@modelcontextprotocol/sdk": ">=1.26.0"
+  mdast-util-to-hast: ">=13.2.1"
+  rollup: ">=4.59.0"
+  minimatch: ">=10.2.3"
+  ajv: ">=8.18.0"
+  hono: ">=4.12.18"
+  "@hono/node-server": ">=1.19.13"
+  fast-uri: ">=3.1.2"
+  ip-address: ">=10.1.1"
+  "postcss@<8.5.10": ">=8.5.10"
+  body-parser: ">=2.2.1"
+  js-yaml: ">=4.1.1"
+  "@octokit/request": ">=8.4.1"
+  "@octokit/plugin-paginate-rest": ">=9.2.2"
+  "@octokit/request-error": ">=5.1.1"
+  picomatch: ">=4.0.4"
+  path-to-regexp: ">=8.4.0"
+  brace-expansion: ">=5.0.5"
+  yaml: ">=2.8.3"
+  vite: ">=7.3.2"
+  lodash-es: ">=4.18.0"


### PR DESCRIPTION
## Why

pnpm 11+ **silently ignores** `pnpm.overrides` defined inside `package.json` at the workspace root. The block parses without error but has no effect on dependency resolution — so every one of the 33 security overrides added in prior sweeps was dead config and the underlying CVEs were still live in `node_modules`.

## What

Moved the entire `pnpm.overrides` block (33 entries) from `package.json` into `pnpm-workspace.yaml` at top level, which is the supported location in pnpm 11+. Removed the now-empty `pnpm` block from `package.json`. Existing `allowBuilds:` map in workspace yaml left intact.

## Verification

- `pnpm install --no-frozen-lockfile` regenerated the lockfile.
- `pnpm install --frozen-lockfile` passes.
- `pnpm run build` passes (turbo build across all packages).
- `pnpm-lock.yaml` now contains a top-level `overrides:` block (previously missing). Resolved versions reflect each override (e.g. `ip-address@10.2.0`, `fast-uri` upgraded, `picomatch >= 4.0.4`).

## Notes

Same migration applied across the rest of the portfolio repos that received overrides in earlier security sweeps. No app code changes — config only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized workspace dependency version override configurations to ensure consistent dependency resolution and build stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/educlopez/smoothui/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->