### PR TITLE
fix(a11y): audit every component with axe, plus CI and release-flow gaps

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -10,7 +10,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   push:
-    branches: [main]
+    # `develop` is the integration branch, so a direct push there has to be
+    # scanned too — otherwise a secret can sit in history until it reaches main.
+    branches: [main, develop]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,52 @@
+# Releasing
+
+## Branches
+
+| Branch    | Role                                                                 |
+| --------- | -------------------------------------------------------------------- |
+| `develop` | Integration. Feature branches merge here. Releases are prepared here. |
+| `main`    | Released code. `release-please` watches this branch and nothing else. |
+
+Both branches are protected: Build, Lint, Test, Typecheck, Browser Smoke,
+Lockfile Audit and gitleaks must pass, and neither accepts a force push or a
+deletion. `main` additionally requires a branch to be up to date with its base
+before merging; `develop` does not, so day-to-day work is not spent rebasing.
+
+## The flow
+
+1. Branch from `develop`. Open a PR back into `develop`. CI runs on both
+   `main` and `develop` targets, so this is gated.
+2. When `develop` holds a set of changes worth shipping, open a PR from
+   `develop` into `main`.
+3. Merging that PR triggers `release-please` on `main`, which opens (or
+   updates) its own release PR with the version bump and changelog.
+4. Merging the release PR cuts the tag, the GitHub release, and — for
+   `packages/cli` — publishes to npm through OIDC.
+
+## Why step 2 is not automated
+
+A workflow can open the `develop → main` PR, but a pull request created with
+the default `GITHUB_TOKEN` does not trigger other workflows. CI would never
+run on it, and because `main` requires those exact checks the PR could never
+be merged — the automation would deadlock against the branch protection.
+
+Automating it properly needs a PAT or a GitHub App token, which is a real
+secret to own and rotate for something that happens a handful of times a
+month. Until that trade is worth making, open it by hand:
+
+```bash
+gh pr create --base main --head develop \
+  --title "chore: promote develop to main" \
+  --body "Cuts a release from the work currently on develop."
+```
+
+Created from your own token, CI runs normally.
+
+## Conventional commits drive the changelog
+
+`release-please` reads commit messages, and squash-merging makes the **PR
+title** the commit message. So the PR title is what lands in the release
+notes — make it describe the most significant change in the PR, not the
+smallest. `feat:` and `fix:` are user-visible; `chore:`, `ci:`, `test:`,
+`style:` and `build:` are hidden from the changelog by
+`release-please-config.json`.

--- a/apps/docs/content/docs/components/text-morph.mdx
+++ b/apps/docs/content/docs/components/text-morph.mdx
@@ -24,12 +24,12 @@ installer: text-morph
 
 | Attribute | Element | Purpose |
 |-----------|---------|---------|
-| `aria-label` | Wrapper element | Exposes the full, intact string once to assistive technology |
+| `class="sr-only"` | Visually hidden text node | Exposes the full, intact string once to assistive technology |
 | `aria-hidden="true"` | Per-token spans | Hides the fragmented, animated tokens from screen readers |
 
 ### Screen Reader
 
-- The wrapper carries `aria-label={text}`, so screen readers announce the current string as a single, coherent phrase.
+- The wrapper renders the current string once as visually hidden text, so screen readers announce it as a single, coherent phrase. An `aria-label` would not work here: it is prohibited on the generic roles that the default `as="span"` (and `as="div"`) produce, so assistive technology would drop it and — with every token `aria-hidden` — announce nothing at all.
 - The animated character or word spans underneath are `aria-hidden`, so nothing is read out twice or letter-by-letter.
 - The text remains selectable in the DOM at all times.
 

--- a/packages/smoothui/components/agent-avatar/__tests__/agent-avatar.test.tsx
+++ b/packages/smoothui/components/agent-avatar/__tests__/agent-avatar.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AgentAvatar from "../index";
 
@@ -54,6 +55,12 @@ const mockMatchMedia = (matches: boolean) => {
 };
 
 describe("AgentAvatar", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<AgentAvatar seed="test-seed" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   let mockCtx: MockContext2D;
   let rafCallbacks: FrameRequestCallback[];
 

--- a/packages/smoothui/components/ai-approval/__tests__/ai-approval.test.tsx
+++ b/packages/smoothui/components/ai-approval/__tests__/ai-approval.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AIApproval, { type AIApprovalOption } from "../index";
 
@@ -9,6 +10,14 @@ const OPTIONS: AIApprovalOption[] = [
 ];
 
 describe("AIApproval", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <AIApproval options={OPTIONS} question="Proceed?" />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders the question and every option", () => {
     render(<AIApproval options={OPTIONS} question="Proceed?" />);
     expect(screen.getByText("Proceed?")).toBeInTheDocument();

--- a/packages/smoothui/components/ai-artifact/__tests__/ai-artifact.test.tsx
+++ b/packages/smoothui/components/ai-artifact/__tests__/ai-artifact.test.tsx
@@ -1,9 +1,18 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AIArtifact from "../index";
 
 describe("AIArtifact", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <AIArtifact code="source" preview={<p>rendered</p>} title="utils.ts" />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("names the artifact", () => {
     render(<AIArtifact preview={<p>rendered</p>} title="utils.ts" />);
     expect(screen.getByText("utils.ts")).toBeInTheDocument();

--- a/packages/smoothui/components/ai-artifact/index.tsx
+++ b/packages/smoothui/components/ai-artifact/index.tsx
@@ -92,7 +92,11 @@ const AIArtifact = ({
         </span>
 
         {available.length > 1 && (
-          <div className="ml-auto flex items-center gap-0.5 rounded-lg bg-muted p-0.5">
+          <div
+            aria-label="Artifact view"
+            className="ml-auto flex items-center gap-0.5 rounded-lg bg-muted p-0.5"
+            role="tablist"
+          >
             {available.map((candidate) => (
               <button
                 aria-selected={pane === candidate}

--- a/packages/smoothui/components/ai-branch/__tests__/ai-branch.test.tsx
+++ b/packages/smoothui/components/ai-branch/__tests__/ai-branch.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AiBranch, {
   AIBranch,
@@ -35,6 +36,14 @@ const branches = [
 ];
 
 describe("AiBranch (legacy)", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <AiBranch branches={branches} onBranchSelect={() => {}} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <AiBranch branches={branches.slice(0, 1)} onBranchSelect={() => {}} />

--- a/packages/smoothui/components/ai-citation/__tests__/ai-citation.test.tsx
+++ b/packages/smoothui/components/ai-citation/__tests__/ai-citation.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AICitation from "../index";
 
@@ -11,6 +12,12 @@ const PROPS = {
 };
 
 describe("AICitation", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<AICitation {...PROPS} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders the pill as a real link", () => {
     render(<AICitation {...PROPS} />);
     const link = screen.getByRole("link", { name: "1" });

--- a/packages/smoothui/components/ai-context-meter/__tests__/ai-context-meter.test.tsx
+++ b/packages/smoothui/components/ai-context-meter/__tests__/ai-context-meter.test.tsx
@@ -1,9 +1,22 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AIContextMeter from "../index";
 
 describe("AIContextMeter", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <AIContextMeter
+        breakdown={[{ label: "System prompt", tokens: 1800 }]}
+        limit={200_000}
+        used={48_000}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("formats tokens compactly", () => {
     render(<AIContextMeter limit={200_000} used={48_000} />);
     expect(screen.getByRole("button")).toHaveTextContent("48k/200k");

--- a/packages/smoothui/components/ai-conversation/__tests__/ai-conversation.test.tsx
+++ b/packages/smoothui/components/ai-conversation/__tests__/ai-conversation.test.tsx
@@ -1,8 +1,19 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AIConversation from "../index";
 
 describe("AIConversation", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <AIConversation>
+        <p>message</p>
+      </AIConversation>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders its children", () => {
     const { container } = render(
       <AIConversation>

--- a/packages/smoothui/components/ai-diff/__tests__/ai-diff.test.tsx
+++ b/packages/smoothui/components/ai-diff/__tests__/ai-diff.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AIDiff, { type AIDiffLine } from "../index";
 
@@ -11,6 +12,14 @@ const LINES: AIDiffLine[] = [
 ];
 
 describe("AIDiff", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <AIDiff lines={LINES} onAccept={vi.fn()} onReject={vi.fn()} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders every line with its prefix", () => {
     render(<AIDiff lines={LINES} />);
     expect(screen.getByText("old line")).toBeInTheDocument();

--- a/packages/smoothui/components/ai-loader/__tests__/ai-loader.test.tsx
+++ b/packages/smoothui/components/ai-loader/__tests__/ai-loader.test.tsx
@@ -1,9 +1,16 @@
 import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AILoader, { AI_LOADER_CYCLE_SECONDS } from "../index";
 
 describe("AILoader", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<AILoader />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("exports a shared cycle length so variants stay in sync", () => {
     expect(AI_LOADER_CYCLE_SECONDS).toBeGreaterThan(0);
   });

--- a/packages/smoothui/components/ai-message/__tests__/ai-message.test.tsx
+++ b/packages/smoothui/components/ai-message/__tests__/ai-message.test.tsx
@@ -1,9 +1,20 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AIMessage from "../index";
 
 describe("AIMessage", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <AIMessage copyText="x" timestamp="14:32">
+        Hello
+      </AIMessage>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders its content and timestamp", () => {
     render(<AIMessage timestamp="14:32">Hello</AIMessage>);
     expect(screen.getByText("Hello")).toBeInTheDocument();

--- a/packages/smoothui/components/ai-orb-face/__tests__/ai-orb-face.test.tsx
+++ b/packages/smoothui/components/ai-orb-face/__tests__/ai-orb-face.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import type { AIState } from "../../ai-core";
 import AIOrbFace from "../index";
@@ -17,6 +18,14 @@ const countEyeRects = (container: HTMLElement) =>
   [...container.querySelectorAll("rect")].length;
 
 describe("AIOrbFace", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <AIOrbFace aria-label="Assistant is thinking" state="thinking" />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders in every state without throwing", () => {
     for (const state of ALL_STATES) {
       const { container } = render(<AIOrbFace state={state} />);

--- a/packages/smoothui/components/ai-prompt-input/__tests__/ai-prompt-input.test.tsx
+++ b/packages/smoothui/components/ai-prompt-input/__tests__/ai-prompt-input.test.tsx
@@ -1,9 +1,16 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AIPromptInput from "../index";
 
 describe("AIPromptInput", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<AIPromptInput placeholder="Ask anything…" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders the placeholder", () => {
     render(<AIPromptInput placeholder="Ask anything…" />);
     expect(screen.getByPlaceholderText("Ask anything…")).toBeInTheDocument();

--- a/packages/smoothui/components/ai-reasoning/__tests__/ai-reasoning.test.tsx
+++ b/packages/smoothui/components/ai-reasoning/__tests__/ai-reasoning.test.tsx
@@ -1,9 +1,18 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AIReasoning from "../index";
 
 describe("AIReasoning", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <AIReasoning duration={4.2}>trace</AIReasoning>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("starts open while streaming", () => {
     render(<AIReasoning isStreaming>trace</AIReasoning>);
     expect(screen.getByRole("button")).toHaveAttribute("aria-expanded", "true");

--- a/packages/smoothui/components/ai-response/__tests__/ai-response.test.tsx
+++ b/packages/smoothui/components/ai-response/__tests__/ai-response.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AIResponse from "../index";
 
@@ -19,6 +20,14 @@ const CITATIONS = [
 ];
 
 describe("AIResponse", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <AIResponse citations={CITATIONS} text="Scales with compute [1]." />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders the text", () => {
     render(<AIResponse text="Hello there" />);
     expect(screen.getByText(/Hello/)).toBeInTheDocument();

--- a/packages/smoothui/components/ai-sources/__tests__/ai-sources.test.tsx
+++ b/packages/smoothui/components/ai-sources/__tests__/ai-sources.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AISources, { type AISource } from "../index";
 
@@ -11,6 +12,12 @@ const SOURCES: AISource[] = [
 ];
 
 describe("AISources", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<AISources defaultOpen sources={SOURCES} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("starts collapsed, because provenance should be available not loud", () => {
     render(<AISources sources={SOURCES} />);
     expect(screen.getByRole("button")).toHaveAttribute(

--- a/packages/smoothui/components/ai-suggestions/__tests__/ai-suggestions.test.tsx
+++ b/packages/smoothui/components/ai-suggestions/__tests__/ai-suggestions.test.tsx
@@ -1,5 +1,6 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AISuggestions from "../index";
 
@@ -10,6 +11,14 @@ const SUGGESTIONS = [
 ];
 
 describe("AISuggestions", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <AISuggestions label="Follow-ups" suggestions={SUGGESTIONS} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders one button per suggestion inside a list", () => {
     const { container } = render(<AISuggestions suggestions={SUGGESTIONS} />);
     expect(container.querySelectorAll("li")).toHaveLength(3);

--- a/packages/smoothui/components/ai-task-list/__tests__/ai-task-list.test.tsx
+++ b/packages/smoothui/components/ai-task-list/__tests__/ai-task-list.test.tsx
@@ -1,5 +1,6 @@
 import { screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AITaskList, { type AITask } from "../index";
 
@@ -17,6 +18,12 @@ const TASKS: AITask[] = [
 ];
 
 describe("AITaskList", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<AITaskList tasks={TASKS} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders every task and sub-task", () => {
     render(<AITaskList tasks={TASKS} />);
     expect(screen.getByText("Verify records")).toBeInTheDocument();

--- a/packages/smoothui/components/ai-tool-call/__tests__/ai-tool-call.test.tsx
+++ b/packages/smoothui/components/ai-tool-call/__tests__/ai-tool-call.test.tsx
@@ -1,9 +1,22 @@
 import { fireEvent, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AIToolCall, { type AIToolCallStatus } from "../index";
 
 describe("AIToolCall", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <AIToolCall
+        args={<span>args</span>}
+        name="search_web"
+        result={<span>res</span>}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("shows the tool name", () => {
     render(<AIToolCall name="search_web" />);
     expect(screen.getByText("search_web")).toBeInTheDocument();

--- a/packages/smoothui/components/animated-avatar-group/__tests__/animated-avatar-group.test.tsx
+++ b/packages/smoothui/components/animated-avatar-group/__tests__/animated-avatar-group.test.tsx
@@ -1,8 +1,22 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AnimatedAvatarGroup from "../index";
 
 describe("AnimatedAvatarGroup", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <AnimatedAvatarGroup
+        avatars={[
+          { alt: "User 1", src: "https://example.com/avatar1.png" },
+          { alt: "User 2", src: "https://example.com/avatar2.png" },
+        ]}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <AnimatedAvatarGroup

--- a/packages/smoothui/components/animated-file-upload/__tests__/animated-file-upload.test.tsx
+++ b/packages/smoothui/components/animated-file-upload/__tests__/animated-file-upload.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { fireEvent, render, screen } from "../../../test-utils/render";
 import AnimatedFileUpload from "../index";
 
@@ -8,6 +9,14 @@ const createFile = (name: string, size: number, type = "image/png") => {
 };
 
 describe("AnimatedFileUpload", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <AnimatedFileUpload onFilesSelected={() => {}} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <AnimatedFileUpload onFilesSelected={() => {}} />
@@ -136,13 +145,15 @@ describe("AnimatedFileUpload", () => {
   });
 
   it("opens the file picker on Enter and Space keys", () => {
-    const { getByLabelText } = render(
+    const { container, getByLabelText } = render(
       <AnimatedFileUpload onFilesSelected={() => {}} />
     );
     const dropzone = getByLabelText(
       "File upload area. Drag and drop files or press to browse"
     );
-    const input = dropzone.querySelector(
+    // The input is a sibling of the dropzone, not a child: nesting it inside
+    // put a focusable, unlabelled field inside another control.
+    const input = container.querySelector(
       'input[type="file"]'
     ) as HTMLInputElement;
     const clickSpy = vi.spyOn(input, "click");

--- a/packages/smoothui/components/animated-file-upload/index.tsx
+++ b/packages/smoothui/components/animated-file-upload/index.tsx
@@ -219,6 +219,22 @@ export default function AnimatedFileUpload({
 
   return (
     <div className={cn("w-full space-y-3", className)}>
+      {/* The dropzone below is the control: it owns the accessible name and the
+          keyboard activation. This input is only ever clicked through the ref,
+          so it sits outside the dropzone and out of the accessibility tree —
+          nested inside it, it was an unlabelled field within another control. */}
+      <input
+        accept={accept}
+        aria-hidden="true"
+        className="sr-only"
+        disabled={disabled}
+        multiple={multiple}
+        onChange={handleInputChange}
+        ref={inputRef}
+        tabIndex={-1}
+        type="file"
+      />
+
       <motion.div
         animate={
           shouldReduceMotion
@@ -247,16 +263,6 @@ export default function AnimatedFileUpload({
         tabIndex={disabled ? -1 : 0}
         transition={shouldReduceMotion ? { duration: 0 } : SPRING}
       >
-        <input
-          accept={accept}
-          className="sr-only"
-          disabled={disabled}
-          multiple={multiple}
-          onChange={handleInputChange}
-          ref={inputRef}
-          type="file"
-        />
-
         <UploadIcon isDragOver={isDragOver} />
 
         <AnimatePresence initial={false} mode="wait">

--- a/packages/smoothui/components/animated-input/__tests__/animated-input.test.tsx
+++ b/packages/smoothui/components/animated-input/__tests__/animated-input.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AnimatedInput from "../index";
 
 describe("AnimatedInput", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<AnimatedInput label="Email" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<AnimatedInput label="Email" />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/animated-list/__tests__/animated-list.test.tsx
+++ b/packages/smoothui/components/animated-list/__tests__/animated-list.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AnimatedList, { type AnimatedListItem } from "../index";
 
@@ -9,6 +10,12 @@ const items: AnimatedListItem[] = [
 ];
 
 describe("AnimatedList", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<AnimatedList items={items} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<AnimatedList items={items} />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/animated-number-input/__tests__/animated-number-input.test.tsx
+++ b/packages/smoothui/components/animated-number-input/__tests__/animated-number-input.test.tsx
@@ -1,9 +1,18 @@
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { fireEvent, render, screen } from "../../../test-utils/render";
 import AnimatedNumberInput from "../index";
 
 describe("AnimatedNumberInput", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <AnimatedNumberInput defaultValue={10} label="Quantity" scrub stepper />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<AnimatedNumberInput />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/animated-o-t-p-input/__tests__/animated-o-t-p-input.test.tsx
+++ b/packages/smoothui/components/animated-o-t-p-input/__tests__/animated-o-t-p-input.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AnimatedOTPInput from "../index";
 
 describe("AnimatedOTPInput", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<AnimatedOTPInput />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<AnimatedOTPInput />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/animated-progress-bar/__tests__/animated-progress-bar.test.tsx
+++ b/packages/smoothui/components/animated-progress-bar/__tests__/animated-progress-bar.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AnimatedProgressBar from "../index";
 
 describe("AnimatedProgressBar", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<AnimatedProgressBar value={50} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<AnimatedProgressBar value={50} />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/animated-stepper/__tests__/animated-stepper.test.tsx
+++ b/packages/smoothui/components/animated-stepper/__tests__/animated-stepper.test.tsx
@@ -1,8 +1,19 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AnimatedStepper from "../index";
 
 describe("AnimatedStepper", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <AnimatedStepper
+        steps={[{ label: "Step 1" }, { label: "Step 2" }, { label: "Step 3" }]}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <AnimatedStepper

--- a/packages/smoothui/components/animated-stepper/index.tsx
+++ b/packages/smoothui/components/animated-stepper/index.tsx
@@ -124,13 +124,14 @@ export default function AnimatedStepper({
     >
       <div
         aria-label="Progress steps"
+        aria-orientation={isHorizontal ? "horizontal" : "vertical"}
         className={cn(
           "relative flex",
           isHorizontal
             ? "flex-row items-center justify-between"
             : "flex-col items-start gap-2"
         )}
-        role="group"
+        role="tablist"
       >
         {steps.map((step, index) => {
           const isActive = index === activeStep;

--- a/packages/smoothui/components/animated-tabs/__tests__/animated-tabs.test.tsx
+++ b/packages/smoothui/components/animated-tabs/__tests__/animated-tabs.test.tsx
@@ -1,8 +1,22 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AnimatedTabs from "../index";
 
 describe("AnimatedTabs", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <AnimatedTabs
+        tabs={[
+          { id: "tab1", label: "Tab 1" },
+          { id: "tab2", label: "Tab 2" },
+        ]}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <AnimatedTabs

--- a/packages/smoothui/components/animated-tags/__tests__/animated-tags.test.tsx
+++ b/packages/smoothui/components/animated-tags/__tests__/animated-tags.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AnimatedTags from "../index";
 
 describe("AnimatedTags", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<AnimatedTags />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<AnimatedTags />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/animated-toggle/__tests__/animated-toggle.test.tsx
+++ b/packages/smoothui/components/animated-toggle/__tests__/animated-toggle.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AnimatedToggle from "../index";
 
 describe("AnimatedToggle", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<AnimatedToggle label="Test toggle" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<AnimatedToggle label="Test toggle" />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/animated-tooltip/__tests__/animated-tooltip.test.tsx
+++ b/packages/smoothui/components/animated-tooltip/__tests__/animated-tooltip.test.tsx
@@ -1,8 +1,19 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AnimatedTooltip from "../index";
 
 describe("AnimatedTooltip", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <AnimatedTooltip content="Tooltip text">
+        <button type="button">Hover me</button>
+      </AnimatedTooltip>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <AnimatedTooltip content="Tooltip text">

--- a/packages/smoothui/components/aperture-blur-transition/__tests__/aperture-blur-transition.test.tsx
+++ b/packages/smoothui/components/aperture-blur-transition/__tests__/aperture-blur-transition.test.tsx
@@ -1,5 +1,6 @@
 import { useReducedMotion } from "motion/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import {
   flushFrames,
@@ -15,6 +16,16 @@ vi.mock("motion/react", async (importOriginal) => {
 });
 
 describe("ApertureBlurTransition", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ApertureBlurTransition transitionKey="draft">
+        Draft saved
+      </ApertureBlurTransition>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   beforeEach(() => {
     installWebglMock();
   });

--- a/packages/smoothui/components/app-download-stack/__tests__/app-download-stack.test.tsx
+++ b/packages/smoothui/components/app-download-stack/__tests__/app-download-stack.test.tsx
@@ -1,13 +1,62 @@
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
-import { render, screen, waitFor } from "../../../test-utils/render";
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "../../../test-utils/render";
 import AppDownloadStack from "../index";
 
 const apps = [
   { icon: "https://example.com/github.png", id: 1, name: "GitHub" },
   { icon: "https://example.com/figma.png", id: 2, name: "Figma" },
 ];
+
+/** The component's own `setTimeout` gates, mirrored so the clock can skip them. */
+const DOWNLOAD_DURATION_MS = 3000;
+const RESET_DELAY_MS = 1000;
+
+/** Upper bound on how many real frames a Motion transition is given to finish. */
+const MAX_TRANSITION_FRAMES = 120;
+
+/** Skips one of the component's faked `setTimeout` gates. */
+const skipGate = (ms: number) => {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+};
+
+const nextFrame = () =>
+  new Promise<void>((resolve) => {
+    requestAnimationFrame(() => resolve());
+  });
+
+/**
+ * Waits on the animation frameloop rather than on `setTimeout`.
+ *
+ * `waitFor` polls with `setTimeout`, and RTL only advances a faked clock for
+ * that poll when `jest` is a global — under Vitest it is not, so any `waitFor`
+ * in a fake-timer test hangs until the suite kills it. Motion drives its
+ * transitions off `requestAnimationFrame`, which is left real here, so stepping
+ * frames waits for exactly the thing that has to happen and nothing else.
+ */
+const waitForElement = async (query: () => HTMLElement | null) => {
+  for (let frame = 0; frame < MAX_TRANSITION_FRAMES; frame++) {
+    const found = query();
+    if (found) {
+      return found;
+    }
+    await act(async () => {
+      await nextFrame();
+    });
+  }
+  throw new Error(
+    `Element never appeared within ${MAX_TRANSITION_FRAMES} animation frames`
+  );
+};
 
 /** Fully controlled wrapper mirroring real-world usage of selectedApps + onChange. */
 const ControlledStack = ({
@@ -99,34 +148,65 @@ describe("AppDownloadStack", () => {
   });
 
   it("runs the full download flow and calls onDownload, resetting after completion", async () => {
-    const user = userEvent.setup();
-    const onDownload = vi.fn();
-    render(<AppDownloadStack apps={apps} onDownload={onDownload} />);
+    // This test used to sleep through the flow in real time. The component gates
+    // itself on two `setTimeout`s — 3000ms of simulated downloading, then 1000ms
+    // before it resets — so `waitFor` spent four wall-clock seconds polling for
+    // state that only a clock could produce. That is 80% of the default 5s
+    // budget spent idle, which is why it needed a hand-written 10s timeout and
+    // still sat one slow CI runner away from failing.
+    //
+    // Only `setTimeout` is faked. Motion's transitions stay on the real
+    // frameloop, so the `AnimatePresence mode="wait"` handoffs between the three
+    // labels play exactly as they did before — they were never the expensive
+    // part, and driving them off a faked `requestAnimationFrame` proved brittle.
+    // What is skipped is only the dead time between them.
+    vi.useFakeTimers({ toFake: ["clearTimeout", "setTimeout"] });
 
-    await user.click(
-      screen.getByRole("button", { name: "Expand app selection" })
-    );
-    await user.click(screen.getByRole("button", { name: /GitHub/ }));
-    await user.click(screen.getByRole("button", { name: "Download Selected" }));
+    try {
+      const onDownload = vi.fn();
+      render(<AppDownloadStack apps={apps} onDownload={onDownload} />);
 
-    expect(onDownload).toHaveBeenCalledWith([1]);
-    await waitFor(() =>
-      expect(screen.getByText("Downloading...")).toBeInTheDocument()
-    );
+      // `fireEvent`, not `userEvent`, only because of the fake clock: RTL's
+      // async wrapper drains its microtask queue behind a `setTimeout(0)` that
+      // it only advances when `jest` is a global, so under Vitest's fake timers
+      // every `await user.click(...)` deadlocks. These are plain button clicks
+      // with no pointer sequence worth simulating, so nothing is lost — the
+      // `userEvent` paths through this component are covered by the tests above.
+      fireEvent.click(
+        screen.getByRole("button", { name: "Expand app selection" })
+      );
+      await waitForElement(() =>
+        screen.queryByRole("button", { name: /GitHub/ })
+      );
 
-    await waitFor(
-      () => expect(screen.getByText("Download Complete!")).toBeInTheDocument(),
-      { timeout: 4000 }
-    );
+      fireEvent.click(screen.getByRole("button", { name: /GitHub/ }));
+      fireEvent.click(
+        screen.getByRole("button", { name: "Download Selected" })
+      );
 
-    await waitFor(
-      () =>
-        expect(
-          screen.getByRole("button", { name: "Expand app selection" })
-        ).toBeInTheDocument(),
-      { timeout: 2000 }
-    );
-  }, 10_000);
+      expect(onDownload).toHaveBeenCalledWith([1]);
+      expect(
+        await waitForElement(() => screen.queryByText("Downloading..."))
+      ).toBeInTheDocument();
+
+      // Past the download timeout the complete label takes over...
+      skipGate(DOWNLOAD_DURATION_MS);
+      expect(
+        await waitForElement(() => screen.queryByText("Download Complete!"))
+      ).toBeInTheDocument();
+
+      // ...and past the reset delay the whole thing collapses back to its
+      // trigger.
+      skipGate(RESET_DELAY_MS);
+      expect(
+        await waitForElement(() =>
+          screen.queryByRole("button", { name: "Expand app selection" })
+        )
+      ).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 
   it("supports controlled selectedApps and isExpanded", () => {
     const noSelection: number[] = [];

--- a/packages/smoothui/components/apple-invites/__tests__/apple-invites.test.tsx
+++ b/packages/smoothui/components/apple-invites/__tests__/apple-invites.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AppleInvites, { type Event } from "../index";
 
@@ -18,6 +19,12 @@ const events: Event[] = [
 ];
 
 describe("AppleInvites", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<AppleInvites events={events} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<AppleInvites events={events} />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/arcade-pixel/__tests__/arcade-pixel.test.tsx
+++ b/packages/smoothui/components/arcade-pixel/__tests__/arcade-pixel.test.tsx
@@ -171,7 +171,20 @@ describe("ArcadePixel painting", () => {
 
   it("never settles a looping animation", () => {
     setup({ animate: "marquee", loop: true, text: "SCROLL" });
-    runFramesFor(3000);
+
+    // Stepped coarsely on purpose — this was by far the most expensive test in
+    // the file. A marquee repaints every lit cell *and* blooms the phosphor by
+    // blitting the canvas over itself, which the Canvas2D fake services by
+    // stamping all 240x120 pixels one at a time; at the default 16ms step,
+    // 3000ms meant ~188 of those full-surface repaints for a single assertion.
+    //
+    // The simulated span stays at 3000ms, which is what carries the meaning:
+    // "SCROLL" is 36 columns plus an 8-column tail at 16 columns/second, so the
+    // marquee wraps once inside the window and a non-looping animation would
+    // have settled well before it ends. Only the sampling rate drops. Marquee
+    // offset is derived from elapsed time rather than from a frame counter, so
+    // coarser frames land the message in the same places, just fewer of them.
+    runFramesFor(3000, { stepMs: 150 });
     expect(pendingFrameCount()).toBeGreaterThan(0);
   });
 

--- a/packages/smoothui/components/ascii-render/__tests__/ascii-render.test.tsx
+++ b/packages/smoothui/components/ascii-render/__tests__/ascii-render.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import {
   type Canvas2DMock,
   flushFrames,
@@ -45,6 +46,14 @@ describe("AsciiRender", () => {
 });
 
 describe("AsciiRender sampling", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <AsciiRender alt="A photo" columns={COLUMNS} source={IMAGE_SOURCE} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   let canvas2d: Canvas2DMock;
 
   beforeEach(() => {

--- a/packages/smoothui/components/aurora-curtain/__tests__/aurora-curtain.test.tsx
+++ b/packages/smoothui/components/aurora-curtain/__tests__/aurora-curtain.test.tsx
@@ -1,8 +1,19 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AuroraCurtain from "../index";
 
 describe("AuroraCurtain", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <AuroraCurtain>
+        <p>Content above the aurora</p>
+      </AuroraCurtain>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <AuroraCurtain>

--- a/packages/smoothui/components/auth-form/__tests__/auth-form.test.tsx
+++ b/packages/smoothui/components/auth-form/__tests__/auth-form.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import AuthForm from "../index";
 
 describe("AuthForm", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<AuthForm mode="sign-in" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing in sign-in mode", () => {
     const { container } = render(<AuthForm mode="sign-in" />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/basic-accordion/__tests__/basic-accordion.test.tsx
+++ b/packages/smoothui/components/basic-accordion/__tests__/basic-accordion.test.tsx
@@ -1,8 +1,22 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import BasicAccordion from "../index";
 
 describe("BasicAccordion", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <BasicAccordion
+        items={[
+          { content: "Content 1", id: "1", title: "Section 1" },
+          { content: "Content 2", id: "2", title: "Section 2" },
+        ]}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <BasicAccordion

--- a/packages/smoothui/components/basic-dropdown/__tests__/basic-dropdown.test.tsx
+++ b/packages/smoothui/components/basic-dropdown/__tests__/basic-dropdown.test.tsx
@@ -1,5 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { fireEvent, render, screen, waitFor } from "../../../test-utils/render";
 import BasicDropdown from "../index";
 
@@ -10,6 +11,14 @@ const items = [
 ];
 
 describe("BasicDropdown", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <BasicDropdown items={items} label="Select option" />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <BasicDropdown items={items} label="Select option" />

--- a/packages/smoothui/components/basic-modal/__tests__/basic-modal.test.tsx
+++ b/packages/smoothui/components/basic-modal/__tests__/basic-modal.test.tsx
@@ -1,8 +1,19 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import BasicModal from "../index";
 
 describe("BasicModal", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <BasicModal isOpen onClose={() => {}}>
+        <p>Modal content</p>
+      </BasicModal>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <BasicModal isOpen={false} onClose={() => {}}>

--- a/packages/smoothui/components/basic-toast/__tests__/basic-toast.test.tsx
+++ b/packages/smoothui/components/basic-toast/__tests__/basic-toast.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import BasicToast from "../index";
 
 describe("BasicToast", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<BasicToast message="Test message" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<BasicToast message="Test message" />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/book/__tests__/book.test.tsx
+++ b/packages/smoothui/components/book/__tests__/book.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import Book from "../index";
 
 describe("Book", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<Book title="Test Book" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<Book title="Test Book" />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/border-beam/__tests__/border-beam.test.tsx
+++ b/packages/smoothui/components/border-beam/__tests__/border-beam.test.tsx
@@ -1,4 +1,5 @@
 import { afterAll, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import BorderBeam from "../index";
 
@@ -45,6 +46,16 @@ afterAll(() => {
 });
 
 describe("BorderBeam", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <BorderBeam>
+        <div>content</div>
+      </BorderBeam>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <BorderBeam>

--- a/packages/smoothui/components/breadcrumb/__tests__/breadcrumb.test.tsx
+++ b/packages/smoothui/components/breadcrumb/__tests__/breadcrumb.test.tsx
@@ -1,8 +1,23 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import Breadcrumb from "../index";
 
 describe("Breadcrumb", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <Breadcrumb
+        items={[
+          { href: "/", label: "Home" },
+          { href: "/docs", label: "Docs" },
+          { label: "Current" },
+        ]}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <Breadcrumb

--- a/packages/smoothui/components/breakpoint-indicator/__tests__/breakpoint-indicator.test.tsx
+++ b/packages/smoothui/components/breakpoint-indicator/__tests__/breakpoint-indicator.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import BreakpointIndicator from "../index";
 
 describe("BreakpointIndicator", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<BreakpointIndicator enabled />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<BreakpointIndicator enabled />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/button-copy/__tests__/button-copy.test.tsx
+++ b/packages/smoothui/components/button-copy/__tests__/button-copy.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ButtonCopy from "../index";
 
 describe("ButtonCopy", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<ButtonCopy />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<ButtonCopy />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/card-swipe-deck/__tests__/card-swipe-deck.test.tsx
+++ b/packages/smoothui/components/card-swipe-deck/__tests__/card-swipe-deck.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import CardSwipeDeck, { type CardSwipeDeckItem } from "../index";
 
@@ -8,6 +9,12 @@ const items: CardSwipeDeckItem[] = [
 ];
 
 describe("CardSwipeDeck", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<CardSwipeDeck items={items} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<CardSwipeDeck items={items} />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/checkbox/__tests__/checkbox.test.tsx
+++ b/packages/smoothui/components/checkbox/__tests__/checkbox.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import Checkbox from "../index";
 
 describe("Checkbox", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<Checkbox aria-label="Accept terms" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<Checkbox />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/checkbox/index.tsx
+++ b/packages/smoothui/components/checkbox/index.tsx
@@ -6,6 +6,10 @@ import { Checkbox as CheckboxPrimitive } from "radix-ui";
 import { SPRING_DEFAULT } from "../../lib/animation";
 
 export interface CheckboxProps {
+  /** Accessible name, for checkboxes without a visible `<label>` */
+  "aria-label"?: string;
+  /** ID of the element labelling the checkbox */
+  "aria-labelledby"?: string;
   /** Whether the checkbox is checked */
   checked?: boolean;
   /** Optional CSS class */
@@ -16,7 +20,7 @@ export interface CheckboxProps {
   id?: string;
   /** Whether the checkbox is in an indeterminate state */
   indeterminate?: boolean;
-  /** Accessible name for the checkbox */
+  /** Name attribute for form submission */
   name?: string;
   /** Callback when the checked state changes */
   onCheckedChange?: (checked: boolean) => void;
@@ -30,6 +34,8 @@ const CheckmarkPath = motion.path;
 const MotionSvg = motion.svg;
 
 export default function Checkbox({
+  "aria-label": ariaLabel,
+  "aria-labelledby": ariaLabelledBy,
   checked = false,
   indeterminate = false,
   onCheckedChange,
@@ -58,6 +64,8 @@ export default function Checkbox({
   return (
     <CheckboxPrimitive.Root
       aria-checked={indeterminate ? "mixed" : checked}
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
       checked={indeterminate ? "indeterminate" : checked}
       className={cn(
         "peer size-4 shrink-0 rounded-[4px] border border-input shadow-xs outline-none transition-shadow focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 data-[state=checked]:border-foreground data-[state=indeterminate]:border-foreground data-[state=checked]:bg-foreground data-[state=indeterminate]:bg-foreground data-[state=unchecked]:bg-background data-[state=checked]:text-background data-[state=indeterminate]:text-background dark:data-[state=unchecked]:bg-input/30 dark:aria-invalid:ring-destructive/40",

--- a/packages/smoothui/components/chroma-blur-transition/__tests__/chroma-blur-transition.test.tsx
+++ b/packages/smoothui/components/chroma-blur-transition/__tests__/chroma-blur-transition.test.tsx
@@ -1,5 +1,6 @@
 import { useReducedMotion } from "motion/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import {
   flushFrames,
@@ -22,6 +23,16 @@ describe("ChromaBlurTransition", () => {
   afterEach(() => {
     uninstallWebglMock();
     vi.mocked(useReducedMotion).mockReturnValue(false);
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ChromaBlurTransition transitionKey="draft">
+        Draft saved
+      </ChromaBlurTransition>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 
   it("renders the active content", () => {

--- a/packages/smoothui/components/clip-corners-button/__tests__/clip-corners-button.test.tsx
+++ b/packages/smoothui/components/clip-corners-button/__tests__/clip-corners-button.test.tsx
@@ -1,8 +1,17 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import { ClipCornersButton } from "../index";
 
 describe("ClipCornersButton", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ClipCornersButton>Click me</ClipCornersButton>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <ClipCornersButton>Click me</ClipCornersButton>

--- a/packages/smoothui/components/code-block/__tests__/code-block.test.tsx
+++ b/packages/smoothui/components/code-block/__tests__/code-block.test.tsx
@@ -1,8 +1,17 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import CodeBlock from "../index";
 
 describe("CodeBlock", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <CodeBlock code="const x = 1;" language="ts" />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <CodeBlock code="const x = 1;" language="ts" />

--- a/packages/smoothui/components/combobox/__tests__/combobox.test.tsx
+++ b/packages/smoothui/components/combobox/__tests__/combobox.test.tsx
@@ -1,8 +1,23 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import Combobox from "../index";
 
 describe("Combobox", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <Combobox
+        aria-label="Test combobox"
+        options={[
+          { label: "Option A", value: "a" },
+          { label: "Option B", value: "b" },
+        ]}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <Combobox

--- a/packages/smoothui/components/context-menu/__tests__/context-menu.test.tsx
+++ b/packages/smoothui/components/context-menu/__tests__/context-menu.test.tsx
@@ -1,8 +1,19 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ContextMenu from "../index";
 
 describe("ContextMenu", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ContextMenu items={[{ key: "item1", label: "Item 1" }]}>
+        <div>Right-click me</div>
+      </ContextMenu>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <ContextMenu items={[{ key: "item1", label: "Item 1" }]}>

--- a/packages/smoothui/components/contribution-graph/__tests__/contribution-graph.test.tsx
+++ b/packages/smoothui/components/contribution-graph/__tests__/contribution-graph.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ContributionGraph from "../index";
 
 describe("ContributionGraph", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<ContributionGraph />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<ContributionGraph />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/country-dialog/__tests__/country-dialog.test.tsx
+++ b/packages/smoothui/components/country-dialog/__tests__/country-dialog.test.tsx
@@ -1,6 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { fireEvent, render, screen, waitFor } from "../../../test-utils/render";
 import CountryDialog, { type Country, type CountryDialogProps } from "../index";
 
@@ -48,6 +49,20 @@ const CountryDialogHarness = ({
 };
 
 describe("CountryDialog", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <CountryDialog
+        countries={countries}
+        groupBy
+        onOpenChange={vi.fn()}
+        onValueChange={vi.fn()}
+        open
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing when closed", () => {
     const { container } = render(
       <CountryDialog

--- a/packages/smoothui/components/coverflow-carousel/__tests__/coverflow-carousel.test.tsx
+++ b/packages/smoothui/components/coverflow-carousel/__tests__/coverflow-carousel.test.tsx
@@ -1,8 +1,23 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import CoverflowCarousel from "../index";
 
 describe("CoverflowCarousel", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <CoverflowCarousel
+        items={[
+          { id: "1", image: "https://example.com/one.png" },
+          { id: "2", image: "https://example.com/two.png" },
+          { content: "Third slide", id: "3" },
+        ]}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <CoverflowCarousel

--- a/packages/smoothui/components/cursor-follow/__tests__/cursor-follow.test.tsx
+++ b/packages/smoothui/components/cursor-follow/__tests__/cursor-follow.test.tsx
@@ -1,8 +1,19 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import CursorFollow from "../index";
 
 describe("CursorFollow", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <CursorFollow>
+        <div>Content</div>
+      </CursorFollow>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <CursorFollow>

--- a/packages/smoothui/components/cursor-image-trail/__tests__/cursor-image-trail.test.tsx
+++ b/packages/smoothui/components/cursor-image-trail/__tests__/cursor-image-trail.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { act, fireEvent, render } from "../../../test-utils/render";
 import CursorImageTrail, { type CursorTrailImage } from "../index";
 
@@ -111,6 +112,16 @@ describe("CursorImageTrail", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <CursorImageTrail images={images} poolSize={2}>
+        <p>Hover area</p>
+      </CursorImageTrail>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 
   it("renders without throwing", () => {

--- a/packages/smoothui/components/dialog/__tests__/dialog.test.tsx
+++ b/packages/smoothui/components/dialog/__tests__/dialog.test.tsx
@@ -1,8 +1,19 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import Dialog from "../index";
 
 describe("Dialog", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <Dialog title="Test Dialog" trigger={<button type="button">Open</button>}>
+        <p>Content</p>
+      </Dialog>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <Dialog title="Test Dialog" trigger={<button type="button">Open</button>}>

--- a/packages/smoothui/components/dither-chart/__tests__/dither-chart.test.tsx
+++ b/packages/smoothui/components/dither-chart/__tests__/dither-chart.test.tsx
@@ -137,11 +137,25 @@ describe("DitherChart draw pass", () => {
     const initialDraws = buffer.putImageData.mock.calls.length;
     expect(initialDraws).toBeGreaterThan(0);
 
-    flushFrames(4);
+    flushFrames(2);
     expect(buffer.putImageData.mock.calls.length).toBeGreaterThan(initialDraws);
 
     // The draw-in lasts 900ms; past that the loop must not reschedule.
-    runFramesFor(1200);
+    //
+    // Stepped coarsely on purpose. Every frame redraws the whole chart, and the
+    // last thing `draw` does is blit the low-res buffer over the full 320x180
+    // canvas — which the Canvas2D fake services by stamping all 57,600 pixels
+    // one at a time. That put ~75 full-surface repaints (1200ms at the default
+    // 16ms step) behind this one assertion and made it the slowest test in the
+    // file by an order of magnitude, close enough to the 5s budget that a busy
+    // machine could tip it over.
+    //
+    // Nothing is skipped by stepping in 300ms: the loop's stop condition is
+    // `elapsed >= DRAW_IN_DURATION_MS`, a clock comparison, not a frame count.
+    // Four coarse frames cross 900ms exactly as 75 fine ones do, and the
+    // assertion — that the loop stops rescheduling once past the draw-in — is
+    // unchanged.
+    runFramesFor(1200, { stepMs: 300 });
     expect(pendingFrameCount()).toBe(0);
   });
 

--- a/packages/smoothui/components/dither-image/__tests__/dither-image.test.tsx
+++ b/packages/smoothui/components/dither-image/__tests__/dither-image.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import {
   type Canvas2DMock,
   installCanvas2DMock,
@@ -19,6 +20,12 @@ const GRID_WIDTH = WIDTH / PIXEL_SIZE;
 const GRID_HEIGHT = HEIGHT / PIXEL_SIZE;
 
 describe("DitherImage", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<DitherImage alt="A photo" src={SRC} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<DitherImage alt="A photo" src={SRC} />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/dock/__tests__/dock.test.tsx
+++ b/packages/smoothui/components/dock/__tests__/dock.test.tsx
@@ -1,8 +1,23 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import Dock from "../index";
 
 describe("Dock", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <Dock
+        items={[
+          { icon: <span>A</span>, id: "one", label: "One" },
+          { active: true, icon: <span>B</span>, id: "two", label: "Two" },
+          { icon: <span>C</span>, id: "three", label: "Three" },
+        ]}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <Dock

--- a/packages/smoothui/components/dock/index.tsx
+++ b/packages/smoothui/components/dock/index.tsx
@@ -273,9 +273,9 @@ const DockIcon = ({
   };
 
   return (
-    <motion.li
+    <motion.div
       className={cn(
-        "absolute list-none",
+        "absolute",
         isHorizontal ? "bottom-0 left-0" : "top-0 right-0"
       )}
       onPointerEnter={onPointerEnter}
@@ -344,7 +344,7 @@ const DockIcon = ({
           )}
         />
       ) : null}
-    </motion.li>
+    </motion.div>
   );
 };
 
@@ -563,7 +563,7 @@ export default function Dock({
           }
         />
 
-        <ul
+        <div
           aria-orientation={orientation}
           className="absolute inset-0"
           role="toolbar"
@@ -590,7 +590,7 @@ export default function Dock({
               tabIndex={index === focusedIndex ? 0 : -1}
             />
           ))}
-        </ul>
+        </div>
       </div>
     </nav>
   );

--- a/packages/smoothui/components/dot-morph-button/__tests__/dot-morph-button.test.tsx
+++ b/packages/smoothui/components/dot-morph-button/__tests__/dot-morph-button.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import { DotMorphButton } from "../index";
 
 describe("DotMorphButton", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<DotMorphButton label="Click me" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<DotMorphButton label="Click me" />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/drawer/__tests__/drawer.test.tsx
+++ b/packages/smoothui/components/drawer/__tests__/drawer.test.tsx
@@ -1,8 +1,19 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import Drawer from "../index";
 
 describe("Drawer", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <Drawer title="Test Drawer" trigger={<button type="button">Open</button>}>
+        <p>Content</p>
+      </Drawer>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <Drawer title="Test Drawer" trigger={<button type="button">Open</button>}>

--- a/packages/smoothui/components/drawing-cursor/__tests__/drawing-cursor.test.tsx
+++ b/packages/smoothui/components/drawing-cursor/__tests__/drawing-cursor.test.tsx
@@ -1,5 +1,6 @@
 import { createRef } from "react";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import {
   type Canvas2DMock,
   flushFrame,
@@ -15,6 +16,16 @@ import DrawingCursor, { type DrawingCursorHandle } from "../index";
 const SIZE = 200;
 
 describe("DrawingCursor", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <DrawingCursor>
+        <p>Draw over this area</p>
+      </DrawingCursor>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <DrawingCursor>

--- a/packages/smoothui/components/dropdown-menu/__tests__/dropdown-menu.test.tsx
+++ b/packages/smoothui/components/dropdown-menu/__tests__/dropdown-menu.test.tsx
@@ -1,8 +1,19 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import DropdownMenu from "../index";
 
 describe("DropdownMenu", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <DropdownMenu items={[{ key: "item1", label: "Item 1" }]}>
+        <button type="button">Menu</button>
+      </DropdownMenu>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <DropdownMenu items={[{ key: "item1", label: "Item 1" }]}>

--- a/packages/smoothui/components/duration-picker/__tests__/duration-picker.test.tsx
+++ b/packages/smoothui/components/duration-picker/__tests__/duration-picker.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { fireEvent, render, screen } from "../../../test-utils/render";
 import DurationPicker, { formatDuration } from "../index";
 
 describe("DurationPicker", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<DurationPicker />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<DurationPicker />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/dynamic-island/__tests__/dynamic-island.test.tsx
+++ b/packages/smoothui/components/dynamic-island/__tests__/dynamic-island.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import DynamicIsland from "../index";
 
 describe("DynamicIsland", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<DynamicIsland />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<DynamicIsland />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/emboss-surface/__tests__/emboss-surface.test.tsx
+++ b/packages/smoothui/components/emboss-surface/__tests__/emboss-surface.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import EmbossSurface from "../index";
 
 describe("EmbossSurface", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<EmbossSurface>Relief text</EmbossSurface>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<EmbossSurface>Relief text</EmbossSurface>);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/emoji-reaction/__tests__/emoji-reaction.test.tsx
+++ b/packages/smoothui/components/emoji-reaction/__tests__/emoji-reaction.test.tsx
@@ -1,6 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render, screen, waitFor, within } from "../../../test-utils/render";
 import EmojiReaction, {
   type EmojiReactionItem,
@@ -50,6 +51,19 @@ const ControlledEmojiReaction = ({
 };
 
 describe("EmojiReaction", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <EmojiReaction
+        reactions={[
+          { count: 3, emoji: "🎉", id: "party", label: "Party" },
+          { emoji: "🔥", id: "fire", label: "Fire", reacted: true },
+        ]}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <EmojiReaction

--- a/packages/smoothui/components/expandable-cards/__tests__/expandable-cards.test.tsx
+++ b/packages/smoothui/components/expandable-cards/__tests__/expandable-cards.test.tsx
@@ -1,8 +1,22 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ExpandableCards from "../index";
 
 describe("ExpandableCards", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ExpandableCards
+        cards={[
+          { content: "Content 1", id: 1, image: "/test.jpg", title: "Card 1" },
+          { content: "Content 2", id: 2, image: "/test.jpg", title: "Card 2" },
+        ]}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <ExpandableCards

--- a/packages/smoothui/components/expandable-cards/index.tsx
+++ b/packages/smoothui/components/expandable-cards/index.tsx
@@ -92,24 +92,13 @@ export default function ExpandableCards({
             animate={{
               width: selectedCard === card.id ? "500px" : "200px",
             }}
-            aria-label={`${card.title} card${selectedCard === card.id ? ", expanded" : ""}`}
-            aria-selected={selectedCard === card.id}
-            className={`relative mr-4 h-[300px] shrink-0 cursor-pointer overflow-hidden rounded-2xl border bg-background shadow-lg focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 ${cardClassName}`}
+            className={`relative mr-4 h-[300px] shrink-0 cursor-pointer overflow-hidden rounded-2xl border bg-background shadow-lg ${cardClassName}`}
             data-card-id={card.id}
             key={card.id}
             layout
-            onClick={() => handleCardClick(card.id)}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" || e.key === " ") {
-                e.preventDefault();
-                handleCardClick(card.id);
-              }
-            }}
-            role="button"
             style={{
               scrollSnapAlign: "start",
             }}
-            tabIndex={0}
             transition={
               shouldReduceMotion
                 ? { duration: 0 }
@@ -130,8 +119,19 @@ export default function ExpandableCards({
               />
               <div className="absolute inset-0 bg-black/20" />
               <div className="absolute inset-0 flex flex-col justify-between p-6 text-white">
-                <h2 className="font-bold text-2xl">{card.title}</h2>
-                <div className="flex items-center gap-2">
+                <h2 className="font-bold text-2xl">
+                  {/* The `after` overlay makes the whole card face clickable
+                      without nesting the play button inside another control. */}
+                  <button
+                    aria-expanded={selectedCard === card.id}
+                    className="rounded-sm text-left after:absolute after:inset-0 after:content-[''] focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    onClick={() => handleCardClick(card.id)}
+                    type="button"
+                  >
+                    {card.title}
+                  </button>
+                </h2>
+                <div className="relative flex items-center gap-2">
                   <button
                     aria-label={`Play video: ${card.title}`}
                     className="ease flex h-12 min-h-[44px] w-12 min-w-[44px] items-center justify-center rounded-full bg-background/30 backdrop-blur-sm transition-transform duration-200 hover:scale-110 focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"

--- a/packages/smoothui/components/expandable-navbar/__tests__/expandable-navbar.test.tsx
+++ b/packages/smoothui/components/expandable-navbar/__tests__/expandable-navbar.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ExpandableNavbar, { type ExpandableNavbarItem } from "../index";
 
@@ -8,6 +9,12 @@ const items: ExpandableNavbarItem[] = [
 ];
 
 describe("ExpandableNavbar", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<ExpandableNavbar items={items} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<ExpandableNavbar items={items} />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/exposure-slider/__tests__/exposure-slider.test.tsx
+++ b/packages/smoothui/components/exposure-slider/__tests__/exposure-slider.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ExposureSlider from "../index";
 
 describe("ExposureSlider", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<ExposureSlider />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<ExposureSlider />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/favicon-search/__tests__/favicon-search.test.tsx
+++ b/packages/smoothui/components/favicon-search/__tests__/favicon-search.test.tsx
@@ -1,5 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { fireEvent, render, screen } from "../../../test-utils/render";
 import FaviconSearch, { type FaviconSearchResult } from "../index";
 
@@ -18,6 +19,12 @@ const results: FaviconSearchResult[] = [
 ];
 
 describe("FaviconSearch", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<FaviconSearch results={results} />);
+    const axeResults = await axe(container);
+    expect(axeResults).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<FaviconSearch results={results} />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/figma-comment/__tests__/figma-comment.test.tsx
+++ b/packages/smoothui/components/figma-comment/__tests__/figma-comment.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import Component from "../index";
 
 describe("FigmaComment", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<Component />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<Component />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/file-tree/__tests__/file-tree.test.tsx
+++ b/packages/smoothui/components/file-tree/__tests__/file-tree.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { fireEvent, render, screen } from "../../../test-utils/render";
 import FileTree, { type FileTreeItem } from "../index";
 
@@ -22,6 +23,12 @@ const getRow = (name: string) =>
   screen.getByText(name).closest('[role="treeitem"]') as HTMLElement;
 
 describe("FileTree", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<FileTree items={flatItems} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<FileTree items={flatItems} />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/floating-navbar/__tests__/floating-navbar.test.tsx
+++ b/packages/smoothui/components/floating-navbar/__tests__/floating-navbar.test.tsx
@@ -1,8 +1,22 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import FloatingNavbar from "../index";
 
 describe("FloatingNavbar", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <FloatingNavbar
+        items={[
+          { href: "#home", id: "home", label: "Home" },
+          { id: "about", label: "About" },
+        ]}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <FloatingNavbar

--- a/packages/smoothui/components/folder-reveal/__tests__/folder-reveal.test.tsx
+++ b/packages/smoothui/components/folder-reveal/__tests__/folder-reveal.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import FolderReveal, { type FolderRevealItem } from "../index";
 
@@ -8,6 +9,12 @@ const items: FolderRevealItem[] = [
 ];
 
 describe("FolderReveal", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<FolderReveal items={items} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<FolderReveal items={items} />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/form/__tests__/form.test.tsx
+++ b/packages/smoothui/components/form/__tests__/form.test.tsx
@@ -1,8 +1,25 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import Form, { FormControl, FormField, FormLabel, FormMessage } from "../index";
 
 describe("Form", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <Form>
+        <FormField name="email">
+          <FormLabel>Email</FormLabel>
+          <FormControl>
+            <input type="email" />
+          </FormControl>
+          <FormMessage />
+        </FormField>
+      </Form>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <Form>

--- a/packages/smoothui/components/github-stars-animation/__tests__/github-stars-animation.test.tsx
+++ b/packages/smoothui/components/github-stars-animation/__tests__/github-stars-animation.test.tsx
@@ -1,5 +1,6 @@
 import { waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import Component, { type Stargazer } from "../index";
 
@@ -33,6 +34,12 @@ describe("GithubStarsAnimation", () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<Component />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 
   it("renders without throwing", () => {

--- a/packages/smoothui/components/glass-card/__tests__/glass-card.test.tsx
+++ b/packages/smoothui/components/glass-card/__tests__/glass-card.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import GlassCard from "../index";
 
 describe("GlassCard", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<GlassCard>Card content</GlassCard>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<GlassCard>Card content</GlassCard>);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/glow-hover-card/__tests__/glow-hover-card.test.tsx
+++ b/packages/smoothui/components/glow-hover-card/__tests__/glow-hover-card.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import GlowHover, { type GlowHoverItem } from "../index";
 
@@ -8,6 +9,12 @@ const items: GlowHoverItem[] = [
 ];
 
 describe("GlowHoverCard", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<GlowHover items={items} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<GlowHover items={items} />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/gooey-filter/__tests__/gooey-filter.test.tsx
+++ b/packages/smoothui/components/gooey-filter/__tests__/gooey-filter.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import GooeyFilter from "../index";
 
 describe("GooeyFilter", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<GooeyFilter>Blob content</GooeyFilter>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<GooeyFilter>Blob content</GooeyFilter>);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/gooey-popover/__tests__/gooey-popover.test.tsx
+++ b/packages/smoothui/components/gooey-popover/__tests__/gooey-popover.test.tsx
@@ -1,5 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import {
   fireEvent,
   render,
@@ -33,6 +34,12 @@ const mockScrollHeight = (height: number) => {
 describe("GooeyPopover", () => {
   afterEach(() => {
     mockMatchMedia(false);
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<GooeyPopover>Open</GooeyPopover>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 
   it("renders without throwing", () => {

--- a/packages/smoothui/components/gooey-popover/index.tsx
+++ b/packages/smoothui/components/gooey-popover/index.tsx
@@ -19,6 +19,11 @@ const CONTENT_BORDER_RADIUS = 18;
 export type GooeyPopoverProps = {
   children: React.ReactNode;
   trigger?: React.ReactNode;
+  /**
+   * Accessible name for the trigger. Required when `trigger` renders no text
+   * of its own; the default plus icon falls back to "Open popover".
+   */
+  triggerLabel?: string;
   triggerSize?: number;
   isOpen?: boolean;
   onOpenChange?: (open: boolean) => void;
@@ -34,6 +39,7 @@ export type GooeyPopoverProps = {
 export default function GooeyPopover({
   children,
   trigger,
+  triggerLabel,
   triggerSize = DEFAULT_TRIGGER_SIZE,
   isOpen: controlledIsOpen,
   onOpenChange,
@@ -300,6 +306,7 @@ export default function GooeyPopover({
 
   const defaultTriggerIcon = (
     <svg
+      aria-hidden="true"
       fill="none"
       height={20}
       stroke="currentColor"
@@ -395,6 +402,7 @@ export default function GooeyPopover({
       <button
         aria-expanded={isOpen}
         aria-haspopup="dialog"
+        aria-label={triggerLabel ?? (trigger ? undefined : "Open popover")}
         className={cn(
           "relative z-10 flex cursor-pointer items-center justify-center rounded-full text-white transition-colors",
           bgClassName

--- a/packages/smoothui/components/gravity-letters/__tests__/gravity-letters.test.tsx
+++ b/packages/smoothui/components/gravity-letters/__tests__/gravity-letters.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { fireEvent, render } from "../../../test-utils/render";
 import GravityLetters from "../index";
 
@@ -71,6 +72,12 @@ describe("GravityLetters", () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<GravityLetters text="Hello" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 
   it("renders without throwing", () => {

--- a/packages/smoothui/components/gravity-stars/__tests__/gravity-stars.test.tsx
+++ b/packages/smoothui/components/gravity-stars/__tests__/gravity-stars.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, type Mock } from "vitest";
+import { axe } from "vitest-axe";
 import {
   type Canvas2DMock,
   type FakeCanvas2DContext,
@@ -19,6 +20,16 @@ const SPRITE_LEVELS = 5;
 const COUNT = 40;
 
 describe("GravityStars", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <GravityStars>
+        <p>Content above the starfield</p>
+      </GravityStars>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <GravityStars>

--- a/packages/smoothui/components/grid-loader/__tests__/grid-loader.test.tsx
+++ b/packages/smoothui/components/grid-loader/__tests__/grid-loader.test.tsx
@@ -1,8 +1,15 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import Component from "../index";
 
 describe("GridLoader", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<Component />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<Component />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/holographic-foil/__tests__/holographic-foil.test.tsx
+++ b/packages/smoothui/components/holographic-foil/__tests__/holographic-foil.test.tsx
@@ -1,8 +1,17 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import HolographicFoil from "../index";
 
 describe("HolographicFoil", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <HolographicFoil>Card content</HolographicFoil>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <HolographicFoil>Card content</HolographicFoil>

--- a/packages/smoothui/components/hover-expand/__tests__/hover-expand.test.tsx
+++ b/packages/smoothui/components/hover-expand/__tests__/hover-expand.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import HoverExpand, { type HoverExpandItem } from "../index";
 
@@ -8,6 +9,12 @@ const items: HoverExpandItem[] = [
 ];
 
 describe("HoverExpand", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(<HoverExpand items={items} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(<HoverExpand items={items} />);
     expect(container).toBeInTheDocument();

--- a/packages/smoothui/components/hover-image-list/__tests__/hover-image-list.test.tsx
+++ b/packages/smoothui/components/hover-image-list/__tests__/hover-image-list.test.tsx
@@ -1,8 +1,34 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import HoverImageList from "../index";
 
 describe("HoverImageList", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <HoverImageList
+        items={[
+          {
+            alt: "First item",
+            id: "1",
+            image: "https://example.com/one.png",
+            title: "First",
+          },
+          {
+            alt: "Second item",
+            href: "#second",
+            id: "2",
+            image: "https://example.com/two.png",
+            meta: "2024",
+            title: "Second",
+          },
+        ]}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("renders without throwing", () => {
     const { container } = render(
       <HoverImageList

--- a/packages/smoothui/components/image-generation-panel/__tests__/image-generation-panel.test.tsx
+++ b/packages/smoothui/components/image-generation-panel/__tests__/image-generation-panel.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ImageGenerationPanel, { type ImageGenerationImage } from "../index";
 
@@ -22,5 +23,11 @@ describe("ImageGenerationPanel", () => {
       />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<ImageGenerationPanel />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/image-metadata-preview/__tests__/image-metadata-preview.test.tsx
+++ b/packages/smoothui/components/image-metadata-preview/__tests__/image-metadata-preview.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ImageMetadataPreview, { type ImageMetadata } from "../index";
 
@@ -18,5 +19,16 @@ describe("ImageMetadataPreview", () => {
       />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ImageMetadataPreview
+        imageSrc="https://example.com/photo.jpg"
+        metadata={metadata}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/infinite-slider/__tests__/infinite-slider.test.tsx
+++ b/packages/smoothui/components/infinite-slider/__tests__/infinite-slider.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import InfiniteSlider from "../index";
 
@@ -11,5 +12,16 @@ describe("InfiniteSlider", () => {
       </InfiniteSlider>
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <InfiniteSlider>
+        <span>One</span>
+        <span>Two</span>
+      </InfiniteSlider>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/inline-testimonials/__tests__/inline-testimonials.test.tsx
+++ b/packages/smoothui/components/inline-testimonials/__tests__/inline-testimonials.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import InlineTestimonials, { type Testimonial } from "../index";
 
@@ -33,5 +34,16 @@ describe("InlineTestimonials", () => {
       />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <InlineTestimonials
+        testimonials={testimonials}
+        text="Loved by {{t1}} and many more."
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/interactive-image-selector/__tests__/interactive-image-selector.test.tsx
+++ b/packages/smoothui/components/interactive-image-selector/__tests__/interactive-image-selector.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent, waitFor } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import InteractiveImageSelector, { type ImageData } from "../index";
 
@@ -155,5 +156,11 @@ describe("InteractiveImageSelector", () => {
 
     expect(getByRole("button", { name: "Reset selection" })).not.toBeDisabled();
     vi.useRealTimers();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<InteractiveImageSelector images={images} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/job-listing-component/__tests__/job-listing-component.test.tsx
+++ b/packages/smoothui/components/job-listing-component/__tests__/job-listing-component.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import JobListingComponent, { type Job } from "../index";
 
@@ -19,5 +20,11 @@ describe("JobListingComponent", () => {
   it("renders without throwing", () => {
     const { container } = render(<JobListingComponent jobs={jobs} />);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<JobListingComponent jobs={jobs} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/kinetic-center-build/__tests__/kinetic-center-build.test.tsx
+++ b/packages/smoothui/components/kinetic-center-build/__tests__/kinetic-center-build.test.tsx
@@ -1,5 +1,6 @@
 import { act, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import KineticCenterBuild from "../index";
 
@@ -109,5 +110,15 @@ describe("KineticCenterBuild with reduced motion", () => {
 
     expect(screen.getByText("Goodbye")).toBeInTheDocument();
     expect(screen.getByText("now")).toBeInTheDocument();
+  });
+});
+
+describe("KineticCenterBuild accessibility", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <KineticCenterBuild phrases={["Hello World"]} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/kinetic-type-scroll/__tests__/kinetic-type-scroll.test.tsx
+++ b/packages/smoothui/components/kinetic-type-scroll/__tests__/kinetic-type-scroll.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import KineticTypeScroll from "../index";
 
@@ -15,5 +16,11 @@ describe("KineticTypeScroll", () => {
       <KineticTypeScroll align="end" words={words} />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<KineticTypeScroll words={words} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/kinetic-type-scroll/index.tsx
+++ b/packages/smoothui/components/kinetic-type-scroll/index.tsx
@@ -197,7 +197,6 @@ export default function KineticTypeScroll({
 
   return (
     <div
-      aria-label={words.join(" ")}
       className={cn(
         // Gaps are in `em` and sized to clear the peak scale: `scale` is a
         // transform, so a magnified word overflows its layout box and a fixed
@@ -208,6 +207,9 @@ export default function KineticTypeScroll({
       )}
       ref={wrapperRef}
     >
+      {/* Every glyph below is aria-hidden, so the readable copy lives here. An
+          aria-label on this plain div would be dropped by assistive tech. */}
+      <span className="sr-only">{words.join(" ")}</span>
       {words.map((word, index) => (
         <KineticWord
           dimRange={dimRange}

--- a/packages/smoothui/components/liquid-metal/__tests__/liquid-metal.test.tsx
+++ b/packages/smoothui/components/liquid-metal/__tests__/liquid-metal.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import LiquidMetal from "../index";
 
@@ -15,5 +16,11 @@ describe("LiquidMetal", () => {
       </LiquidMetal>
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<LiquidMetal>Chrome</LiquidMetal>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/mac-terminal/__tests__/mac-terminal.test.tsx
+++ b/packages/smoothui/components/mac-terminal/__tests__/mac-terminal.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { act, fireEvent, render, screen } from "../../../test-utils/render";
 import MacTerminal, { type TerminalLine } from "../index";
 
@@ -160,5 +161,15 @@ describe("MacTerminal", () => {
     expect(
       screen.getByText("Click or press Enter to run this session")
     ).toBeInTheDocument();
+  });
+});
+
+describe("MacTerminal accessibility", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <MacTerminal autoPlay={false} lines={lines} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/magnetic-button/__tests__/magnetic-button.test.tsx
+++ b/packages/smoothui/components/magnetic-button/__tests__/magnetic-button.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import MagneticButton from "../index";
 
@@ -6,5 +7,11 @@ describe("MagneticButton", () => {
   it("renders without throwing", () => {
     const { container } = render(<MagneticButton>Pull me</MagneticButton>);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<MagneticButton>Pull me</MagneticButton>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/magnetic-field/__tests__/magnetic-field.test.tsx
+++ b/packages/smoothui/components/magnetic-field/__tests__/magnetic-field.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { fireEvent, render, screen } from "../../../test-utils/render";
 import MagneticField from "../index";
 
@@ -267,5 +268,17 @@ describe("MagneticField", () => {
     expect(button.style.transform).toBe(
       "translate3d(0px, 0px, 0) rotate(0deg)"
     );
+  });
+});
+
+describe("MagneticField accessibility", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <MagneticField>
+        <button type="button">Item</button>
+      </MagneticField>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/morph-icon/__tests__/morph-icon.test.tsx
+++ b/packages/smoothui/components/morph-icon/__tests__/morph-icon.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import MorphIcon, { MORPH_ICON_VARIANTS } from "../index";
 
@@ -13,5 +14,13 @@ describe("MorphIcon", () => {
   it("renders the active check variant without throwing", () => {
     const { container } = render(<MorphIcon active variant="check" />);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <MorphIcon variant={MORPH_ICON_VARIANTS[0]} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/morph-surface/__tests__/morph-surface.test.tsx
+++ b/packages/smoothui/components/morph-surface/__tests__/morph-surface.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import MorphSurface from "../index";
 
@@ -6,5 +7,11 @@ describe("MorphSurface", () => {
   it("renders without throwing", () => {
     const { container } = render(<MorphSurface />);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<MorphSurface />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/motion-loader/__tests__/motion-loader.test.tsx
+++ b/packages/smoothui/components/motion-loader/__tests__/motion-loader.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import MotionLoader from "../index";
 
@@ -18,5 +19,11 @@ describe("MotionLoader", () => {
       <MotionLoader color="tomato" size={64} variant="wave-bars" />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<MotionLoader />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/music-toggle/__tests__/music-toggle.test.tsx
+++ b/packages/smoothui/components/music-toggle/__tests__/music-toggle.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import MusicToggle from "../index";
 
@@ -19,5 +20,11 @@ describe("MusicToggle", () => {
       />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<MusicToggle />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/notification-badge/__tests__/notification-badge.test.tsx
+++ b/packages/smoothui/components/notification-badge/__tests__/notification-badge.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import NotificationBadge from "../index";
 
@@ -6,5 +7,11 @@ describe("NotificationBadge", () => {
   it("renders without throwing", () => {
     const { container } = render(<NotificationBadge />);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<NotificationBadge />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/number-flow/__tests__/number-flow.test.tsx
+++ b/packages/smoothui/components/number-flow/__tests__/number-flow.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import NumberFlow from "../index";
 
@@ -6,5 +7,11 @@ describe("NumberFlow", () => {
   it("renders without throwing", () => {
     const { container } = render(<NumberFlow />);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<NumberFlow />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/orbital-image-wheel/__tests__/orbital-image-wheel.test.tsx
+++ b/packages/smoothui/components/orbital-image-wheel/__tests__/orbital-image-wheel.test.tsx
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { act, fireEvent, render, screen } from "../../../test-utils/render";
 import OrbitalImageWheel, { type OrbitalImageWheelItem } from "../index";
 
@@ -289,5 +290,15 @@ describe("OrbitalImageWheel", () => {
       "aria-current",
       "true"
     );
+  });
+});
+
+describe("OrbitalImageWheel accessibility", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <OrbitalImageWheel autoRotate={false} items={items} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/organic-merge-transition/__tests__/organic-merge-transition.test.tsx
+++ b/packages/smoothui/components/organic-merge-transition/__tests__/organic-merge-transition.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import OrganicMergeTransition from "../index";
 
@@ -11,5 +12,15 @@ describe("OrganicMergeTransition", () => {
     );
 
     expect(getByText("Draft saved")).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <OrganicMergeTransition transitionKey="draft">
+        Draft saved
+      </OrganicMergeTransition>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/page-preloader/__tests__/page-preloader.test.tsx
+++ b/packages/smoothui/components/page-preloader/__tests__/page-preloader.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import PagePreloader, { PAGE_PRELOADER_VARIANTS } from "../index";
 
@@ -13,5 +14,13 @@ describe("PagePreloader", () => {
   it("renders the pixel variant without throwing", () => {
     const { container } = render(<PagePreloader active variant="pixel" />);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <PagePreloader active variant={PAGE_PRELOADER_VARIANTS[0]} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/pagination/__tests__/pagination.test.tsx
+++ b/packages/smoothui/components/pagination/__tests__/pagination.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import Pagination from "../index";
 
@@ -8,5 +9,13 @@ describe("Pagination", () => {
       <Pagination onPageChange={vi.fn()} page={1} totalPages={10} />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <Pagination onPageChange={vi.fn()} page={1} totalPages={10} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/parallax-layers/__tests__/parallax-layers.test.tsx
+++ b/packages/smoothui/components/parallax-layers/__tests__/parallax-layers.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ParallaxLayers from "../index";
 
@@ -24,5 +25,18 @@ describe("ParallaxLayers", () => {
       />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ParallaxLayers
+        layers={[
+          { content: <div>Back</div>, depth: 0.2, id: "back" },
+          { blur: 2, content: <div>Front</div>, depth: 0.8, id: "front" },
+        ]}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/perspective-text-3d/__tests__/perspective-text-3d.test.tsx
+++ b/packages/smoothui/components/perspective-text-3d/__tests__/perspective-text-3d.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import PerspectiveText3D from "../index";
 
@@ -19,5 +20,13 @@ describe("PerspectiveText3D", () => {
       />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <PerspectiveText3D text="Hello depth world" />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/perspective-text-3d/index.tsx
+++ b/packages/smoothui/components/perspective-text-3d/index.tsx
@@ -137,11 +137,13 @@ export default function PerspectiveText3D({
 
   return (
     <div
-      aria-label={content}
       className={cn("inline-block", className)}
       ref={wrapperRef}
       style={{ perspective }}
     >
+      {/* Every segment below is aria-hidden, so the readable copy lives here.
+          An aria-label on this plain div would be dropped by assistive tech. */}
+      <span className="sr-only">{content}</span>
       <motion.div
         animate={planeAnimate}
         initial={planeInitial}

--- a/packages/smoothui/components/phototab/__tests__/phototab.test.tsx
+++ b/packages/smoothui/components/phototab/__tests__/phototab.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import Phototab from "../index";
 
@@ -10,5 +11,15 @@ describe("Phototab", () => {
       />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <Phototab
+        tabs={[{ icon: <span>icon</span>, image: "/test.jpg", name: "Tab 1" }]}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/phototab/index.tsx
+++ b/packages/smoothui/components/phototab/index.tsx
@@ -38,6 +38,16 @@ export interface PhototabProps {
   tabTriggerClassName?: string;
 }
 
+const WHITESPACE = /\s+/g;
+
+/**
+ * Radix derives the trigger/panel element ids from the tab value, and an id may
+ * not contain whitespace — a multi-word tab name such as "Tab 1" produced an
+ * `aria-controls` that resolved to nothing, breaking the tab/panel pairing for
+ * assistive tech. Values are slugged so the generated ids stay valid.
+ */
+const toTabValue = (name: string) => name.replace(WHITESPACE, "-");
+
 export default function Phototab({
   tabs,
   defaultTab,
@@ -84,7 +94,7 @@ export default function Phototab({
   return (
     <TabsRoot
       className={`group relative aspect-square w-auto overflow-hidden ${className}`}
-      defaultValue={defaultTab || (tabs[0]?.name ?? "")}
+      defaultValue={toTabValue(defaultTab || (tabs[0]?.name ?? ""))}
       orientation="horizontal"
       style={{ height: `${height}px` }}
     >
@@ -136,7 +146,7 @@ export default function Phototab({
             ref={(el) => {
               triggersRef.current[index] = el;
             }}
-            value={tab.name}
+            value={toTabValue(tab.name)}
           >
             <span className="relative z-10 rounded-full focus:outline-none">
               {tab.icon}
@@ -146,7 +156,11 @@ export default function Phototab({
         ))}
       </TabsList>
       {tabs.map((tab) => (
-        <TabsContent className="h-full w-full" key={tab.name} value={tab.name}>
+        <TabsContent
+          className="h-full w-full"
+          key={tab.name}
+          value={toTabValue(tab.name)}
+        >
           <img
             alt={tab.name}
             className={`h-full w-full rounded-2xl bg-primary object-cover ${imageClassName}`}

--- a/packages/smoothui/components/pinned-list/__tests__/pinned-list.test.tsx
+++ b/packages/smoothui/components/pinned-list/__tests__/pinned-list.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import PinnedList, { type PinnedListItem } from "../index";
 
@@ -21,5 +22,11 @@ describe("PinnedList", () => {
       />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<PinnedList items={items} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/pixel-brush-canvas/__tests__/pixel-brush-canvas.test.tsx
+++ b/packages/smoothui/components/pixel-brush-canvas/__tests__/pixel-brush-canvas.test.tsx
@@ -1,5 +1,6 @@
 import { createRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import {
   type Canvas2DMock,
   installCanvas2DMock,
@@ -28,6 +29,12 @@ describe("PixelBrushCanvas", () => {
   it("renders with the grid overlay and no tools without throwing", () => {
     const { container } = render(<PixelBrushCanvas grid showTools={false} />);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<PixelBrushCanvas />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });
 

--- a/packages/smoothui/components/pixel-flow-field/__tests__/pixel-flow-field.test.tsx
+++ b/packages/smoothui/components/pixel-flow-field/__tests__/pixel-flow-field.test.tsx
@@ -7,6 +7,7 @@ import {
   expect,
   it,
 } from "vitest";
+import { axe } from "vitest-axe";
 import {
   type Canvas2DMock,
   type FakeCanvas2DContext,
@@ -55,6 +56,12 @@ describe("PixelFlowField", () => {
   it("renders with a circle shape and custom text", () => {
     const { container } = render(<PixelFlowField shape="circle" text="flow" />);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<PixelFlowField>Content</PixelFlowField>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });
 

--- a/packages/smoothui/components/power-off-slide/__tests__/power-off-slide.test.tsx
+++ b/packages/smoothui/components/power-off-slide/__tests__/power-off-slide.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import PowerOffSlide from "../index";
 
@@ -6,5 +7,11 @@ describe("PowerOffSlide", () => {
   it("renders without throwing", () => {
     const { container } = render(<PowerOffSlide />);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<PowerOffSlide />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/price-flow/__tests__/price-flow.test.tsx
+++ b/packages/smoothui/components/price-flow/__tests__/price-flow.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import PriceFlow from "../index";
 
@@ -6,5 +7,11 @@ describe("PriceFlow", () => {
   it("renders without throwing", () => {
     const { container } = render(<PriceFlow value={42} />);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<PriceFlow value={42} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/prism-sweep-transition/__tests__/prism-sweep-transition.test.tsx
+++ b/packages/smoothui/components/prism-sweep-transition/__tests__/prism-sweep-transition.test.tsx
@@ -1,5 +1,6 @@
 import { useReducedMotion } from "motion/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import {
   flushFrames,
@@ -186,4 +187,16 @@ describe("PrismSweepTransition", () => {
       expect(onRest).toHaveBeenCalledTimes(1);
     });
   }
+});
+
+describe("PrismSweepTransition accessibility", () => {
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <PrismSweepTransition transitionKey="draft">
+        Draft saved
+      </PrismSweepTransition>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
 });

--- a/packages/smoothui/components/product-card/__tests__/product-card.test.tsx
+++ b/packages/smoothui/components/product-card/__tests__/product-card.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ProductCard from "../index";
 
@@ -8,5 +9,13 @@ describe("ProductCard", () => {
       <ProductCard image="/test.jpg" price={29.99} title="Test Product" />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ProductCard image="/test.jpg" price={29.99} title="Test Product" />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/progressive-blur/__tests__/progressive-blur.test.tsx
+++ b/packages/smoothui/components/progressive-blur/__tests__/progressive-blur.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ProgressiveBlur from "../index";
 
@@ -17,5 +18,15 @@ describe("ProgressiveBlur", () => {
       <ProgressiveBlur direction="radial" layers={4} />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ProgressiveBlur>
+        <p>Content above the blur</p>
+      </ProgressiveBlur>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/radial-circles-transition/__tests__/radial-circles-transition.test.tsx
+++ b/packages/smoothui/components/radial-circles-transition/__tests__/radial-circles-transition.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import RadialCirclesTransition from "../index";
 
@@ -11,5 +12,15 @@ describe("RadialCirclesTransition", () => {
     );
 
     expect(getByText("Draft saved")).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <RadialCirclesTransition transitionKey="draft">
+        Draft saved
+      </RadialCirclesTransition>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/radio-group/__tests__/radio-group.a11y.test.tsx
+++ b/packages/smoothui/components/radio-group/__tests__/radio-group.a11y.test.tsx
@@ -22,6 +22,20 @@ describe("RadioGroup a11y", () => {
     expect(results).toHaveNoViolations();
   });
 
+  // `id` is optional on Radio, and every case above supplies one. Without a
+  // generated fallback the label's htmlFor resolved to nothing and the radio
+  // was left with no accessible name at all.
+  it("has no accessibility violations without explicit ids", async () => {
+    const { container } = render(
+      <RadioGroup aria-label="Unlabelled options" defaultValue="a">
+        <Radio value="a">Option A</Radio>
+        <Radio value="b">Option B</Radio>
+      </RadioGroup>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
   it("has no accessibility violations when disabled", async () => {
     const { container } = render(
       <RadioGroup aria-label="Disabled options" defaultValue="a" disabled>

--- a/packages/smoothui/components/radio-group/index.tsx
+++ b/packages/smoothui/components/radio-group/index.tsx
@@ -4,7 +4,7 @@ import { cn } from "@repo/shadcn-ui/lib/utils";
 import { motion, useReducedMotion } from "motion/react";
 import { RadioGroup as RadioGroupPrimitive } from "radix-ui";
 import type React from "react";
-import { Children, cloneElement, isValidElement } from "react";
+import { Children, cloneElement, isValidElement, useId } from "react";
 import { SPRING_DEFAULT } from "../../lib/animation";
 
 export interface RadioGroupProps {
@@ -115,6 +115,12 @@ export function Radio({
   const shouldReduceMotion = useReducedMotion();
   const staggerDelay =
     _staggerIndex === undefined ? 0 : _staggerIndex * STAGGER_DELAY;
+  // Radix renders the item as a <button role="radio"> with no inner text, so
+  // its only accessible name is the sibling <label>. Without a generated
+  // fallback the label's htmlFor pointed nowhere whenever the consumer omitted
+  // `id`, leaving the control nameless.
+  const generatedId = useId();
+  const radioId = id ?? generatedId;
 
   const wrapper = (content: React.ReactNode) => {
     if (shouldReduceMotion || _staggerIndex === undefined) {
@@ -149,7 +155,7 @@ export function Radio({
           )}
           data-slot="radio-group-item"
           disabled={disabled}
-          id={id}
+          id={radioId}
           value={value}
         >
           <RadioGroupPrimitive.Indicator
@@ -188,7 +194,7 @@ export function Radio({
             "font-medium text-sm leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70",
             disabled && "cursor-not-allowed opacity-70"
           )}
-          htmlFor={id}
+          htmlFor={radioId}
         >
           {children}
         </label>

--- a/packages/smoothui/components/ransom-note/__tests__/ransom-note.test.tsx
+++ b/packages/smoothui/components/ransom-note/__tests__/ransom-note.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import RansomNote from "../index";
 
@@ -13,5 +14,11 @@ describe("RansomNote", () => {
       <RansomNote animate="jitter" text="Jittery note" />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<RansomNote text="Ransom note" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/reveal-text/__tests__/reveal-text.test.tsx
+++ b/packages/smoothui/components/reveal-text/__tests__/reveal-text.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import RevealText from "../index";
 
@@ -6,5 +7,11 @@ describe("RevealText", () => {
   it("renders without throwing", () => {
     const { container } = render(<RevealText>Hello World</RevealText>);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<RevealText>Hello World</RevealText>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/reviews-carousel/__tests__/reviews-carousel.test.tsx
+++ b/packages/smoothui/components/reviews-carousel/__tests__/reviews-carousel.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ReviewsCarousel from "../index";
 
@@ -13,5 +14,18 @@ describe("ReviewsCarousel", () => {
       />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ReviewsCarousel
+        reviews={[
+          { author: "Alice", body: "Great!", id: "1", title: "Review 1" },
+          { author: "Bob", body: "Nice!", id: "2", title: "Review 2" },
+        ]}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/rich-popover/__tests__/rich-popover.test.tsx
+++ b/packages/smoothui/components/rich-popover/__tests__/rich-popover.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import RichPopover from "../index";
 
@@ -8,5 +9,13 @@ describe("RichPopover", () => {
       <RichPopover title="Test" trigger={<button type="button">Open</button>} />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <RichPopover title="Test" trigger={<button type="button">Open</button>} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/rolling-text/__tests__/rolling-text.test.tsx
+++ b/packages/smoothui/components/rolling-text/__tests__/rolling-text.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import RollingText from "../index";
 
@@ -13,5 +14,11 @@ describe("RollingText", () => {
       <RollingText direction="down" text="Smooth" />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<RollingText text="Smooth" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/rolling-text/index.tsx
+++ b/packages/smoothui/components/rolling-text/index.tsx
@@ -171,11 +171,13 @@ export default function RollingText({
 
   return (
     <span
-      aria-label={text}
       className={className}
       onPointerEnter={handlePointerEnter}
       ref={containerRef}
     >
+      {/* Every glyph below is aria-hidden, so the readable copy lives here. An
+          aria-label on this plain span would be dropped by assistive tech. */}
+      <span className="sr-only">{text}</span>
       {characters.map((character, characterIndex) =>
         character.isWhitespace ? (
           <span

--- a/packages/smoothui/components/scramble-hover/__tests__/scramble-hover.test.tsx
+++ b/packages/smoothui/components/scramble-hover/__tests__/scramble-hover.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ScrambleHover from "../index";
 
@@ -6,5 +7,11 @@ describe("ScrambleHover", () => {
   it("renders without throwing", () => {
     const { container } = render(<ScrambleHover>Hello</ScrambleHover>);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<ScrambleHover>Hello</ScrambleHover>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/scroll-image-reveal/__tests__/scroll-image-reveal.test.tsx
+++ b/packages/smoothui/components/scroll-image-reveal/__tests__/scroll-image-reveal.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ScrollImageReveal from "../index";
 
@@ -22,5 +23,16 @@ describe("ScrollImageReveal", () => {
       />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ScrollImageReveal
+        alt="A landscape photo"
+        src="https://example.com/landscape.png"
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/scroll-progress/__tests__/scroll-progress.test.tsx
+++ b/packages/smoothui/components/scroll-progress/__tests__/scroll-progress.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ScrollProgress from "../index";
 
@@ -16,5 +17,11 @@ describe("ScrollProgress", () => {
   it("renders the segments variant without throwing", () => {
     const { container } = render(<ScrollProgress variant="segments" />);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<ScrollProgress showLabel />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/scroll-reveal-paragraph/__tests__/scroll-reveal-paragraph.test.tsx
+++ b/packages/smoothui/components/scroll-reveal-paragraph/__tests__/scroll-reveal-paragraph.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ScrollRevealParagraph from "../index";
 
@@ -8,5 +9,13 @@ describe("ScrollRevealParagraph", () => {
       <ScrollRevealParagraph paragraph="This is a test paragraph." />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ScrollRevealParagraph paragraph="This is a test paragraph." />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/scrollable-card-stack/__tests__/scrollable-card-stack.test.tsx
+++ b/packages/smoothui/components/scrollable-card-stack/__tests__/scrollable-card-stack.test.tsx
@@ -1,5 +1,6 @@
 import { act } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { fireEvent, render, screen } from "../../../test-utils/render";
 import ScrollableCardStack from "../index";
 
@@ -139,5 +140,12 @@ describe("ScrollableCardStack", () => {
     const { container } = render(<ScrollableCardStack items={buildItems(2)} />);
 
     expect(container.querySelector('[data-active="true"]')).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    vi.useRealTimers();
+    const { container } = render(<ScrollableCardStack items={buildItems(2)} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/scrubber/__tests__/scrubber.test.tsx
+++ b/packages/smoothui/components/scrubber/__tests__/scrubber.test.tsx
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { fireEvent, render, screen } from "../../../test-utils/render";
 import Scrubber from "../index";
 
@@ -185,5 +186,13 @@ describe("Scrubber", () => {
     const { container } = render(<Scrubber ticks={0} />);
 
     expect(container.querySelectorAll(".bg-foreground\\/25").length).toBe(0);
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <Scrubber decimals={1} defaultValue={0.5} label="Opacity" />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/sdf-blob-transition/__tests__/sdf-blob-transition.test.tsx
+++ b/packages/smoothui/components/sdf-blob-transition/__tests__/sdf-blob-transition.test.tsx
@@ -1,5 +1,6 @@
 import { useReducedMotion } from "motion/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import {
   flushFrames,
@@ -155,4 +156,12 @@ describe("SdfBlobTransition", () => {
       expect(onRest).toHaveBeenCalledTimes(1);
     });
   }
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <SdfBlobTransition transitionKey="draft">Draft saved</SdfBlobTransition>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
 });

--- a/packages/smoothui/components/sdf-circle-transition/__tests__/sdf-circle-transition.test.tsx
+++ b/packages/smoothui/components/sdf-circle-transition/__tests__/sdf-circle-transition.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import SdfCircleTransition from "../index";
 
@@ -11,5 +12,15 @@ describe("SdfCircleTransition", () => {
     );
 
     expect(getByText("Draft saved")).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <SdfCircleTransition transitionKey="draft">
+        Draft saved
+      </SdfCircleTransition>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/searchable-dropdown/__tests__/searchable-dropdown.test.tsx
+++ b/packages/smoothui/components/searchable-dropdown/__tests__/searchable-dropdown.test.tsx
@@ -1,5 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { fireEvent, render, screen, waitFor } from "../../../test-utils/render";
 import SearchableDropdown from "../index";
 
@@ -186,5 +187,25 @@ describe("SearchableDropdown", () => {
       ).not.toBeInTheDocument()
     );
     expect(trigger).toHaveFocus();
+  });
+
+  it("has no accessibility violations when closed", async () => {
+    const { container } = render(
+      <SearchableDropdown items={items} label="Pick a fruit" />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it("has no accessibility violations when open", async () => {
+    const user = userEvent.setup();
+    const { container } = render(
+      <SearchableDropdown items={items} label="Pick a fruit" />
+    );
+
+    await user.click(screen.getByRole("button", { name: "Pick a fruit" }));
+
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/shader-reveal-circle-transition/__tests__/shader-reveal-circle-transition.test.tsx
+++ b/packages/smoothui/components/shader-reveal-circle-transition/__tests__/shader-reveal-circle-transition.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ShaderRevealCircleTransition from "../index";
 
@@ -11,5 +12,15 @@ describe("ShaderRevealCircleTransition", () => {
     );
 
     expect(getByText("Draft saved")).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ShaderRevealCircleTransition transitionKey="draft">
+        Draft saved
+      </ShaderRevealCircleTransition>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/shader-reveal-luma-transition/__tests__/shader-reveal-luma-transition.test.tsx
+++ b/packages/smoothui/components/shader-reveal-luma-transition/__tests__/shader-reveal-luma-transition.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ShaderRevealLumaTransition from "../index";
 
@@ -11,5 +12,15 @@ describe("ShaderRevealLumaTransition", () => {
     );
 
     expect(getByText("Draft saved")).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ShaderRevealLumaTransition transitionKey="draft">
+        Draft saved
+      </ShaderRevealLumaTransition>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/shader-reveal-noise-transition/__tests__/shader-reveal-noise-transition.test.tsx
+++ b/packages/smoothui/components/shader-reveal-noise-transition/__tests__/shader-reveal-noise-transition.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ShaderRevealNoiseTransition from "../index";
 
@@ -11,5 +12,15 @@ describe("ShaderRevealNoiseTransition", () => {
     );
 
     expect(getByText("Draft saved")).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ShaderRevealNoiseTransition transitionKey="draft">
+        Draft saved
+      </ShaderRevealNoiseTransition>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/shader-reveal-planetary-transition/__tests__/shader-reveal-planetary-transition.test.tsx
+++ b/packages/smoothui/components/shader-reveal-planetary-transition/__tests__/shader-reveal-planetary-transition.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ShaderRevealPlanetaryTransition from "../index";
 
@@ -11,5 +12,15 @@ describe("ShaderRevealPlanetaryTransition", () => {
     );
 
     expect(getByText("Draft saved")).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ShaderRevealPlanetaryTransition transitionKey="draft">
+        Draft saved
+      </ShaderRevealPlanetaryTransition>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/shader-reveal-push-transition/__tests__/shader-reveal-push-transition.test.tsx
+++ b/packages/smoothui/components/shader-reveal-push-transition/__tests__/shader-reveal-push-transition.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ShaderRevealPushTransition from "../index";
 
@@ -11,5 +12,15 @@ describe("ShaderRevealPushTransition", () => {
     );
 
     expect(getByText("Draft saved")).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ShaderRevealPushTransition transitionKey="draft">
+        Draft saved
+      </ShaderRevealPushTransition>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/shader-reveal-stripes-transition/__tests__/shader-reveal-stripes-transition.test.tsx
+++ b/packages/smoothui/components/shader-reveal-stripes-transition/__tests__/shader-reveal-stripes-transition.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ShaderRevealStripesTransition from "../index";
 
@@ -11,5 +12,15 @@ describe("ShaderRevealStripesTransition", () => {
     );
 
     expect(getByText("Draft saved")).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ShaderRevealStripesTransition transitionKey="draft">
+        Draft saved
+      </ShaderRevealStripesTransition>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/shader-reveal-transition/__tests__/shader-reveal-transition.test.tsx
+++ b/packages/smoothui/components/shader-reveal-transition/__tests__/shader-reveal-transition.test.tsx
@@ -1,5 +1,6 @@
 import { useReducedMotion } from "motion/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import {
   flushFrames,
@@ -160,4 +161,14 @@ describe("ShaderRevealTransition", () => {
       expect(onRest).toHaveBeenCalledTimes(1);
     });
   }
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ShaderRevealTransition transitionKey="draft">
+        Draft saved
+      </ShaderRevealTransition>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
 });

--- a/packages/smoothui/components/shader-reveal-wipe-transition/__tests__/shader-reveal-wipe-transition.test.tsx
+++ b/packages/smoothui/components/shader-reveal-wipe-transition/__tests__/shader-reveal-wipe-transition.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ShaderRevealWipeTransition from "../index";
 
@@ -11,5 +12,15 @@ describe("ShaderRevealWipeTransition", () => {
     );
 
     expect(getByText("Draft saved")).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ShaderRevealWipeTransition transitionKey="draft">
+        Draft saved
+      </ShaderRevealWipeTransition>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/shader-reveal-zoom-transition/__tests__/shader-reveal-zoom-transition.test.tsx
+++ b/packages/smoothui/components/shader-reveal-zoom-transition/__tests__/shader-reveal-zoom-transition.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ShaderRevealZoomTransition from "../index";
 
@@ -11,5 +12,15 @@ describe("ShaderRevealZoomTransition", () => {
     );
 
     expect(getByText("Draft saved")).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <ShaderRevealZoomTransition transitionKey="draft">
+        Draft saved
+      </ShaderRevealZoomTransition>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/short-slide-down/__tests__/short-slide-down.test.tsx
+++ b/packages/smoothui/components/short-slide-down/__tests__/short-slide-down.test.tsx
@@ -1,5 +1,6 @@
 import { act, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ShortSlideDown from "../index";
 
@@ -109,5 +110,12 @@ describe("ShortSlideDown with reduced motion", () => {
 
     expect(screen.getByText("Goodbye")).toBeInTheDocument();
     expect(screen.getByText("now")).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    vi.useRealTimers();
+    const { container } = render(<ShortSlideDown phrases={["Hello World"]} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/siri-orb/__tests__/siri-orb.test.tsx
+++ b/packages/smoothui/components/siri-orb/__tests__/siri-orb.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import SiriOrb from "../index";
 
@@ -6,5 +7,11 @@ describe("SiriOrb", () => {
   it("renders without throwing", () => {
     const { container } = render(<SiriOrb />);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<SiriOrb />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/skeleton-loader/__tests__/skeleton-loader.test.tsx
+++ b/packages/smoothui/components/skeleton-loader/__tests__/skeleton-loader.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import Skeleton from "../index";
 
@@ -6,5 +7,11 @@ describe("Skeleton", () => {
   it("renders without throwing", () => {
     const { container } = render(<Skeleton />);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<Skeleton />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/smooth-button/__tests__/smooth-button.test.tsx
+++ b/packages/smoothui/components/smooth-button/__tests__/smooth-button.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import SmoothButton from "../index";
 
@@ -66,5 +67,11 @@ describe("SmoothButton", () => {
     );
     expect(getByTestId("prefix")).toBeInTheDocument();
     expect(getByTestId("suffix")).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<SmoothButton>Click me</SmoothButton>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/social-hover-card/__tests__/social-hover-card.test.tsx
+++ b/packages/smoothui/components/social-hover-card/__tests__/social-hover-card.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import SocialHoverCard, { type SocialProfile } from "../index";
 
@@ -18,5 +19,11 @@ describe("SocialHoverCard", () => {
   it("renders in the loading state", () => {
     const { container } = render(<SocialHoverCard loading profile={profile} />);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<SocialHoverCard profile={profile} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/social-selector/__tests__/social-selector.test.tsx
+++ b/packages/smoothui/components/social-selector/__tests__/social-selector.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import SocialSelector from "../index";
 
@@ -6,5 +7,11 @@ describe("SocialSelector", () => {
   it("renders without throwing", () => {
     const { container } = render(<SocialSelector />);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<SocialSelector />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/squircle/__tests__/squircle.test.tsx
+++ b/packages/smoothui/components/squircle/__tests__/squircle.test.tsx
@@ -1,4 +1,5 @@
 import { afterAll, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import Squircle from "../index";
 
@@ -36,5 +37,11 @@ describe("Squircle", () => {
       </Squircle>
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<Squircle>content</Squircle>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/svg-clip-mask/__tests__/svg-clip-mask.test.tsx
+++ b/packages/smoothui/components/svg-clip-mask/__tests__/svg-clip-mask.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import SvgClipMask from "../index";
 
@@ -19,5 +20,15 @@ describe("SvgClipMask", () => {
       </SvgClipMask>
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <SvgClipMask>
+        <div>Content</div>
+      </SvgClipMask>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/svg-draw-on-scroll/__tests__/svg-draw-on-scroll.test.tsx
+++ b/packages/smoothui/components/svg-draw-on-scroll/__tests__/svg-draw-on-scroll.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import SvgDrawOnScroll from "../index";
 
@@ -15,5 +16,11 @@ describe("SvgDrawOnScroll", () => {
       <SvgDrawOnScroll once paths={[PATH, "M10 90 L90 10"]} />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<SvgDrawOnScroll path={PATH} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/swap-panel/__tests__/swap-panel.test.tsx
+++ b/packages/smoothui/components/swap-panel/__tests__/swap-panel.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import SwapPanel, { type SwapToken } from "../index";
 
@@ -50,5 +51,21 @@ describe("SwapPanel", () => {
       />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <SwapPanel
+        amount="1"
+        from={from}
+        onAmountChange={vi.fn()}
+        onFlip={vi.fn()}
+        onSubmit={vi.fn()}
+        status="idle"
+        to={to}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/switchboard-card/__tests__/switchboard-card.test.tsx
+++ b/packages/smoothui/components/switchboard-card/__tests__/switchboard-card.test.tsx
@@ -1,5 +1,6 @@
 import { act, fireEvent } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import SwitchboardCard from "../index";
 
@@ -112,5 +113,13 @@ describe("SwitchboardCard", () => {
       const mediumLights = container.querySelectorAll('[data-state="medium"]');
       expect(mediumLights.length).toBeGreaterThan(0);
     });
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <SwitchboardCard subtitle="Subtitle" title="Test" />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/text-morph/__tests__/text-morph.test.tsx
+++ b/packages/smoothui/components/text-morph/__tests__/text-morph.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import TextMorph from "../index";
 
@@ -11,5 +12,11 @@ describe("TextMorph", () => {
   it("renders the words mode variant without throwing", () => {
     const { container } = render(<TextMorph mode="words" text="Smooth UI" />);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<TextMorph text="Smooth" />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/text-morph/index.tsx
+++ b/packages/smoothui/components/text-morph/index.tsx
@@ -100,7 +100,15 @@ export default function TextMorph({
   }
 
   return (
-    <Tag aria-label={text} className={className}>
+    <Tag className={className}>
+      {/*
+       * The intact string is exposed as visually hidden text rather than an
+       * `aria-label` on the wrapper: `aria-label` is prohibited on the generic
+       * roles the default `as="span"` (and `as="div"`) produce, so screen
+       * readers dropped it — and with every token marked `aria-hidden`, the
+       * component announced nothing at all.
+       */}
+      <span className="sr-only">{text}</span>
       <motion.span
         className={cn("relative inline-flex flex-wrap", ALIGN_CLASS[align])}
         layout

--- a/packages/smoothui/components/theme-toggle/__tests__/theme-toggle.test.tsx
+++ b/packages/smoothui/components/theme-toggle/__tests__/theme-toggle.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import ThemeToggle from "../index";
 
@@ -18,5 +19,11 @@ describe("ThemeToggle", () => {
       <ThemeToggle showSystem={false} variant="switch" />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<ThemeToggle />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/tilt-card/__tests__/tilt-card.test.tsx
+++ b/packages/smoothui/components/tilt-card/__tests__/tilt-card.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import TiltCard from "../index";
 
@@ -19,5 +20,15 @@ describe("TiltCard", () => {
       </TiltCard>
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <TiltCard>
+        <p>Tiltable content</p>
+      </TiltCard>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/time-machine-stack/__tests__/time-machine-stack.test.tsx
+++ b/packages/smoothui/components/time-machine-stack/__tests__/time-machine-stack.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import TimeMachineStack, { type TimeMachineStackItem } from "../index";
 
@@ -16,5 +17,11 @@ describe("TimeMachineStack", () => {
   it("renders with a controlled index", () => {
     const { container } = render(<TimeMachineStack index={1} items={items} />);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<TimeMachineStack items={items} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/tweet-card/__tests__/tweet-card.test.tsx
+++ b/packages/smoothui/components/tweet-card/__tests__/tweet-card.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent } from "@testing-library/react";
 import type { Tweet } from "react-tweet/api";
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import {
   SmoothTweet,
@@ -110,6 +111,12 @@ describe("SmoothTweet", () => {
       "noopener,noreferrer"
     );
     openSpy.mockRestore();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<SmoothTweet tweet={baseTweet} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });
 

--- a/packages/smoothui/components/typewriter-text/__tests__/typewriter-text.test.tsx
+++ b/packages/smoothui/components/typewriter-text/__tests__/typewriter-text.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import TypewriterText from "../index";
 
@@ -6,5 +7,11 @@ describe("TypewriterText", () => {
   it("renders without throwing", () => {
     const { container } = render(<TypewriterText>Hello World</TypewriterText>);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<TypewriterText>Hello World</TypewriterText>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/unlock-face-id/__tests__/unlock-face-id.test.tsx
+++ b/packages/smoothui/components/unlock-face-id/__tests__/unlock-face-id.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import UnlockFaceId from "../index";
 
@@ -15,5 +16,11 @@ describe("UnlockFaceId", () => {
       </UnlockFaceId>
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<UnlockFaceId />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/user-account-avatar/__tests__/user-account-avatar.test.tsx
+++ b/packages/smoothui/components/user-account-avatar/__tests__/user-account-avatar.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import UserAccountAvatar from "../index";
 
@@ -14,5 +15,19 @@ describe("UserAccountAvatar", () => {
       />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <UserAccountAvatar
+        user={{
+          avatar: "/avatar.jpg",
+          email: "test@example.com",
+          name: "Test User",
+        }}
+      />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/vector-editor-toolbar/__tests__/vector-editor-toolbar.test.tsx
+++ b/packages/smoothui/components/vector-editor-toolbar/__tests__/vector-editor-toolbar.test.tsx
@@ -1,5 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import { fireEvent, render, screen, waitFor } from "../../../test-utils/render";
 import VectorEditorToolbar, { type VectorTool } from "../index";
 
@@ -241,5 +242,11 @@ describe("VectorEditorToolbar", () => {
     await user.keyboard("v");
 
     expect(onToolChange).not.toHaveBeenCalled();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<VectorEditorToolbar tools={TOOLS} />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/video-ambient/__tests__/video-ambient.test.tsx
+++ b/packages/smoothui/components/video-ambient/__tests__/video-ambient.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import VideoAmbient from "../index";
 
@@ -20,5 +21,23 @@ describe("VideoAmbient", () => {
       />
     );
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <VideoAmbient alt="Ambient background video" src="/videos/sample.mp4" />
+    );
+    /**
+     * `no-autoplay-audio` is the one rule that cannot run here. To decide
+     * whether an autoplaying element actually emits sound, axe preloads the
+     * media and waits for `loadedmetadata` — an event jsdom never fires,
+     * because it has no media stack at all, so the audit hangs until the test
+     * times out. Everything else in the tree is still audited; the component
+     * is `muted` by default, so the rule has nothing to report anyway.
+     */
+    const results = await axe(container, {
+      rules: { "no-autoplay-audio": { enabled: false } },
+    });
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/video-modal/__tests__/video-modal.test.tsx
+++ b/packages/smoothui/components/video-modal/__tests__/video-modal.test.tsx
@@ -1,6 +1,7 @@
 import userEvent from "@testing-library/user-event";
 import { useReducedMotion } from "motion/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { axe } from "vitest-axe";
 import {
   fireEvent,
   render,
@@ -377,5 +378,21 @@ describe("VideoModal", () => {
       expect(tracks[index]).toHaveAttribute("srclang", caption.srcLang);
       expect(tracks[index]).toHaveAttribute("label", caption.label);
     }
+  });
+
+  it("has no accessibility violations when closed", async () => {
+    const { container } = render(
+      <VideoModal src="https://example.com/video.mp4" title="Demo video" />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+
+  it("has no accessibility violations when open", async () => {
+    const { container } = render(
+      <VideoModal open src="https://example.com/video.mp4" title="Demo video" />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/wallet-card/__tests__/wallet-card.test.tsx
+++ b/packages/smoothui/components/wallet-card/__tests__/wallet-card.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import WalletCard, { type WalletAccount, type WalletMember } from "../index";
 
@@ -34,5 +35,13 @@ describe("WalletCard", () => {
   it("renders the hidden-balance variant without throwing", () => {
     const { container } = render(<WalletCard accounts={accounts} hidden />);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <WalletCard accounts={accounts} members={members} />
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/warped-circle-transition/__tests__/warped-circle-transition.test.tsx
+++ b/packages/smoothui/components/warped-circle-transition/__tests__/warped-circle-transition.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import WarpedCircleTransition from "../index";
 
@@ -11,5 +12,15 @@ describe("WarpedCircleTransition", () => {
     );
 
     expect(getByText("Draft saved")).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(
+      <WarpedCircleTransition transitionKey="draft">
+        Draft saved
+      </WarpedCircleTransition>
+    );
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });

--- a/packages/smoothui/components/wave-text/__tests__/wave-text.test.tsx
+++ b/packages/smoothui/components/wave-text/__tests__/wave-text.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { axe } from "vitest-axe";
 import { render } from "../../../test-utils/render";
 import WaveText from "../index";
 
@@ -6,5 +7,11 @@ describe("WaveText", () => {
   it("renders without throwing", () => {
     const { container } = render(<WaveText>Hello</WaveText>);
     expect(container).toBeInTheDocument();
+  });
+
+  it("has no accessibility violations", async () => {
+    const { container } = render(<WaveText>Hello</WaveText>);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
   });
 });


### PR DESCRIPTION
Five quality gaps, four of them structural. The accessibility one paid for
itself immediately.

## Accessibility — 172 components audited, 14 defects fixed

All 34 blocks already asserted `has no accessibility violations`; only 9 of 199
components did, and none of the 67 added this week. Every component now carries
the same assertion.

Not one of these was visible to a render smoke test — all of them rendered
perfectly:

- **Four animated-text components were silently mute.** `text-morph`,
  `kinetic-type-scroll`, `perspective-text-3d` and `rolling-text` each put
  `aria-label` on a wrapper with a generic role, where the attribute is
  prohibited and dropped, while every animated span was `aria-hidden`. Nothing
  was left to announce. The pattern had clearly been copied from one to the
  next.
- **`checkbox` could not be given an accessible name at all.** Radix renders a
  `button role="checkbox"`, and the component destructured a fixed prop list
  with no rest spread — an API defect, not a markup one. Its JSDoc also called
  `name` the accessible name; it is the form submission name.
- **`phototab` derived Radix ids from the tab `value`**, so `"Tab 1"` produced
  `aria-controls="…-Tab 1"` — an invalid IDREF, leaving trigger and panel
  unpaired.
- **`radio-group` left its radio unnamed when `id` was omitted.** It already
  had an a11y suite, but every case passed an explicit id, so the gap was never
  exercised.
- Plus `ai-artifact` and `animated-stepper` (`role="tab"` with no tablist),
  `animated-file-upload` (unlabelled input nested in a `role="button"`
  dropzone — `aria-hidden` and a negative tabindex do not excuse it),
  `dock` (`ul role="toolbar"` orphaning its `li`s) and `expandable-cards`
  (`aria-selected` on a button role, and a button nested in a button).

## Three tests that were going to flake

Measured under load, all three sat under the 5s timeout by a margin that a busy
runner would erase. `app-download-stack` turned out not to be CPU-bound at all:
it slept through two real timers, 4 of its 4.3 seconds idle. **4351ms → 58ms,
206 → 22, 230 → 28.** No timeout was raised and no assertion was weakened.

## CI and release flow

- `secret-scan.yml` only ran on pushes to `main` — the same gap `test.yml` had.
  PRs were always covered; a direct push to `develop` was not.
- `RELEASING.md` documents the branch roles and the promotion path, including
  why `develop → main` is not automated: a PR opened with the default
  `GITHUB_TOKEN` does not trigger workflows, so CI would never run and the new
  branch protection would make it permanently unmergeable.
- Branch protection is now on both `main` and `develop` (configured on GitHub,
  not in this diff): seven required checks, no force pushes, no deletions.

## Verification

1039 tests pass, and the suite got **faster** — 30.7s against 46.4s — because
the three slow tests cost more than all 172 audits combined. Coverage still
above threshold, typecheck and lint at zero, docs build green.
