### PR TITLE
fix(docs): give /docs its own metadata, and drop three duplicate h1s

### DIFF
--- a/apps/docs/app/(home)/docs/page.tsx
+++ b/apps/docs/app/(home)/docs/page.tsx
@@ -4,6 +4,11 @@ import Link, { type LinkProps } from "next/link";
 import { IconBooksFill24, IconPencilFill24 } from "nucleo-core-fill-24";
 
 export const metadata: Metadata = {
+  // Without these, this page inherited the root layout's title and description
+  // verbatim, so / and /docs were duplicates of each other.
+  title: "Documentation",
+  description:
+    "Guides, component reference and blocks for SmoothUI. Start with installation, then browse every animated React component.",
   alternates: {
     canonical: "/docs",
   },

--- a/apps/docs/content/docs/guides/ai-integration.mdx
+++ b/apps/docs/content/docs/guides/ai-integration.mdx
@@ -3,8 +3,6 @@ title: AI Integration
 description: SmoothUI is built for AI-assisted development. Discover components via MCP, REST API, and machine-readable catalogs.
 ---
 
-# AI Integration
-
 <BodyText>
 SmoothUI is designed from the ground up for AI-assisted development. Whether you are an AI agent selecting components programmatically, or a developer using AI coding tools, SmoothUI provides first-class integration paths.
 </BodyText>

--- a/apps/docs/content/docs/guides/api.mdx
+++ b/apps/docs/content/docs/guides/api.mdx
@@ -3,8 +3,6 @@ title: REST API
 description: Discover, search, and retrieve SmoothUI components and blocks programmatically. Designed for developers and AI agents.
 ---
 
-# REST API
-
 <BodyText>
 SmoothUI exposes a public REST API that lets you discover, search, and retrieve component metadata and source code programmatically. The API is designed for both human developers building tooling and AI agents that need structured component data.
 </BodyText>

--- a/apps/docs/content/docs/guides/mcp.mdx
+++ b/apps/docs/content/docs/guides/mcp.mdx
@@ -3,8 +3,6 @@ title: MCP Server
 description: Enable AI assistants to discover and install SmoothUI components via MCP server integration with the shadcn-compatible registry.
 ---
 
-# MCP Server
-
 <BodyText>
 MCP support for registry developers - Enable AI assistants to discover and use SmoothUI components.
 </BodyText>


### PR DESCRIPTION
Crawled all **189 sitemap URLs** against a local server, checking status, title, description and h1 count. Two real findings, both fixed here.

### `/` and `/docs` were metadata twins

`app/(home)/docs/page.tsx` set only `alternates.canonical` and inherited everything else from the root layout, so both pages shipped:

> SmoothUI - Animated React Components for shadcn/ui | Motion & Tailwind

with the same description. Two pages competing on the same terms with the same text. `/docs` now describes what it is — the portal into guides, components and blocks.

### Three guides had two `<h1>`s

`ai-integration`, `api` and `mcp` each opened with a `# Heading` in the MDX body, on top of the h1 the docs layout already renders from the frontmatter `title`. Every other guide starts at `##`; these three were the exception. Removed the redundant heading.

### Clean

- **0** pages missing a meta description, across all 189
- **no** other duplicate titles or descriptions
- **no** other pages with a wrong h1 count

### Note on the crawl

An initial parallel pass reported 126 non-200s. All of them were code `0` — my crawler timing out at 8-way concurrency against a dev server compiling on demand, not real failures. Re-checked sequentially: all 200.