### PR TITLE
test(registry): fail CI when a served item imports a file it does not ship

### DIFF
--- a/apps/docs/scripts/verify-registry.mts
+++ b/apps/docs/scripts/verify-registry.mts
@@ -2,6 +2,11 @@
 // 1. No workspace import specifiers may leak into served file content.
 // 2. Every served item (components, blocks, libs, themes) must satisfy the
 //    shadcn registry-item schema.
+// 3. Every sibling import in served content must resolve to a file the same
+//    item actually ships. header-1 and header-4 imported "./hero-grid.module.css"
+//    for months while the registry folded every .css into the `css` field and
+//    shipped neither, so both blocks failed to build the moment anyone
+//    installed them.
 import { registryItemSchema } from "shadcn/schema";
 import { getAllPackageNames, getPackage } from "../lib/package";
 import { getSkill, SKILL_ITEM_NAME } from "../lib/registry-skill";
@@ -12,9 +17,29 @@ import { getAllThemeNames, getTheme } from "../lib/registry-themes";
 const LEAK_REGEX =
   /(?:from\s+|import\s*\(\s*|require\s*\(\s*)["'](?:@repo\/|@smoothui\/data|(?:\.\.\/){2,})/;
 
+// Sibling imports only ("./x"). Parent-relative ones are either rewritten to an
+// alias or already caught as a leak by LEAK_REGEX.
+const SIBLING_IMPORT_REGEX =
+  /(?:from\s+|import\s*\(\s*|require\s*\(\s*)["'](\.\/[^"']+)["']/g;
+
+const SIBLING_PREFIX_REGEX = /^\.\//;
+
+// A TS sibling import may omit its extension or point at a directory barrel.
+const resolutionCandidates = (specifier: string): string[] => {
+  const base = specifier.replace(SIBLING_PREFIX_REGEX, "");
+  return [
+    base,
+    ...[".ts", ".tsx", ".js", ".jsx"].flatMap((ext) => [
+      `${base}${ext}`,
+      `${base}/index${ext}`,
+    ]),
+  ];
+};
+
 const names = await getAllPackageNames();
 let leaks = 0;
 let schemaErrors = 0;
+let unresolved = 0;
 
 const validateSchema = (name: string, item: unknown) => {
   const result = registryItemSchema.safeParse(item);
@@ -35,12 +60,27 @@ for (const name of names) {
     validateSchema(name, item);
   }
 
+  const shipped = new Set((item.files ?? []).map((file) => file.path));
+
   for (const file of item.files ?? []) {
     const lines = (file.content ?? "").split("\n");
     for (const [i, line] of lines.entries()) {
       if (LEAK_REGEX.test(line)) {
         leaks++;
         console.log(`LEAK ${name} ${file.path}:${i + 1} ${line.trim()}`);
+      }
+
+      for (const [, specifier] of line.matchAll(SIBLING_IMPORT_REGEX)) {
+        if (
+          !resolutionCandidates(specifier).some((candidate) =>
+            shipped.has(candidate)
+          )
+        ) {
+          unresolved++;
+          console.log(
+            `UNRESOLVED ${name} ${file.path}:${i + 1} imports ${specifier}, which the item does not ship`
+          );
+        }
       }
     }
   }
@@ -54,6 +94,6 @@ for (const themeName of themeNames) {
 validateSchema(SKILL_ITEM_NAME, await getSkill());
 
 console.log(
-  `Items: ${names.length} packages + ${themeNames.length} themes + skill, leaks: ${leaks}, schema errors: ${schemaErrors}`
+  `Items: ${names.length} packages + ${themeNames.length} themes + skill, leaks: ${leaks}, schema errors: ${schemaErrors}, unresolved sibling imports: ${unresolved}`
 );
-process.exit(leaks || schemaErrors ? 1 : 0);
+process.exit(leaks || schemaErrors || unresolved ? 1 : 0);


### PR DESCRIPTION
The regression guard promised in #106.

## Why

`header-1` and `header-4` imported `./hero-grid.module.css` for months while the registry folded every `.css` into the `css` field and shipped neither. Both blocks failed to build the moment anyone installed them, and nothing caught it:

- the leak check only inspects workspace specifiers (`@repo/`, `@smoothui/data`, deep-relative)
- the schema check is perfectly happy with an item whose files reference something absent

## What

A third invariant in the existing `verify-registry.mts` harness, which CI already runs: every sibling import (`./x`) in served content must resolve to a file the same item ships. Resolution allows for omitted TS extensions and directory barrels, so `./animated-group` still matches `animated-group.tsx`.

Parent-relative imports are deliberately out of scope — they are either rewritten to an alias or already caught by `LEAK_REGEX`.

No new test infrastructure. `apps/docs` has no vitest setup, and this fits the harness that already exists rather than bolting a second one alongside it.

## Testing

Green on the current tree:

```
Items: 171 packages + 6 themes + skill, leaks: 0, schema errors: 0, unresolved sibling imports: 0
```

And it genuinely catches the bug it is named for — reverting the CSS-module fix from #106 makes it exit 1:

```
UNRESOLVED smoothui/blocks/headers/header-1 index.tsx:6 imports ./hero-grid.module.css, which the item does not ship
UNRESOLVED smoothui/blocks/headers/header-4 index.tsx:16 imports ./hero-grid.module.css, which the item does not ship
```

Biome: no new warnings (the one remaining `noAwaitInLoops` predates this change).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved registry validation for sibling imports, including extensionless imports and directory-based modules.
  * Added clearer reporting for unresolved imports and ensured validation fails when issues are detected.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->