### PR TITLE
fix(ci): authenticate the pin check and stop it passing when it checks nothing

### DIFF
--- a/scripts/refresh-action-pins.ts
+++ b/scripts/refresh-action-pins.ts
@@ -13,6 +13,7 @@
 //
 // `update` follows the tag each pin already carries — it never jumps you to a
 // new major. Moving from v4 to v7 is a decision, so it stays manual.
+import { execFileSync } from "node:child_process";
 import { readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -33,11 +34,28 @@ interface Occurrence extends Pin {
   file: string;
 }
 
+// Unauthenticated calls to the GitHub API are rate limited hard enough that
+// this returns 403 on an ordinary developer machine, so a token is not optional.
+// gh is already set up for anyone working on this repo; the env vars are there
+// for CI, should this ever run there.
+const readToken = (): string | undefined => {
+  if (process.env.GITHUB_TOKEN || process.env.GH_TOKEN) {
+    return process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  }
+  try {
+    return execFileSync("gh", ["auth", "token"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {}
+};
+
+const token = readToken();
 const headers: Record<string, string> = {
   accept: "application/vnd.github+json",
 };
-if (process.env.GITHUB_TOKEN) {
-  headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+if (token) {
+  headers.authorization = `Bearer ${token}`;
 }
 
 const api = async <T>(path: string): Promise<T | null> => {
@@ -106,6 +124,7 @@ const main = async () => {
   }
 
   let moved = 0;
+  let unresolved = 0;
 
   // One API round trip per action@tag, however many files reference it.
   const targets = [
@@ -127,6 +146,7 @@ const main = async () => {
       latest !== pin.tag && latest !== "?" ? `  (latest ${latest})` : "";
 
     if (!current) {
+      unresolved++;
       console.log(`?  ${pin.action}@${pin.tag} — could not resolve${behind}`);
       continue;
     }
@@ -163,6 +183,19 @@ const main = async () => {
         );
       }
     }
+  }
+
+  // Never report an all-clear off the back of calls that did not happen: a
+  // check that passes because it could not reach the API is worse than none.
+  if (unresolved > 0) {
+    console.log(
+      `\nCould not resolve ${unresolved} of ${resolved.length} pins — nothing was verified.` +
+        (token
+          ? ""
+          : " No token found: set GITHUB_TOKEN or run `gh auth login`.")
+    );
+    process.exitCode = 1;
+    return;
   }
 
   if (moved === 0) {

--- a/scripts/refresh-action-pins.ts
+++ b/scripts/refresh-action-pins.ts
@@ -38,16 +38,20 @@ interface Occurrence extends Pin {
 // this returns 403 on an ordinary developer machine, so a token is not optional.
 // gh is already set up for anyone working on this repo; the env vars are there
 // for CI, should this ever run there.
-const readToken = (): string | undefined => {
-  if (process.env.GITHUB_TOKEN || process.env.GH_TOKEN) {
-    return process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+const readToken = (): string | null => {
+  const fromEnv = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+  if (fromEnv) {
+    return fromEnv;
   }
   try {
     return execFileSync("gh", ["auth", "token"], {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "ignore"],
     }).trim();
-  } catch {}
+  } catch {
+    // gh missing or logged out — the caller reports this rather than guessing.
+    return null;
+  }
 };
 
 const token = readToken();


### PR DESCRIPTION
Two defects in the script merged in #112. Both surfaced the first time I ran it fresh on `main` rather than in the shell where I had been developing it.

## Punto 1 — no credentials

It called the GitHub API with a bare `fetch`. Unauthenticated requests are rate limited hard enough to return **403** from an ordinary developer machine:

```
?  actions/checkout@v4 — could not resolve
?  pnpm/action-setup@v4 — could not resolve
...
```

It worked while I was building it only because nothing had exhausted the quota yet. Now it reads `GITHUB_TOKEN` or `GH_TOKEN`, falling back to `gh auth token` — already set up for anyone working on this repo.

## Punto 2 — the one that actually matters

With every lookup failing, it still printed:

```
All pins current.
```

and exited 0. A check that reports an all-clear because it could not reach the API is worse than no check at all: it converts an outage into a false assurance, which is precisely the failure mode this whole line of work has been about removing.

Unresolved pins are now counted, reported honestly, and fail:

```
Could not resolve 5 of 5 pins — nothing was verified.
No token found: set GITHUB_TOKEN or run `gh auth login`.
```

## Testing

| Condition | Output | Exit |
| --- | --- | --- |
| token available | all five resolve, `All pins current.` | 0 |
| `gh` stubbed to fail, env cleared | `nothing was verified` | 1 |

Exit codes checked without a pipe, since `$?` after `| tail` reports tail.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved action pin verification by using available authentication credentials.
  * Clearly reports unresolved pins and incomplete verification.
  * Prevents successful completion from being reported when verification fails.
  * Handles missing authentication gracefully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->