### PR TITLE
chore(deps): bump qs override to >=6.15.2 (GHSA-q8mj-m7cp-5q26)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,7 @@ overrides:
   '@types/react-dom': ^19.2.3
   csstype: ^3.2.3
   lodash: '>=4.18.0'
-  qs: '>=6.14.2'
+  qs: '>=6.15.2'
   diff: '>=8.0.3'
   '@isaacs/brace-expansion': '>=5.0.1'
   '@modelcontextprotocol/sdk': '>=1.26.0'
@@ -8693,8 +8693,8 @@ packages:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
-  qs@6.15.1:
-    resolution: {integrity: sha512-6YHEFRL9mfgcAvql/XhwTvf5jKcOiiupt2FiJxHkiX1z4j7WL8J/jRHYLluORvc1XxB5rV20KoeK00gVJamspg==}
+  qs@6.15.2:
+    resolution: {integrity: sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -8839,6 +8839,7 @@ packages:
   recharts@2.15.4:
     resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
     engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
     peerDependencies:
       react: ^19.2.1
       react-dom: ^19.2.1
@@ -12307,7 +12308,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.15.1
+      qs: 6.15.2
       raw-body: 3.0.2
       type-is: 2.1.0
     transitivePeerDependencies:
@@ -13042,7 +13043,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.15.1
+      qs: 6.15.2
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -15035,7 +15036,7 @@ snapshots:
 
   punycode@2.3.1: {}
 
-  qs@6.15.1:
+  qs@6.15.2:
     dependencies:
       side-channel: 1.1.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,7 @@ overrides:
   "@types/react-dom": "^19.2.3"
   csstype: "^3.2.3"
   lodash: ">=4.18.0"
-  qs: ">=6.14.2"
+  qs: ">=6.15.2"
   diff: ">=8.0.3"
   "@isaacs/brace-expansion": ">=5.0.1"
   "@modelcontextprotocol/sdk": ">=1.26.0"


### PR DESCRIPTION
Resolves Dependabot alert #155.

`qs` resolved to 6.15.1 via the existing `>=6.14.2` override — still inside the vulnerable range (`>= 6.11.1, <= 6.15.1`).

**Advisory:** GHSA-q8mj-m7cp-5q26 — remotely triggerable DoS: `qs.stringify` crashes with TypeError on null/undefined entries in comma-format arrays when `encodeValuesOnly` is set. Patched in 6.15.2.

## Changes
- `pnpm-workspace.yaml`: override `qs: ">=6.14.2"` → `">=6.15.2"`
- `pnpm-lock.yaml`: regenerated, qs@6.15.1 → qs@6.15.2 (transitive)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency version constraint to ensure compatibility with newer package releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->