### PR TITLE
docs(ci): record why the release PR can never use auto-merge

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -26,18 +26,21 @@ jobs:
       # opened by Actions with GITHUB_TOKEN does not trigger workflow runs, so
       # such a job would never fire.
       #
-      # `--auto` rather than a straight merge: with no required checks on main it
-      # merges immediately, and the day branch protection arrives it waits for
-      # the checks instead of needing to be rewritten. It falls back to a direct
-      # merge because GitHub refuses to arm auto-merge on a PR that is already in
-      # clean status, which is exactly what an unprotected main produces.
+      # The direct merge is the path that actually runs. `--auto` is tried first
+      # only so that the day branch protection arrives this waits for checks
+      # rather than needing a rewrite, but on this repo it always refuses with
       #
-      # Caveat worth knowing before adding branch protection: CI and Secret Scan
-      # on this PR finish with conclusion `action_required` and never actually
-      # run, because it is opened by github-actions[bot]. That leaves the PR
-      # permanently `UNSTABLE` even with every other check green. Harmless while
-      # nothing is a required check; make them required and this stalls, and the
-      # release PR would have to be opened with a PAT for its checks to run.
+      #     Pull request is in unstable status (enablePullRequestAutoMerge)
+      #
+      # because CI and Secret Scan on the release PR finish with conclusion
+      # `action_required` and never actually run: the PR is opened by
+      # github-actions[bot], and approving a concluded run through the API is a
+      # no-op. So the PR sits at UNSTABLE forever even with every other check
+      # green, auto-merge cannot be armed, and the fallback merges it.
+      #
+      # Harmless while nothing on main is a required check. Make them required
+      # and both halves fail — loudly, which is the point — and the real fix is
+      # to open the release PR with a PAT so its own checks run.
       #
       # The number is parsed in the shell, not with `fromJSON` in `env`: Actions
       # evaluates a step's whole template before deciding whether to run it, so


### PR DESCRIPTION
Follow-up to #109. No behaviour change — the step already works. The comment above it was wrong about why.

## What cutting 3.7.0 taught us

#109 said `--auto` "merges immediately with no required checks on main". It does not. It refuses outright:

```
GraphQL: Pull request Pull request is in unstable status (enablePullRequestAutoMerge)
```

The cause is the `action_required` trap #109 documented, but its consequence is bigger than that PR credited. CI and Secret Scan on the release PR finish with **conclusion** `action_required` and never run, because the PR is opened by `github-actions[bot]` — and approving an already-concluded run through the API is a no-op, which I confirmed by trying.

So the release PR sits at `UNSTABLE` **permanently**, even with every other check green:

```
PR #101: 4 passed, 0 failed  →  mergeStateStatus: UNSTABLE
```

Auto-merge cannot be armed on an unstable PR. The fallback direct merge added in #109 is therefore not a fallback at all — it is the only path that ever runs, and it is what cut v3.7.0.

`--auto` is kept as the first attempt so the day branch protection arrives this waits for checks rather than needing a rewrite. Worth knowing that on that day **both halves will fail** — loudly, which is the right failure mode — and the real fix will be to open the release PR with a PAT so its own checks run.

## Also worth recording

The auto-merge step only fires when release-please sets its `pr` output, which it does only when the release PR actually changes. A push that touches nothing under `packages/smoothui` logs `PR #101 remained the same`, leaves the output unset, and skips the step. That is why merging #109 did not itself release anything — its own commit was a workflow file, outside the configured package path.

## Testing

v3.7.0 is out, cut by running the exact command form from the fixed workflow:

- PR #101 merged at 21:25:08
- tag `v3.7.0` created
- GitHub release `v3.7.0` marked Latest
- `packages/smoothui/package.json` and `.release-please-manifest.json` both at 3.7.0 on main

Workflow YAML re-validated after the edit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated release workflow comments to clarify the current auto-merge limitation and fallback merge behavior.
  * Documented the expected resolution path for restoring reliable automatic merging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->