### PR TITLE
fix(smoothui): make Dynamic Island content readable in light mode

### DIFF
--- a/packages/smoothui/components/dynamic-island/index.tsx
+++ b/packages/smoothui/components/dynamic-island/index.tsx
@@ -42,7 +42,7 @@ const DefaultIdle = () => {
       <AnimatePresence mode="wait">
         <motion.div
           animate={{ opacity: 1, scale: 1 }}
-          className="text-foreground"
+          className="text-white"
           exit={{ opacity: 0, scale: 0.8 }}
           initial={{ opacity: 0, scale: 0.8 }}
           key="storm"
@@ -72,7 +72,7 @@ const DefaultIdle = () => {
 
 // Ring Component
 const DefaultRing = () => (
-  <div className="flex w-64 items-center gap-3 overflow-hidden px-4 py-2 text-foreground">
+  <div className="flex w-64 items-center gap-3 overflow-hidden px-4 py-2 text-white">
     <Phone className="h-5 w-5 text-green-500" />
     <div className="flex-1">
       <p className="pointer-events-none font-medium text-sm text-white">
@@ -98,7 +98,7 @@ const DefaultTimer = () => {
   }, []);
 
   return (
-    <div className="flex w-64 items-center gap-3 overflow-hidden px-4 py-2 text-foreground">
+    <div className="flex w-64 items-center gap-3 overflow-hidden px-4 py-2 text-white">
       <TimerIcon className="h-5 w-5 text-amber-500" />
       <div className="flex-1">
         <p className="pointer-events-none font-medium text-sm text-white">
@@ -119,7 +119,7 @@ const DefaultTimer = () => {
 
 // Notification Component
 const Notification = () => (
-  <div className="flex w-64 items-center gap-3 overflow-hidden px-4 py-2 text-foreground">
+  <div className="flex w-64 items-center gap-3 overflow-hidden px-4 py-2 text-white">
     <Bell className="h-5 w-5 text-yellow-400" />
     <div className="flex-1">
       <p className="pointer-events-none font-medium text-sm text-white">
@@ -139,7 +139,7 @@ const Notification = () => (
 const MusicPlayer = () => {
   const [playing, setPlaying] = useState(true);
   return (
-    <div className="flex w-72 items-center gap-3 overflow-hidden px-4 py-2 text-foreground">
+    <div className="flex w-72 items-center gap-3 overflow-hidden px-4 py-2 text-white">
       <Music2 className="h-5 w-5 text-pink-500" />
       <div className="min-w-0 flex-1">
         <p className="pointer-events-none truncate font-medium text-sm text-white">


### PR DESCRIPTION
One file, five lines.

The island surface is `bg-black` in **both** themes — it imitates the iPhone notch — but five elements inside it used `text-foreground`, which resolves to near-black in light mode. Black text on a black pill: the weather label, the timer, the call and the notification copy were **invisible to anyone not in dark mode**.

Their siblings in the same component already used `text-white`, which is the right choice for a surface that never changes colour. This makes the five match.

```diff
-          className="text-foreground"
+          className="text-white"
```
×5 (lines 45, 75, 101, 122, 142)

## How it surfaced

21st.dev has kept Dynamic Island out of its public listings since April with the reviewer note *"fix colours scheme"*. Same defect, seen from outside — the component ships this way through our registry too, so it is worth fixing at source rather than only in the 21st.dev copy.

## Verification

Tests pass (`vitest run components/dynamic-island`). Diff is exactly the five class swaps — an earlier attempt accidentally staged a repo-wide biome reformat, which I discarded and redid from clean, so nothing unrelated rides along here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved visual consistency by updating Dynamic Island component text to display in white across idle, ring, timer, notification, and music states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->