### PR TITLE
ci: add secret scanning and PR-title validation

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,50 @@
+# Mirrors the shared gates in educlopez/github-actions-workflows.
+#
+# This repo is public and that one is private, and GitHub does not let a public
+# repo call a reusable workflow from a private repo — the run fails before any
+# job starts. So the steps live here. Keep them in sync with the shared repo.
+
+name: Secret Scan
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  gitleaks:
+    name: gitleaks
+    runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    steps:
+      - name: 📥 Checkout
+        uses: actions/checkout@v4
+        with:
+          # Full history so the PR commit range / full-repo scan can walk it.
+          fetch-depth: 0
+
+      - name: 📦 Install gitleaks
+        run: |
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v8.30.1/gitleaks_8.30.1_linux_x64.tar.gz" -o gitleaks.tar.gz
+          tar -xzf gitleaks.tar.gz gitleaks
+          sudo mv gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: 🕵️ Scan for secrets
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ "$EVENT" = "pull_request" ]; then
+            echo "Scanning PR commit range: ${BASE_SHA}..${HEAD_SHA}"
+            gitleaks detect --source . --redact --no-banner \
+              --log-opts="${BASE_SHA}..${HEAD_SHA}"
+          else
+            echo "Scanning full repository history"
+            gitleaks detect --source . --redact --no-banner
+          fi

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -1,0 +1,26 @@
+# Mirrors the shared gates in educlopez/github-actions-workflows.
+#
+# This repo is public and that one is private, and GitHub does not let a public
+# repo call a reusable workflow from a private repo — the run fails before any
+# job starts. So the steps live here. Keep them in sync with the shared repo.
+
+name: Semantic PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: 📝 Lint PR title against Conventional Commits
+        uses: amannn/action-semantic-pull-request@v5.5.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "postpublish": "cp README.github.md README.md && rm README.github.md",
     "build": "turbo build",
     "dev": "turbo dev",
+    "lint": "ultracite check",
     "check": "ultracite check",
     "fix": "ultracite fix",
     "test": "turbo test",


### PR DESCRIPTION
Adds the two gates this repo was missing, matching the other nine.

- **`secret-scan`** — gitleaks over the PR's commit range (full history on push).
- **`semantic-pr-title`** — Conventional Commits validation of the PR title.
- **`lint` script** aliasing `check`, so every repo answers to the same command.

The existing `test.yml` (lockfile audit, lint, typecheck, tests) is untouched.

## Why the steps are inlined
This repo is public and `educlopez/github-actions-workflows` is private. GitHub does not let a public repo call a reusable workflow from a private one: the run fails before any job starts, with no indication that visibility is the cause. Each file carries a comment saying so and pointing back to the canonical copy.

## Deliberately not in this PR
Ultracite is on 7.6.0 and Biome on 2.4.13 here, against 7.9.4 / 2.5.6 elsewhere. Bumping them reformats a large share of the tree, which would collide with the SEO work in flight. Worth doing on its own once those branches land.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Added automated security checks to detect accidentally committed secrets in code changes.
  - Added validation to ensure pull request titles follow a consistent Conventional Commits format.
  - Added a standard linting command to help identify code quality issues before changes are submitted.
  - Security and title checks run with read-only access and exclude draft pull requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->