### PR TITLE
ci: add pnpm lockfile supply-chain audit gate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,35 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lockfile-audit:
+    name: Lockfile Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # Supply-chain gate: pnpm-lock.yaml must only resolve from the registry
+      # over HTTPS with integrity hashes. lockfile-lint does not support pnpm
+      # lockfiles, so we assert the invariants directly. Package integrity
+      # (SHA-512) and lockfile/manifest drift are already enforced by the
+      # `pnpm install --frozen-lockfile` step in the other jobs.
+      - name: Validate pnpm-lock.yaml (HTTPS-only, no exotic sources)
+        run: |
+          set -euo pipefail
+          fail=0
+          if grep -nE 'resolution:.*http://' pnpm-lock.yaml; then
+            echo "::error::Insecure http:// resolution found in pnpm-lock.yaml"
+            fail=1
+          fi
+          if grep -nE 'resolution:[[:space:]]*\{[[:space:]]*(tarball|git|directory):' pnpm-lock.yaml; then
+            echo "::error::Exotic (git/tarball/directory) resolution found in pnpm-lock.yaml"
+            fail=1
+          fi
+          if [ "$fail" -eq 0 ]; then
+            echo "pnpm-lock.yaml OK: registry-only, HTTPS, no git/tarball sources."
+          fi
+          exit "$fail"
+
   lint:
     name: Lint
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What
Adds a `Lockfile Audit` CI job that fails if `pnpm-lock.yaml` contains:
- insecure `http://` resolutions, or
- exotic `git` / `tarball` / `directory` sources (registry-bypass).

## Why
Closes the lockfile-validation gap (practices #6–8 of the supply-chain baseline). `lockfile-lint` only supports npm/yarn lockfiles — it errors on pnpm with `Unable to find relevant lockfile parser for type "pnpm"` — so this asserts the same invariants directly. Package integrity (SHA-512) and lockfile/manifest drift are already enforced by `pnpm install --frozen-lockfile` in the existing jobs.

## Verification
Ran the gate locally against the current lockfile: `pnpm-lock.yaml OK` (0 insecure, 0 exotic), exit 0. YAML lints clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened CI/build pipeline with additional lockfile validation checks to ensure proper dependency management and security standards across the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->