### PR TITLE
fix(ci): stop next typegen racing tsc, and cover the skipped registry items

### DIFF
--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -7,7 +7,7 @@
     "counts": "tsx scripts/generate-counts.mts",
     "dev": "next dev --turbopack",
     "start": "next start",
-    "typecheck": "fumadocs-mdx && next typegen && tsc --noEmit"
+    "typecheck": "fumadocs-mdx && _FUMADOCS_MDX=1 next typegen && tsc --noEmit"
   },
   "dependencies": {
     "@next/bundle-analyzer": "^16.0.7",

--- a/apps/docs/scripts/verify-install.mts
+++ b/apps/docs/scripts/verify-install.mts
@@ -26,17 +26,28 @@ const require = createRequire(import.meta.url);
 const VERSION_RANGE_REGEX = /(?<=.)@[^@]*$/;
 const TS_ERROR_REGEX = /error TS\d+/;
 
-// Resolved from apps/docs and nowhere else, because that is the only thing tsc
-// will see from the scratch project. Checking wider roots marks a package
-// resolvable that then fails to compile.
-const RESOLVE_ROOTS = [join(import.meta.dirname, "..")];
+const DOCS_ROOT = join(import.meta.dirname, "..");
+const PACKAGES_ROOT = join(import.meta.dirname, "../../../packages");
 
-const isResolvable = (specifier: string): boolean => {
+// Every component and block is its own pnpm workspace package, so a dependency
+// like react-tweet or gsap is installed under that package rather than hoisted.
+// Resolving only from apps/docs therefore reports plenty of installed packages
+// as missing. Resolve from the item's own directory too, and hand tsc a path
+// mapping so it can follow — otherwise the item is skipped for a dependency that
+// is sitting right there.
+const resolveFrom = (specifier: string, roots: string[]): string | null => {
   try {
-    require.resolve(specifier, { paths: RESOLVE_ROOTS });
-    return true;
+    const manifest = require.resolve(`${specifier}/package.json`, {
+      paths: roots,
+    });
+    return dirname(manifest);
   } catch {
-    return false;
+    try {
+      // Some packages do not export ./package.json; fall back to the entry.
+      return dirname(require.resolve(specifier, { paths: roots }));
+    } catch {
+      return null;
+    }
   }
 };
 
@@ -104,6 +115,7 @@ const main = async () => {
   let written = 0;
   let items = 0;
   const skipped: string[] = [];
+  const extraPaths: Record<string, string[]> = {};
 
   try {
     for (const [path, contents] of Object.entries(STUBS)) {
@@ -111,25 +123,35 @@ const main = async () => {
       mkdirSync(dirname(target), { recursive: true });
       writeFileSync(target, contents);
     }
-    writeFileSync(
-      join(project, "tsconfig.json"),
-      JSON.stringify(TSCONFIG, null, 2)
-    );
 
     for (const name of await getAllPackageNames()) {
       const item = await getPackage(name);
       if (!item.files?.length) {
         continue;
       }
-      // An item whose declared npm dependencies are not installed anywhere in
-      // the workspace is skipped rather than stubbed: a shorthand ambient
-      // declaration turns their types into `any`, which silently downgrades the
-      // very errors this exists to find, and on a component that imports types
-      // rather than values it invents new ones. Better to check less and mean
-      // it, and say out loud what was skipped.
-      const missing = (item.dependencies ?? [])
-        .map((dep) => dep.replace(VERSION_RANGE_REGEX, ""))
-        .filter((dep) => !isResolvable(dep));
+      // An item whose declared npm dependencies cannot be found at all is
+      // skipped rather than stubbed: a shorthand ambient declaration turns their
+      // types into `any`, which silently downgrades the very errors this exists
+      // to find, and on a component that imports types rather than values it
+      // invents new ones. Better to check less and mean it, and say out loud
+      // what was skipped.
+      const itemDir = join(PACKAGES_ROOT, name);
+      const missing: string[] = [];
+
+      for (const dep of (item.dependencies ?? []).map((entry) =>
+        entry.replace(VERSION_RANGE_REGEX, "")
+      )) {
+        if (resolveFrom(dep, [DOCS_ROOT])) {
+          continue;
+        }
+        const local = resolveFrom(dep, [itemDir]);
+        if (local) {
+          extraPaths[dep] = [local];
+          extraPaths[`${dep}/*`] = [join(local, "*")];
+        } else {
+          missing.push(dep);
+        }
+      }
 
       if (missing.length > 0) {
         skipped.push(`${name} (${missing.join(", ")})`);
@@ -146,6 +168,21 @@ const main = async () => {
         written++;
       }
     }
+
+    writeFileSync(
+      join(project, "tsconfig.json"),
+      JSON.stringify(
+        {
+          ...TSCONFIG,
+          compilerOptions: {
+            ...TSCONFIG.compilerOptions,
+            paths: { ...TSCONFIG.compilerOptions.paths, ...extraPaths },
+          },
+        },
+        null,
+        2
+      )
+    );
 
     // shadcn's own components arrive through registryDependencies and are not in
     // this scratch project. A shorthand ambient declaration types every import


### PR DESCRIPTION
The two open items from the status review.

## Punto 1 — the typecheck flake, root cause found

Typecheck had degraded to failing **two of the last three runs on main**, always with the same signature and always green on a bare re-run:

```
Module "@/.source/server" has no exported member "blog"
Parameter "preProps" implicitly has an "any" type
```

#97 narrowed this by making the generation explicit (`fumadocs-mdx && next typegen && tsc`) but could not close it, and the reason is inside fumadocs-mdx. `next.config.ts` calls `createMDX()`, which runs on **any** Next invocation, `typegen` included:

```js
if (process.env._FUMADOCS_MDX !== "1") {
  process.env._FUMADOCS_MDX = "1";
  init(isDev, core);        // async, never awaited
}
```

`init` awaits `core.emit({ write: true })` — it rewrites `.source`. Nothing waits for it, so `next typegen` returns while the write is still in flight and `tsc` starts reading a directory being rebuilt underneath it. Running the explicit generator first does not help: Next re-triggers it afterwards.

The guard is the librarys own. Setting `_FUMADOCS_MDX=1` makes `createMDX` skip `init` entirely, leaving the explicit `fumadocs-mdx` run as the only writer.

**Verified mechanically** by hashing every `.source` files mtime:

| Command | `.source` |
| --- | --- |
| `next typegen` | **rewritten** |
| `_FUMADOCS_MDX=1 next typegen` | untouched |

The flake itself still cannot be reproduced on demand — the local repro has passed every time since #97 — but the writer that causes it is provably gone.

## Punto 2 — the 11 items the install check was skipping

It reported gsap, react-tweet, usehooks-ts, input-otp and three radix packages as "not installed in the workspace". **They were installed the whole time.**

Every component and block is its own pnpm workspace package, so their dependencies land in that packages `node_modules` rather than hoisted anywhere reachable from `apps/docs`. Resolving only from `apps/docs` made them look absent.

Dependencies are now resolved from the items own directory too, and that location is handed to tsc as a path mapping so it can follow.

```
Wrote 187 files from 170 items
Install typecheck clean
```

159 items to **all 170**, nothing skipped. **No dependencies added** — this uses what pnpm already installed, rather than pulling ~6.8MB (gsap alone is 6.1MB) into `apps/docs` to typecheck components that never run there.

Verified the new coverage is real rather than vacuous: injecting a type error into `tweet-card`, one of the previously skipped items, now fails the check.

## Also done, outside this diff

14 merged local branches deleted. `develop` kept — it is the integration branch for the redesign flow, merged or not. The four unmerged branches (`blog/ai-design-slop`, two `chore/*` from May, `refactor/landing-visual-polish`) are untouched: that is your unfinished work, not mine to bin.