### PR TITLE
fix(ci): parse the release PR number in the shell, not in the env template

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,9 +29,13 @@ jobs:
       # `--auto` rather than a straight merge: with no required checks on main it
       # merges immediately, and the day branch protection arrives it waits for
       # the checks instead of needing to be rewritten.
+      #
+      # The number is parsed in the shell, not with `fromJSON` in `env`: Actions
+      # evaluates a step's whole template before deciding whether to run it, so
+      # `fromJSON("")` on a push that releases nothing failed the job outright.
       - name: Auto-merge the release PR
         if: steps.release.outputs.pr
-        run: gh pr merge --auto --merge "$PR_NUMBER"
+        run: gh pr merge --auto --merge "$(jq -r .number <<<"$PR_JSON")"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}
+          PR_JSON: ${{ steps.release.outputs.pr }}


### PR DESCRIPTION
Actions evaluates a step's whole template before deciding whether to run it, so `fromJSON(steps.release.outputs.pr)` failed the release-please job on any push that releases nothing — the output is an empty string there and the `if:` guard never got a say.

It failed on the very first push after the auto-merge feature landed (run 30632501988). The release itself was unaffected: release-please had already done its work, and my step ran after it.

The number now comes out of `jq` inside the step, so the empty case reaches the guard instead of the parser.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation configuration to improve extraction of release metadata during the auto-merge process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->