### PR TITLE
fix(tweet-card): guard against tweets with missing entity arrays

### DIFF
--- a/packages/smoothui/components/tweet-card/index.tsx
+++ b/packages/smoothui/components/tweet-card/index.tsx
@@ -261,7 +261,21 @@ export const SmoothTweet = ({
   userInfoPosition?: "top" | "bottom";
   avatarRounded?: string;
 }) => {
-  const enrichedTweet = enrichTweet(tweet);
+  // react-tweet's enrichTweet iterates over each entity array without
+  // guarding for undefined. The syndication API can omit arrays (e.g.
+  // symbols/user_mentions) for some tweets, which would throw
+  // "entities is not iterable" and crash the whole tree. Normalize first.
+  const safeTweet: Tweet = {
+    ...tweet,
+    entities: {
+      hashtags: tweet.entities?.hashtags ?? [],
+      symbols: tweet.entities?.symbols ?? [],
+      urls: tweet.entities?.urls ?? [],
+      user_mentions: tweet.entities?.user_mentions ?? [],
+      ...(tweet.entities?.media ? { media: tweet.entities.media } : {}),
+    },
+  };
+  const enrichedTweet = enrichTweet(safeTweet);
   const userInfo = (
     <TweetHeader avatarRounded={avatarRounded} tweet={enrichedTweet} />
   );


### PR DESCRIPTION
## Problem
`smoothui.dev` homepage crashed with **"This page couldn't load"** — client error `Uncaught TypeError: r is not iterable` (minified).

Real error: **`entities is not iterable`** at `packages/smoothui/components/tweet-card/index.tsx` → `enrichTweet(tweet)`.

react-tweet@3.3.0's `getEntities` runs `for (const entity of tweet.entities.X)` with no undefined guard. The Twitter syndication API can omit an entity array (e.g. `symbols` / `user_mentions`) for some tweets, which throws during render. The homepage testimonials (`WhatTheySay → MediaPlayer → ClientTweetCard → SmoothTweet`) call `enrichTweet` directly with no surrounding error boundary, so the whole page died.

## Fix
Normalize `tweet.entities` into a `safeTweet` with empty-array defaults before calling `enrichTweet`. Defensive against any partial or deleted tweet, not just the current offender.

## Verification
Reproduced locally in dev (Next 16.2.6): homepage hit the root error boundary. After the fix, homepage loads, **7 tweets render, 0 not-found**, no console error. `tsc` clean for the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed tweet card crashes when API responses omit optional data fields
* Improved component resilience by normalizing incoming data to ensure all required structures are properly initialized
* Enhanced overall application stability when rendering tweets from syndication sources with variable data completeness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->