### PR TITLE
fix(blocks): correct the @repo/* tsconfig paths mapping

### DIFF
--- a/packages/smoothui/blocks/footers/footer-2/tsconfig.json
+++ b/packages/smoothui/blocks/footers/footer-2/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "@repo/typescript-config/react-library.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      "@repo/*": ["../../../../*"]
+    }
   },
   "include": ["."],
   "exclude": ["node_modules", "dist"]

--- a/packages/smoothui/blocks/footers/footer-3/tsconfig.json
+++ b/packages/smoothui/blocks/footers/footer-3/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@repo/*": ["../*"],
-      "@/components/*": ["../shadcn-ui/components/*"],
-      "@/lib/*": ["../shadcn-ui/lib/*"]
+      "@repo/*": ["../../../../*"]
     },
     "strictNullChecks": true
   },

--- a/packages/smoothui/blocks/headers/header-1/tsconfig.json
+++ b/packages/smoothui/blocks/headers/header-1/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "@repo/typescript-config/react-library.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      "@repo/*": ["../../../../*"]
+    }
   },
   "include": ["."],
   "exclude": ["node_modules", "dist"]

--- a/packages/smoothui/blocks/headers/header-2/tsconfig.json
+++ b/packages/smoothui/blocks/headers/header-2/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "@repo/typescript-config/react-library.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      "@repo/*": ["../../../../*"]
+    }
   },
   "include": ["."],
   "exclude": ["node_modules", "dist"]

--- a/packages/smoothui/blocks/headers/header-3/tsconfig.json
+++ b/packages/smoothui/blocks/headers/header-3/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "@repo/typescript-config/react-library.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      "@repo/*": ["../../../../*"]
+    }
   },
   "include": ["."],
   "exclude": ["node_modules", "dist"]

--- a/packages/smoothui/blocks/headers/header-4/tsconfig.json
+++ b/packages/smoothui/blocks/headers/header-4/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "@repo/typescript-config/react-library.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      "@repo/*": ["../../../../*"]
+    }
   },
   "include": ["."],
   "exclude": ["node_modules", "dist"]

--- a/packages/smoothui/blocks/logos/logo-cloud-1/tsconfig.json
+++ b/packages/smoothui/blocks/logos/logo-cloud-1/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "@repo/typescript-config/react-library.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      "@repo/*": ["../../../../*"]
+    }
   },
   "include": ["."],
   "exclude": ["node_modules", "dist"]

--- a/packages/smoothui/blocks/logos/logo-cloud-2/tsconfig.json
+++ b/packages/smoothui/blocks/logos/logo-cloud-2/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "@repo/typescript-config/react-library.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      "@repo/*": ["../../../../*"]
+    }
   },
   "include": ["."],
   "exclude": ["node_modules", "dist"]

--- a/packages/smoothui/blocks/logos/logo-cloud-3/tsconfig.json
+++ b/packages/smoothui/blocks/logos/logo-cloud-3/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@repo/*": ["../*"],
-      "@/components/*": ["../shadcn-ui/components/*"],
-      "@/lib/*": ["../shadcn-ui/lib/*"]
+      "@repo/*": ["../../../../*"]
     },
     "strictNullChecks": true
   },

--- a/packages/smoothui/blocks/logos/logo-cloud-4/tsconfig.json
+++ b/packages/smoothui/blocks/logos/logo-cloud-4/tsconfig.json
@@ -3,9 +3,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
-      "@repo/*": ["../*"],
-      "@/components/*": ["../shadcn-ui/components/*"],
-      "@/lib/*": ["../shadcn-ui/lib/*"]
+      "@repo/*": ["../../../../*"]
     },
     "strictNullChecks": true
   },

--- a/packages/smoothui/blocks/pricing/pricing-1/tsconfig.json
+++ b/packages/smoothui/blocks/pricing/pricing-1/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "@repo/typescript-config/react-library.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      "@repo/*": ["../../../../*"]
+    }
   },
   "include": ["."],
   "exclude": ["node_modules", "dist"]

--- a/packages/smoothui/blocks/pricing/pricing-2/tsconfig.json
+++ b/packages/smoothui/blocks/pricing/pricing-2/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "@repo/typescript-config/react-library.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      "@repo/*": ["../../../../*"]
+    }
   },
   "include": ["."],
   "exclude": ["node_modules", "dist"]

--- a/packages/smoothui/blocks/pricing/pricing-3/tsconfig.json
+++ b/packages/smoothui/blocks/pricing/pricing-3/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "@repo/typescript-config/react-library.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      "@repo/*": ["../../../../*"]
+    }
   },
   "include": ["."],
   "exclude": ["node_modules", "dist"]

--- a/packages/smoothui/blocks/shared/tsconfig.json
+++ b/packages/smoothui/blocks/shared/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "@repo/typescript-config/react-library.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      "@repo/*": ["../../../*"]
+    }
   },
   "include": ["."],
   "exclude": ["node_modules", "dist"]

--- a/packages/smoothui/blocks/testimonials/testimonials-2/tsconfig.json
+++ b/packages/smoothui/blocks/testimonials/testimonials-2/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "@repo/typescript-config/react-library.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      "@repo/*": ["../../../../*"]
+    }
   },
   "include": ["."],
   "exclude": ["node_modules", "dist"]

--- a/packages/smoothui/blocks/testimonials/testimonials-3/tsconfig.json
+++ b/packages/smoothui/blocks/testimonials/testimonials-3/tsconfig.json
@@ -2,7 +2,11 @@
   "extends": "@repo/typescript-config/react-library.json",
   "compilerOptions": {
     "outDir": "./dist",
-    "strictNullChecks": true
+    "strictNullChecks": true,
+    "baseUrl": ".",
+    "paths": {
+      "@repo/*": ["../../../../*"]
+    }
   },
   "include": ["."],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Follow-up to #104, which left a standing editor diagnostic in `hero-header.tsx`:

```
Cannot find module "@repo/smoothui/components/smooth-button"
```

## Root cause

`@repo/smoothui` is not a real package name — `packages/smoothui/package.json` is named plainly `smoothui`. So unlike `@repo/shadcn-ui`, which resolves through node_modules as a genuine workspace dependency, `@repo/smoothui/components/*` resolves **only** through a tsconfig `paths` mapping.

Most block tsconfigs had no mapping at all. The four that did had `["../*"]` copy-pasted from `packages/smoothui/tsconfig.json` — the right depth there, but inside a block it points at a sibling block directory.

Net effect: unresolved-module errors across **16 of 27** block tsconfigs. Editor-only, which is why this went unnoticed — `packages/smoothui/tsconfig.json` does not `include` `blocks/`, so CI typecheck never looked.

## What

Adds `"@repo/*": ["../../../../*"]` (`../../../*` for `blocks/shared`, one level shallower) to the 16 affected tsconfigs.

Drops the stale `@/components/*` and `@/lib/*` aliases from the four that carried them — blocks reach shadcn through the real `@repo/shadcn-ui` dependency, so those aliases only ever pointed at nothing.

**Import specifiers are deliberately untouched.** `apps/docs/lib/package.ts:22` rewrites `@repo/smoothui/components/` to `@/components/smoothui/`, so that specifier is load-bearing for the registry; changing it would break every generated package.

## Testing

- Unresolved `@repo/` errors across all 27 block tsconfigs: **30 before, 0 after**.
- Registry output byte-identical before and after, sampled over `header-1`, `header-4`, `shared`, `pricing-1`, `logo-cloud-3`. Expected, since `lib/package.ts` only collects `.ts`/`.tsx`/`.css` and never ships tsconfigs.
- Ran the real CLI against the local registry into a scratch project: `npx shadcn@latest add .../r/header-1.json` resolved the full chain (`header-1` to `shared` to `smooth-button`), created 8 files, rewrote every import correctly, and left zero `@repo/` references behind.

## Found while testing, NOT fixed here

`header-1` and `header-4` are **broken when installed through the registry**. Both import `./hero-grid.module.css` and use `styles.mainGrid` / `styles.subgrid` / `styles.cell`, but the registry never ships the file: `lib/package.ts` funnels CSS into the shadcn `css` field by walking `@layer` at-rules, and a CSS module has none, so the payload comes out as `files: ["index.tsx"]` with `css: {}`. The installed component fails to build on a missing module. Pre-existing and independent of this PR — worth its own fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized import path resolution across shared UI blocks.
  * Added consistent repository-wide aliases for reusable components and utilities.
  * Preserved strict type-checking behavior.
  * Removed outdated, block-specific import aliases where applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->