### PR TITLE
Refactor resizable handle styles and update preview layout

### DIFF
--- a/apps/docs/components/preview/content.tsx
+++ b/apps/docs/components/preview/content.tsx
@@ -147,19 +147,13 @@ export const PreviewContent = ({
     <div
       className={cn(
         "flex",
-        "h-full",
         "w-full",
         "flex-col",
-        type === "component"
-          ? "size-full"
-          : `h-auto min-h-[${BLOCK_PREVIEW_MIN_HEIGHT_REM}rem]`
+        type === "block" && `h-auto min-h-[${BLOCK_PREVIEW_MIN_HEIGHT_REM}rem]`
       )}
     >
       <ResizablePanelGroup
-        className={cn(
-          "flex-1",
-          type === "component" ? "size-full" : "h-auto w-full"
-        )}
+        className={cn("w-full", "h-auto")}
         defaultLayout={{
           "preview-panel": panel1Size,
           "spacer-panel": panel2Size,
@@ -201,7 +195,7 @@ export const PreviewContent = ({
               title={`${blockPath ?? "block"} preview`}
             />
           ) : (
-            <div className="h-full w-full overflow-hidden">{children}</div>
+            <div className="w-full overflow-hidden">{children}</div>
           )}
         </ResizablePanel>
         <ResizableHandle

--- a/apps/docs/components/preview/content.tsx
+++ b/apps/docs/components/preview/content.tsx
@@ -8,8 +8,6 @@ import {
 import { cn } from "@repo/shadcn-ui/lib/utils";
 import type { ReactNode } from "react";
 import { useEffect, useMemo, useRef, useState } from "react";
-// biome-ignore lint/style/useImportType: used as generic type parameter only
-import { type PanelImperativeHandle } from "react-resizable-panels";
 
 interface PreviewContentProps {
   blockPath?: string;
@@ -20,15 +18,13 @@ interface PreviewContentProps {
 
 export type PreviewSize = "desktop" | "tablet" | "mobile";
 
-const SIZE_TO_PERCENT: Record<PreviewSize, number> = {
+const PANEL1_SIZE: Record<PreviewSize, number> = {
   desktop: 100,
-  tablet: 60,
-  mobile: 30,
+  tablet: 62,
+  mobile: 35,
 };
 
 const BLOCK_PREVIEW_MIN_HEIGHT_REM = 32;
-const COMPONENT_PANEL_MIN_SIZE = 40;
-const BLOCK_PANEL_MIN_SIZE = 30;
 const IFRAME_MIN_HEIGHT_REM = 32;
 const REM_IN_PX = 16;
 const BLOCK_PREVIEW_MIN_HEIGHT_PX = BLOCK_PREVIEW_MIN_HEIGHT_REM * REM_IN_PX;
@@ -78,7 +74,6 @@ export const PreviewContent = ({
   blockPath,
   size = "desktop",
 }: PreviewContentProps) => {
-  const resizablePanelRef = useRef<PanelImperativeHandle | null>(null);
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const blockIdRef = useRef<string | undefined>(blockPath);
   const [blockHeight, setBlockHeight] = useState<number>(
@@ -97,11 +92,6 @@ export const PreviewContent = ({
   useEffect(() => {
     if (type !== "block") {
       return;
-    }
-
-    const percentage = SIZE_TO_PERCENT[size] ?? SIZE_TO_PERCENT.desktop;
-    if (resizablePanelRef.current) {
-      resizablePanelRef.current.resize(percentage);
     }
 
     if (iframeRef.current?.contentWindow) {
@@ -149,6 +139,10 @@ export const PreviewContent = ({
     return `/blocks/preview/${blockPath}`;
   }, [blockPath, type]);
 
+  const panel1Size = PANEL1_SIZE[size] ?? PANEL1_SIZE.desktop;
+  const panel2Size = 100 - panel1Size;
+  const isDesktop = size === "desktop";
+
   return (
     <div
       className={cn(
@@ -166,6 +160,11 @@ export const PreviewContent = ({
           "flex-1",
           type === "component" ? "size-full" : "h-auto w-full"
         )}
+        defaultLayout={{
+          "preview-panel": panel1Size,
+          "spacer-panel": panel2Size,
+        }}
+        key={size}
         orientation="horizontal"
       >
         <ResizablePanel
@@ -173,22 +172,16 @@ export const PreviewContent = ({
             "bg-background",
             "not-fumadocs-codeblock",
             "not-prose",
-            "peer",
             type === "component"
-              ? cn("overflow-hidden!", "size-full")
+              ? "overflow-hidden!"
               : cn(
                   "h-auto",
                   "overflow-hidden!",
-                  "w-full",
                   `min-h-[${BLOCK_PREVIEW_MIN_HEIGHT_REM}rem]`
                 )
           )}
-          defaultSize={100}
-          maxSize={100}
-          minSize={
-            type === "block" ? BLOCK_PANEL_MIN_SIZE : COMPONENT_PANEL_MIN_SIZE
-          }
-          panelRef={type === "block" ? resizablePanelRef : undefined}
+          id="preview-panel"
+          minSize="45%"
         >
           {type === "block" && iframeSrc ? (
             <iframe
@@ -208,17 +201,16 @@ export const PreviewContent = ({
               title={`${blockPath ?? "block"} preview`}
             />
           ) : (
-            children
+            <div className="h-full w-full overflow-hidden">{children}</div>
           )}
         </ResizablePanel>
         <ResizableHandle
-          className="peer-data-[panel-size=100.0]:w-0"
+          className={isDesktop ? "hidden" : undefined}
           withHandle
         />
         <ResizablePanel
           className={cn("bg-background", "border-none")}
-          defaultSize={0}
-          maxSize={70}
+          id="spacer-panel"
           minSize={0}
         />
       </ResizablePanelGroup>

--- a/apps/docs/components/preview/shell.tsx
+++ b/apps/docs/components/preview/shell.tsx
@@ -72,20 +72,14 @@ export const PreviewShell = ({
   return (
     <div
       className={cn(
-        "not-prose size-full overflow-hidden rounded-lg border bg-background",
+        "not-prose w-full overflow-hidden rounded-lg border bg-background",
         type === "block" &&
           "h-auto min-h-[32rem] prose-code:border-none prose-code:p-0",
-        type === "component" && "h-[32rem]",
+        type === "component" && "max-h-[32rem]",
         className
       )}
     >
-      <Tabs
-        className={cn(
-          "flex flex-col gap-0",
-          type === "component" ? "h-full" : "h-auto"
-        )}
-        defaultValue="preview"
-      >
+      <Tabs className="flex flex-col gap-0" defaultValue="preview">
         <div className="flex flex-col gap-2 border-b bg-muted/30 px-3 py-2 sm:flex-row sm:items-center sm:justify-between">
           <TabsList className="flex h-9 items-center gap-1 rounded-md bg-transparent p-0 shadow-none">
             <TabsTrigger value="preview">
@@ -157,8 +151,6 @@ export const PreviewShell = ({
         <TabsContent
           className={cn(
             "bg-background",
-            type === "component" ? "flex-1" : "flex-none",
-            type === "component" ? "size-full" : "h-auto",
             type === "component" ? "overflow-hidden" : "overflow-visible"
           )}
           value="preview"

--- a/apps/docs/components/preview/shell.tsx
+++ b/apps/docs/components/preview/shell.tsx
@@ -103,54 +103,56 @@ export const PreviewShell = ({
               </TabsTrigger>
             )}
           </TabsList>
-          {type === "block" && (
-            <div className="flex items-center justify-end gap-1 sm:gap-1.5">
-              <ToggleGroup
-                className="hidden gap-0.5 rounded-md border bg-background p-1 sm:flex"
-                onValueChange={(value) => {
-                  if (!value) {
-                    return;
-                  }
-                  setPreviewSize(value as PreviewSize);
-                }}
-                type="single"
-                value={previewSize}
-              >
-                {previewSizes.map(({ label, value, icon }) => (
-                  <ToggleGroupItem
-                    className="h-8 w-8 p-0 data-[state=on]:bg-fd-primary/10 data-[state=on]:text-fd-primary"
-                    key={value}
-                    title={label}
-                    value={value}
-                  >
-                    <span className="sr-only">{label}</span>
-                    {icon}
-                  </ToggleGroupItem>
-                ))}
-              </ToggleGroup>
-              <Separator
-                className="hidden h-6 sm:flex"
-                orientation="vertical"
-              />
-              {iframeSrc && (
-                <Button
-                  asChild
-                  className="h-8 w-8 rounded-md p-0"
-                  size="icon-sm"
-                  variant="ghost"
+          <div className="flex items-center justify-end gap-1 sm:gap-1.5">
+            <ToggleGroup
+              className="hidden gap-0.5 rounded-md border bg-background p-1 sm:flex"
+              onValueChange={(value) => {
+                if (!value) {
+                  return;
+                }
+                setPreviewSize(value as PreviewSize);
+              }}
+              type="single"
+              value={previewSize}
+            >
+              {previewSizes.map(({ label, value, icon }) => (
+                <ToggleGroupItem
+                  className="h-8 w-8 p-0 data-[state=on]:bg-fd-primary/10 data-[state=on]:text-fd-primary"
+                  key={value}
+                  title={label}
+                  value={value}
                 >
-                  <Link
-                    href={iframeSrc}
-                    rel="noopener noreferrer"
-                    target="_blank"
+                  <span className="sr-only">{label}</span>
+                  {icon}
+                </ToggleGroupItem>
+              ))}
+            </ToggleGroup>
+            {type === "block" && (
+              <>
+                <Separator
+                  className="hidden h-6 sm:flex"
+                  orientation="vertical"
+                />
+                {iframeSrc && (
+                  <Button
+                    asChild
+                    className="h-8 w-8 rounded-md p-0"
+                    size="icon-sm"
+                    variant="ghost"
                   >
-                    <span className="sr-only">Open preview in new tab</span>
-                    <Fullscreen className="h-4 w-4" />
-                  </Link>
-                </Button>
-              )}
-            </div>
-          )}
+                    <Link
+                      href={iframeSrc}
+                      rel="noopener noreferrer"
+                      target="_blank"
+                    >
+                      <span className="sr-only">Open preview in new tab</span>
+                      <Fullscreen className="h-4 w-4" />
+                    </Link>
+                  </Button>
+                )}
+              </>
+            )}
+          </div>
         </div>
         <TabsContent
           className={cn(

--- a/packages/shadcn-ui/components/ui/resizable.tsx
+++ b/packages/shadcn-ui/components/ui/resizable.tsx
@@ -41,7 +41,7 @@ function ResizableHandle({
   return (
     <ResizablePrimitive.Separator
       className={cn(
-        "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden",
+        "bg-border focus-visible:ring-ring relative flex w-2 cursor-col-resize touch-none select-none items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-4 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden",
         className
       )}
       data-slot="resizable-handle"


### PR DESCRIPTION
# Summary

Fixes the preview panel's responsive size toggling (desktop/tablet/mobile) which was broken due to imperative resize calls failing silently, and eliminates the blank space that appeared below component previews due to a rigid fixed-height layout chain.

# Demo 

## Before 

https://github.com/user-attachments/assets/faa71af4-e59a-419c-8cbc-ef9b4ff46311

## After

https://github.com/user-attachments/assets/d8c2bb0a-fc99-4e23-a86e-7f569a4d927d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refactored preview panel layout and sizing logic for more consistent responsive behavior.
  * Reorganized preview shell header controls, grouping size selection and fullscreen options with improved visual hierarchy.
  * Enhanced resizable handle styling with improved visual appearance and interaction feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->