### PR TITLE
ci: adopt OSS hardening patterns and compile the registry payload

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,13 +4,16 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: write
-  pull-requests: write
+# Deny by default and let the job ask for what it needs, so a second job added
+# here later does not silently inherit write access.
+permissions: {}
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Create the release commit, tag and GitHub release
+      pull-requests: write # Open and update the release PR
     steps:
       - id: release
         uses: googleapis/release-please-action@v4
@@ -18,43 +21,26 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
-      # The release PR is generated: it carries no code, only CHANGELOG.md and a
-      # version number, so a human merging it never adds information. Merging it
-      # by hand is what kept it stale at 3.5.1 while main had moved on.
+      # The release PR is merged by hand, on purpose. This is what shadcn/ui
+      # does: the version bump and changelog are the last chance to look at what
+      # is about to be published, and that review is worth more than the clicks
+      # it costs.
       #
-      # Enabled here rather than in a `pull_request` workflow on purpose: a PR
-      # opened by Actions with GITHUB_TOKEN does not trigger workflow runs, so
-      # such a job would never fire.
+      # Auto-merging it was tried and removed. It could never work here anyway:
+      # CI and Secret Scan on the release PR finish with conclusion
+      # `action_required` and never run, because the PR is opened by
+      # github-actions[bot], so the PR sits at UNSTABLE forever and
+      # `gh pr merge --auto` refuses with "Pull request is in unstable status".
+      # Only a blind unconditional merge got it through, which is precisely the
+      # thing worth not doing to a published release.
       #
-      # The direct merge is the path that actually runs. `--auto` is tried first
-      # only so that the day branch protection arrives this waits for checks
-      # rather than needing a rewrite, but on this repo it always refuses with
-      #
-      #     Pull request is in unstable status (enablePullRequestAutoMerge)
-      #
-      # because CI and Secret Scan on the release PR finish with conclusion
-      # `action_required` and never actually run: the PR is opened by
-      # github-actions[bot], and approving a concluded run through the API is a
-      # no-op. So the PR sits at UNSTABLE forever even with every other check
-      # green, auto-merge cannot be armed, and the fallback merges it.
-      #
-      # Harmless while nothing on main is a required check. Make them required
-      # and both halves fail — loudly, which is the point — and the real fix is
-      # to open the release PR with a PAT so its own checks run.
-      #
-      # The number is parsed in the shell, not with `fromJSON` in `env`: Actions
-      # evaluates a step's whole template before deciding whether to run it, so
-      # `fromJSON("")` on a push that releases nothing failed the job outright.
-      #
-      # `--repo` is required: this job deliberately never checks out, so there is
-      # no .git for gh to infer the repository from and it exits 1 with
-      # "failed to run git: fatal: not a git repository".
-      - name: Auto-merge the release PR
+      # The risk this trades into is forgetting: an unmerged release PR is what
+      # once left the package stale at 3.5.1 while main had moved on. It is
+      # visible in the PR list, so the fix is to look there before saying a fix
+      # has shipped.
+      - name: Report the pending release PR
         if: steps.release.outputs.pr
         run: |
-          pr="$(jq -r .number <<<"$PR_JSON")"
-          gh pr merge --auto --merge --repo "$GITHUB_REPOSITORY" "$pr" \
-            || gh pr merge --merge --repo "$GITHUB_REPOSITORY" "$pr"
+          echo "::notice title=Release PR ready::$(jq -r '"#\(.number) \(.title)"' <<<"$PR_JSON") — merge it to publish."
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_JSON: ${{ steps.release.outputs.pr }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -12,13 +12,14 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   gitleaks:
     name: gitleaks
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required by actions/checkout
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     steps:
       - name: 📥 Checkout

--- a/.github/workflows/semantic-pr-title.yml
+++ b/.github/workflows/semantic-pr-title.yml
@@ -10,14 +10,14 @@ on:
   pull_request:
     types: [opened, edited, reopened, synchronize, ready_for_review]
 
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
 
 jobs:
   validate:
     name: Validate PR title
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read # Read the PR title to validate it
     if: github.event.pull_request.draft == false
     steps:
       - name: 📝 Lint PR title against Conventional Commits

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -128,6 +128,12 @@ jobs:
         working-directory: apps/docs
         run: npx tsx scripts/verify-registry.mts
 
+      # Compiles what the registry actually serves, which structural checks
+      # cannot do. shadcn/ui scaffolds a real app for the same reason.
+      - name: Verify registry output compiles when installed
+        working-directory: apps/docs
+        run: npx tsx scripts/verify-install.mts
+
       # The counts are committed so client components and MDX frontmatter can
       # import them. Checked like a lockfile, so marketing copy cannot silently
       # drift from the catalogue again.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Deny by default and let each job ask for what it needs, the way astro, tailwind
+# and hono set theirs up. Every job here only reads the checkout, so nothing has
+# to escalate.
+permissions: {}
+
 # nucleo-core-fill-24 runs a license-check preinstall (allowlisted in
 # pnpm-workspace.yaml allowBuilds) that fails without this key.
 env:
@@ -19,6 +24,8 @@ jobs:
   lockfile-audit:
     name: Lockfile Audit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required by actions/checkout
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -48,6 +55,8 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required by actions/checkout
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -70,6 +79,8 @@ jobs:
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required by actions/checkout
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -92,6 +103,8 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required by actions/checkout
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -125,6 +138,8 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # Required by actions/checkout
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ skills-lock.json
 
 # Local agent and tool configuration, per machine.
 /.codex/
+
+# Scratch project written by apps/docs/scripts/verify-install.mts
+.install-check/
+apps/docs/.install-check/

--- a/apps/docs/scripts/verify-install.mts
+++ b/apps/docs/scripts/verify-install.mts
@@ -1,0 +1,187 @@
+// Installs registry items into a throwaway project and typechecks the result,
+// the way shadcn/ui's templates workflow scaffolds a real app rather than
+// trusting that the payload it serves would have compiled.
+//
+// verify-registry.mts reasons about the payload; this compiles it, and they are
+// deliberately not redundant. That one catches structure — a file imported but
+// not shipped, a token nothing defines. This one catches whatever only a
+// compiler sees: a rewritten import that lands nowhere, a prop type that stopped
+// lining up, an export the barrel no longer has.
+//
+// It does not catch a missing CSS module: `*.module.css` is declared ambiently
+// below, so an absent one still typechecks. That is verify-registry's job.
+//
+// No network and no dev server: the items are built in-process by getPackage()
+// and written straight to disk with their registry targets, so this runs in CI
+// as a plain script.
+import { execFileSync } from "node:child_process";
+import { mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { getAllPackageNames, getPackage } from "../lib/package";
+
+const require = createRequire(import.meta.url);
+
+// Strips a version range from a dependency spec: "is-even@3.0.0" -> "is-even".
+const VERSION_RANGE_REGEX = /(?<=.)@[^@]*$/;
+const TS_ERROR_REGEX = /error TS\d+/;
+
+// Resolved from apps/docs and nowhere else, because that is the only thing tsc
+// will see from the scratch project. Checking wider roots marks a package
+// resolvable that then fails to compile.
+const RESOLVE_ROOTS = [join(import.meta.dirname, "..")];
+
+const isResolvable = (specifier: string): boolean => {
+  try {
+    require.resolve(specifier, { paths: RESOLVE_ROOTS });
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+const REPO_ROOT = join(import.meta.dirname, "../../..");
+
+const TSCONFIG = {
+  compilerOptions: {
+    allowJs: true,
+    baseUrl: ".",
+    esModuleInterop: true,
+    jsx: "preserve",
+    lib: ["dom", "dom.iterable", "esnext"],
+    module: "esnext",
+    moduleResolution: "bundler",
+    noEmit: true,
+    // The shadcn components an item imports are ambient `any` here, so callbacks
+    // typed through them cannot infer. Strictness over our own source is the job
+    // of `pnpm typecheck`; this run is about whether the payload resolves and
+    // compiles at all.
+    noImplicitAny: false,
+    paths: { "@/*": ["./src/*"] },
+    resolveJsonModule: true,
+    skipLibCheck: true,
+    strict: true,
+    target: "es2017",
+  },
+  include: ["src/**/*.ts", "src/**/*.tsx", "src/**/*.d.ts"],
+};
+
+const STUBS = {
+  "src/globals.d.ts":
+    'declare module "*.module.css" {\n' +
+    "  const classes: Record<string, string>;\n" +
+    "  export default classes;\n" +
+    "}\n" +
+    'declare module "*.css";\n',
+  // Anything the registry expects from a shadcn project but does not ship.
+  "src/lib/utils.ts":
+    'export const cn = (...inputs: unknown[]): string =>\n  inputs.filter(Boolean).join(" ");\n',
+};
+
+const run = (command: string, args: string[], cwd: string): string => {
+  try {
+    return execFileSync(command, args, {
+      cwd,
+      encoding: "utf8",
+      stdio: "pipe",
+    });
+  } catch (error) {
+    const failure = error as { stdout?: string; stderr?: string };
+    return `${failure.stdout ?? ""}${failure.stderr ?? ""}`;
+  }
+};
+
+// Scratch project lives inside apps/docs, not in tmp, so ordinary node
+// resolution walks up and finds its node_modules. It has to be apps/docs
+// specifically: pnpm does not hoist, so the repo root has none of react, motion
+// or lucide-react, and apps/docs is the only workspace carrying all of them.
+const PROJECT = join(import.meta.dirname, "..", ".install-check");
+
+const main = async () => {
+  const project = PROJECT;
+  rmSync(project, { force: true, recursive: true });
+  mkdirSync(project, { recursive: true });
+  let written = 0;
+  let items = 0;
+  const skipped: string[] = [];
+
+  try {
+    for (const [path, contents] of Object.entries(STUBS)) {
+      const target = join(project, path);
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, contents);
+    }
+    writeFileSync(
+      join(project, "tsconfig.json"),
+      JSON.stringify(TSCONFIG, null, 2)
+    );
+
+    for (const name of await getAllPackageNames()) {
+      const item = await getPackage(name);
+      if (!item.files?.length) {
+        continue;
+      }
+      // An item whose declared npm dependencies are not installed anywhere in
+      // the workspace is skipped rather than stubbed: a shorthand ambient
+      // declaration turns their types into `any`, which silently downgrades the
+      // very errors this exists to find, and on a component that imports types
+      // rather than values it invents new ones. Better to check less and mean
+      // it, and say out loud what was skipped.
+      const missing = (item.dependencies ?? [])
+        .map((dep) => dep.replace(VERSION_RANGE_REGEX, ""))
+        .filter((dep) => !isResolvable(dep));
+
+      if (missing.length > 0) {
+        skipped.push(`${name} (${missing.join(", ")})`);
+        continue;
+      }
+
+      items++;
+
+      for (const file of item.files) {
+        // `target` is where the CLI would put it in a real project.
+        const target = join(project, "src", file.target ?? file.path);
+        mkdirSync(dirname(target), { recursive: true });
+        writeFileSync(target, file.content ?? "");
+        written++;
+      }
+    }
+
+    // shadcn's own components arrive through registryDependencies and are not in
+    // this scratch project. A shorthand ambient declaration types every import
+    // from them as `any`, named ones included, which is the one stub worth
+    // making: the installer really will have them.
+    writeFileSync(
+      join(project, "src/ambient.d.ts"),
+      'declare module "@/components/ui/*";\n'
+    );
+
+    console.log(`Wrote ${written} files from ${items} items`);
+    if (skipped.length > 0) {
+      console.log(
+        `Skipped ${skipped.length} items whose deps are not installed in the workspace:`
+      );
+      for (const entry of skipped) {
+        console.log(`  ${entry}`);
+      }
+    }
+
+    const tsc = join(REPO_ROOT, "node_modules/.bin/tsc");
+    const output = run(tsc, ["--noEmit", "-p", "tsconfig.json"], project);
+    const errors = output
+      .split("\n")
+      .filter((line) => TS_ERROR_REGEX.test(line));
+
+    if (errors.length > 0) {
+      console.log(errors.slice(0, 40).join("\n"));
+      console.log(`\nInstall typecheck FAILED: ${errors.length} errors`);
+      process.exit(1);
+    }
+
+    console.log("Install typecheck clean");
+  } finally {
+    rmSync(project, { force: true, recursive: true });
+  }
+};
+
+await main();


### PR DESCRIPTION
Ported from what large OSS repos actually do, after reading their configs rather than guessing. Their branch-protection settings are not readable from outside, but workflows, CODEOWNERS and triggers are, and the patterns are consistent.

## Punto 1 — Least privilege on every workflow

astro sets `permissions: {}` at the workflow root and has each job declare exactly what it needs; tailwindcss and hono do the same with `contents: read`. Here CI had **no `permissions:` block at all**, and release-please granted `contents: write` + `pull-requests: write` at the root, where any job added later would silently inherit them.

Now every workflow denies at the root:

| Workflow | Job | Gets |
| --- | --- | --- |
| CI | all five | `contents: read` (checkout) |
| Secret Scan | gitleaks | `contents: read` |
| Semantic PR Title | validate | `pull-requests: read` (no checkout) |
| release-please | release-please | its two writes, scoped to the one job |

## Punto 2 — The release PR is merged by hand

This is shadcn/uis model: the version bump and changelog are the last chance to look at what is about to be published.

It also could never have worked otherwise. CI and Secret Scan on the release PR finish with conclusion `action_required` and never run, because the PR is opened by `github-actions[bot]`, so it sits at `UNSTABLE` forever and `gh pr merge --auto` refuses outright. Only an unconditional merge got it through, which is exactly the thing not worth doing to a published release. The step is replaced by a `::notice` pointing at the open PR.

**Trade-off, stated plainly:** an unmerged release PR is what once left the package stale at 3.5.1. The mitigation is that it is visible in the PR list and now announced in the run summary.

## Punto 3 — Compile what the registry serves

`verify-registry.mts` reasons about the payload; nothing compiled it. An item could satisfy every structural invariant and still fail to build once installed.

`verify-install.mts` writes every items files to a scratch project at their registry targets and runs `tsc`. It is the cheap version of shadcn/uis `templates.yml`, which scaffolds real apps across package managers — no network, no dev server, items built in-process by `getPackage()`.

```
Wrote 174 files from 159 items
Skipped 11 items whose deps are not installed in the workspace:
  smoothui/components/gooey-popover (gsap)
  smoothui/components/tweet-card (react-tweet)
  ...
Install typecheck clean
```

The 11 are skipped **and named** rather than stubbed. A shorthand ambient declaration would turn their types into `any` and silently downgrade the errors this exists to find — on `tweet-card`, which imports types rather than values, it invented new ones. Better to check less and mean it.

The one stub kept is `@/components/ui/*`: those arrive through registryDependencies, so the installer really will have them.

## Testing

- Install check verified in both directions: clean on the current tree, and injecting `const broken: number = "not a number"` into `smooth-button` fails it with exactly that error.
- All four workflow files re-validated as YAML; permissions audited by parsing them back.
- Biome: one pre-existing `noAwaitInLoops` warning, no new ones.

## Worth knowing

`secret-scan.yml` and `semantic-pr-title.yml` carry a header saying they mirror `educlopez/github-actions-workflows`. This edits them, so that repo now drifts unless you port the same permissions change.

## Not included, proposed separately

astro pins every action to a full commit SHA (`actions/checkout@de0fac2e...`) instead of a tag. Given this repo already gates the lockfile for supply-chain reasons, that is the natural next step — but it touches every `uses:` line and deserves its own PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated verification that generated registry items compile successfully after installation.
  * Reports successfully checked and skipped items, with clear errors when validation fails.

* **Bug Fixes**
  * Improved cleanup of temporary files created during installation checks.

* **Chores**
  * Strengthened workflow permission controls.
  * Release pull requests now require manual merging, with workflow notices identifying pending releases.
  * Added ignore rules for installation-check artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->