### PR TITLE
fix(secret-scan): baseline the known findings and print future ones

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -42,9 +42,9 @@ jobs:
         run: |
           if [ "$EVENT" = "pull_request" ]; then
             echo "Scanning PR commit range: ${BASE_SHA}..${HEAD_SHA}"
-            gitleaks detect --source . --redact --no-banner \
+            gitleaks detect --source . --redact --no-banner --verbose \
               --log-opts="${BASE_SHA}..${HEAD_SHA}"
           else
             echo "Scanning full repository history"
-            gitleaks detect --source . --redact --no-banner
+            gitleaks detect --source . --redact --no-banner --verbose
           fi

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,13 @@
+# Known findings, reviewed and accepted. Each line is a gitleaks fingerprint:
+#   <commit>:<file>:<rule>:<line>
+#
+# These four are JWTs inside lummi.ai image-render URLs, in a demo component
+# added on 2025-01-31 and since deleted. They are third-party stock-image
+# tokens, not credentials to anything of ours, and this repository was already
+# public when they landed — so there is nothing to rotate. They are pinned here
+# rather than rewritten out of history, which would break every existing clone
+# and fork.
+6e7ac96be4f2b6963ab7c7c16b51e8b09578cc2e:src/app/doc/_components/ui/ExpandableCards.tsx:jwt:24
+6e7ac96be4f2b6963ab7c7c16b51e8b09578cc2e:src/app/doc/_components/ui/ExpandableCards.tsx:jwt:36
+6e7ac96be4f2b6963ab7c7c16b51e8b09578cc2e:src/app/doc/_components/ui/ExpandableCards.tsx:jwt:48
+6e7ac96be4f2b6963ab7c7c16b51e8b09578cc2e:src/app/doc/_components/ui/ExpandableCards.tsx:jwt:60


### PR DESCRIPTION
The full-history gitleaks scan on `main` is red. This makes it green and makes future failures diagnosable.

## What it found
Four JWTs inside **lummi.ai image-render URLs**, in `src/app/doc/_components/ui/ExpandableCards.tsx` — a demo component added on 2025-01-31 and since deleted.

They are third-party stock-image tokens, not credentials to anything of ours, and this repository was already public when they landed, so there is nothing to rotate.

## What this does
- Pins the four fingerprints in `.gitleaksignore`, each with a comment explaining why it is safe. Rewriting them out of history would break every existing clone and fork for no security gain.
- Passes `--verbose` to gitleaks. Without it the tool prints only `leaks found: 4` — the red check told us a secret existed somewhere in 761 commits and nothing else. Diagnosing it meant installing gitleaks and rerunning the scan by hand. Values stay redacted either way.

The same `--verbose` fix is already published in the shared workflows repo, so the private repos pick it up automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved secret scan output with more detailed reporting for pull requests and repository history.
  * Documented accepted findings from deleted demo content to reduce false-positive alerts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->