### PR TITLE
fix(registry): ship CSS modules as files instead of folding them into css

### DIFF
--- a/apps/docs/lib/package.ts
+++ b/apps/docs/lib/package.ts
@@ -183,8 +183,21 @@ export const getPackage = cache(async (packageName: string) => {
         (file.name.endsWith(".ts") && !file.name.endsWith(".d.ts")))
   );
 
+  // CSS modules are consumed as a module (`import styles from "./x.module.css"`),
+  // so they have to ship as real files next to the component. Only global CSS
+  // gets folded into the registry `css` field, which the walk below builds from
+  // `@layer` at-rules — a module has none, so folding one in would silently drop
+  // every rule and leave the installed component importing a file that is not
+  // there.
+  const cssModuleFiles = packageFiles.filter(
+    (file) => file.isFile() && file.name.endsWith(".module.css")
+  );
+
   const cssFiles = packageFiles.filter(
-    (file) => file.isFile() && file.name.endsWith(".css")
+    (file) =>
+      file.isFile() &&
+      file.name.endsWith(".css") &&
+      !file.name.endsWith(".module.css")
   );
 
   let fileType: RegistryItem["type"] = "registry:ui";
@@ -211,6 +224,19 @@ export const getPackage = cache(async (packageName: string) => {
       type: fileType,
     });
   }
+
+  // Relative to the component dir, so the `./x.module.css` import in the source
+  // keeps resolving once installed.
+  files.push(
+    ...(await Promise.all(
+      cssModuleFiles.map(async (file) => ({
+        content: await readFile(join(packageDir, file.name), "utf-8"),
+        path: file.name,
+        target: `components/smoothui/${actualPackageName}/${file.name}`,
+        type: fileType,
+      }))
+    ))
+  );
 
   // Detect shadcn-ui dependencies from @/components/ui imports
   const shadcnDependencies =


### PR DESCRIPTION
Fixes the bug reported in #105: `header-1` and `header-4` were **broken when installed through the registry**.

## Root cause

Both import `./hero-grid.module.css` and style themselves through `styles.mainGrid` / `styles.subgrid` / `styles.cell`. But `lib/package.ts` funnelled *every* `.css` in a package into the shadcn `css` field, which it builds by walking `@layer` at-rules. A CSS module has none, so the walk produced nothing and the file was never emitted anywhere:

```
header-1 -> files: ["index.tsx"], css: {}
```

The installed component then failed to build on a missing module.

## What

Splits `*.module.css` out from global CSS. Modules ship as real files targeted next to the component, so the relative `./x.module.css` import keeps resolving after install. Global CSS keeps the existing `@layer` treatment — unchanged, and today it has no producers in `blocks/`, so nothing else moves.

The block sources are untouched: CSS-module behaviour is preserved exactly as-is where it exists, rather than being rewritten into Tailwind.

```
header-1 -> files: ["index.tsx", "hero-grid.module.css"]
header-4 -> files: ["index.tsx", "hero-grid.module.css"]
header-2 -> files: ["index.tsx"]                          # unchanged
```

## Testing

Installed both blocks with the real CLI into a scratch project, against the local registry:

```
npx shadcn@latest add .../r/header-1.json .../r/header-4.json
✔ Created 11 files  (including both hero-grid.module.css)
```

- `tsc --noEmit` on the installed output: **clean**. Before this change it failed with `Cannot find module "./hero-grid.module.css"`.
- Every class the components reference (`mainGrid`, `subgrid`, `cell`) is present in the installed CSS. The only delta against the source is that the shadcn CLI strips comments through its own PostCSS pass; all rules survive.
- Blocks without a CSS module produce byte-identical payloads.
- Biome: no new warnings (the file sat at 3 `noAwaitInLoops`; the new read uses `Promise.all` so it stays at 3). Docs typecheck clean.

## Note

There is no automated regression guard for this — `apps/docs` has no test script, so the registry builder has no harness. Adding one is a larger change than this fix; happy to do it separately if you want the invariant locked down.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CSS Module files are now detected and included separately from global styles.
  * Component-specific CSS Modules are emitted as individual registry files, while global CSS remains consolidated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->