### PR TITLE
fix(ci): remove illegal ../ changelog-path from release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -20,8 +20,7 @@
   ],
   "packages": {
     "packages/smoothui": {
-      "package-name": "smoothui",
-      "changelog-path": "../../CHANGELOG.md"
+      "package-name": "smoothui"
     }
   }
 }


### PR DESCRIPTION
The release-please workflow fails on every push to main with:

```
release-please failed: illegal pathing characters in path: packages/smoothui/../../CHANGELOG.md
```

release-please v4 rejects `..` in `changelog-path` (manifest mode can't write outside the package directory). The setting was added in the v3.4.0 setup commit and never ran clean.

## Fix
Removed `changelog-path` so the changelog defaults to `packages/smoothui/CHANGELOG.md` — standard monorepo behavior. No CHANGELOG.md exists yet, so nothing to migrate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->