### PR TITLE
fix(ci): give gh the repo when auto-merging the release PR

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,14 +28,30 @@ jobs:
       #
       # `--auto` rather than a straight merge: with no required checks on main it
       # merges immediately, and the day branch protection arrives it waits for
-      # the checks instead of needing to be rewritten.
+      # the checks instead of needing to be rewritten. It falls back to a direct
+      # merge because GitHub refuses to arm auto-merge on a PR that is already in
+      # clean status, which is exactly what an unprotected main produces.
+      #
+      # Caveat worth knowing before adding branch protection: CI and Secret Scan
+      # on this PR finish with conclusion `action_required` and never actually
+      # run, because it is opened by github-actions[bot]. That leaves the PR
+      # permanently `UNSTABLE` even with every other check green. Harmless while
+      # nothing is a required check; make them required and this stalls, and the
+      # release PR would have to be opened with a PAT for its checks to run.
       #
       # The number is parsed in the shell, not with `fromJSON` in `env`: Actions
       # evaluates a step's whole template before deciding whether to run it, so
       # `fromJSON("")` on a push that releases nothing failed the job outright.
+      #
+      # `--repo` is required: this job deliberately never checks out, so there is
+      # no .git for gh to infer the repository from and it exits 1 with
+      # "failed to run git: fatal: not a git repository".
       - name: Auto-merge the release PR
         if: steps.release.outputs.pr
-        run: gh pr merge --auto --merge "$(jq -r .number <<<"$PR_JSON")"
+        run: |
+          pr="$(jq -r .number <<<"$PR_JSON")"
+          gh pr merge --auto --merge --repo "$GITHUB_REPOSITORY" "$pr" \
+            || gh pr merge --merge --repo "$GITHUB_REPOSITORY" "$pr"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_JSON: ${{ steps.release.outputs.pr }}


### PR DESCRIPTION
The release automation has been failing on every push to `main`. The release PR gets opened correctly, but the step that should merge it dies.

## Root cause

```
gh pr merge --auto --merge 101
→ failed to run git: fatal: not a git repository (or any of the parent directories): .git
```

The job deliberately never checks out — the release-please action works over the API — so there is no `.git` for `gh` to infer the repository from, and it exits 1.

Reproduced outside CI by running the same command from a directory that is not a git repo: identical message, and it succeeds the moment `--repo` is added.

## What

Punto 1 — passes `--repo "$GITHUB_REPOSITORY"`, which is all it needed.

Punto 2 — falls back to a direct `--merge`. GitHub refuses to arm auto-merge on a PR already in clean status, which is exactly what an unprotected `main` produces, so `--auto` alone can fail for a second and unrelated reason.

## A trap found while diagnosing, documented in the workflow

CI and Secret Scan on the release PR finish with **conclusion** `action_required` and never actually run, because the PR is opened by `github-actions[bot]`. Approving them through the API is a no-op once they have concluded.

That leaves the release PR permanently `UNSTABLE` even with every other check green:

```
PR #101: 4 passed, 0 failed  →  mergeStateStatus: UNSTABLE
```

Harmless today, because `main` has no branch protection and nothing is a required check. But it would be fatal to this automation the day required checks are added — the release PR would have to be opened with a PAT for its own checks to run. Left as a comment next to the step rather than fixed, since it is not currently breaking anything.

## Testing

- Reproduced the exact failure and the fix locally with `gh pr view`, in and out of a git directory.
- Workflow YAML parses, and the step body was dry-run with `PR_JSON`/`GITHUB_REPOSITORY` set to confirm the number is extracted and both commands are well-formed.
- Verified the preconditions the step depends on: `allow_auto_merge: true`, `main` unprotected, and PR #101 `MERGEABLE`.

## Heads up

`release-please` only runs on push to `main`, so merging this is what re-triggers it. It will then pick up the open release PR (#101, `chore(main): release 3.7.0`) and this time actually merge it — **cutting the 3.7.0 release**, tag and GitHub release included. That is the intended behaviour of the automation, but it does mean merging this PR publishes a release rather than just fixing a workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified automated release merge behavior and its limitations.
  * Documented how branch protection and automated checks affect merging.

* **Chores**
  * Improved release automation to attempt automatic merging before falling back to an immediate merge.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->