### PR TITLE
fix: finish the media dictionary sweep across components, blocks and templates

### DIFF
--- a/apps/docs/examples/apple-invites.tsx
+++ b/apps/docs/examples/apple-invites.tsx
@@ -1,70 +1,29 @@
 "use client";
 
+import {
+  INVITE_HOSTS,
+  INVITES,
+  inviteImage,
+} from "@docs/examples/shared/demo-fixtures";
 import AppleInvites, {
   type Event,
 } from "@repo/smoothui/components/apple-invites";
-import { getAllPeople, getAvatarUrl } from "@smoothui/data";
 
 const AVATAR_SIZE = 72;
 
-const demoEvents: Event[] = [
-  {
-    badge: "Hosting",
-    id: 1,
-    image:
-      "https://ik.imagekit.io/16u211libb/smoothui/scenes/golden-ridge.webp?tr=w-400,h-640,f-auto",
-    location: "Central Park",
-    participants: [
-      {
-        avatar: getAvatarUrl(getAllPeople()[0]?.avatar || "", AVATAR_SIZE),
-      },
-    ],
-    subtitle: "Sat, June 14, 6:00 AM",
-    title: "Yoga",
-  },
-  {
-    badge: "Going",
-    id: 2,
-    image:
-      "https://ik.imagekit.io/16u211libb/smoothui/scenes/rust-peak.webp?tr=w-400,h-640,f-auto",
-    location: "Central Park",
-    participants: [
-      {
-        avatar: getAvatarUrl(getAllPeople()[1]?.avatar || "", AVATAR_SIZE),
-      },
-    ],
-    subtitle: "Sat, June 14, 3:00 PM",
-    title: "Tyler Turns 3!",
-  },
-  {
-    badge: "Going",
-    id: 3,
-    image:
-      "https://ik.imagekit.io/16u211libb/smoothui/scenes/cloud-meadow.webp?tr=w-400,h-640,f-auto",
-    location: "Golf Park",
-    participants: [
-      {
-        avatar: getAvatarUrl(getAllPeople()[2]?.avatar || "", AVATAR_SIZE),
-      },
-    ],
-    subtitle: "Sun, April 15, 9:00 AM",
-    title: "Golf party",
-  },
-  {
-    badge: "Interested",
-    id: 4,
-    image:
-      "https://ik.imagekit.io/16u211libb/smoothui/scenes/moonrise-valley.webp?tr=w-400,h-640,f-auto",
-    location: "Cine Town",
-    participants: [
-      {
-        avatar: getAvatarUrl(getAllPeople()[3]?.avatar || "", AVATAR_SIZE),
-      },
-    ],
-    subtitle: "Fri, June 20, 8:00 PM",
-    title: "Movie Night",
-  },
-];
+const demoEvents: Event[] = INVITES.map((invite, index) => ({
+  badge: invite.badge,
+  id: invite.id,
+  image: inviteImage(invite.scene, 640, 900),
+  location: invite.location,
+  participants: [
+    {
+      avatar: `${INVITE_HOSTS[index].avatar}?tr=w-${AVATAR_SIZE},h-${AVATAR_SIZE},f-auto`,
+    },
+  ],
+  subtitle: invite.subtitle,
+  title: invite.title,
+}));
 
 const Example = () => (
   <div className="flex min-h-[500px] items-center justify-center">

--- a/apps/docs/examples/apple-invites.tsx
+++ b/apps/docs/examples/apple-invites.tsx
@@ -11,7 +11,8 @@ const demoEvents: Event[] = [
   {
     badge: "Hosting",
     id: 1,
-    image: "/images/figma/bg-11.webp",
+    image:
+      "https://ik.imagekit.io/16u211libb/smoothui/scenes/golden-ridge.webp?tr=w-400,h-640,f-auto",
     location: "Central Park",
     participants: [
       {
@@ -24,7 +25,8 @@ const demoEvents: Event[] = [
   {
     badge: "Going",
     id: 2,
-    image: "/images/figma/bg-9.webp",
+    image:
+      "https://ik.imagekit.io/16u211libb/smoothui/scenes/rust-peak.webp?tr=w-400,h-640,f-auto",
     location: "Central Park",
     participants: [
       {
@@ -37,7 +39,8 @@ const demoEvents: Event[] = [
   {
     badge: "Going",
     id: 3,
-    image: "/images/figma/bg-5.webp",
+    image:
+      "https://ik.imagekit.io/16u211libb/smoothui/scenes/cloud-meadow.webp?tr=w-400,h-640,f-auto",
     location: "Golf Park",
     participants: [
       {
@@ -50,7 +53,8 @@ const demoEvents: Event[] = [
   {
     badge: "Interested",
     id: 4,
-    image: "/images/figma/bg-13.webp",
+    image:
+      "https://ik.imagekit.io/16u211libb/smoothui/scenes/moonrise-valley.webp?tr=w-400,h-640,f-auto",
     location: "Cine Town",
     participants: [
       {

--- a/apps/docs/examples/canvas/apple-invites.tsx
+++ b/apps/docs/examples/canvas/apple-invites.tsx
@@ -1,74 +1,28 @@
 "use client";
 
+import {
+  INVITE_HOSTS,
+  INVITES,
+  inviteImage,
+} from "@docs/examples/shared/demo-fixtures";
 import type { Event } from "@repo/smoothui/components/apple-invites";
 import AppleInvites from "@repo/smoothui/components/apple-invites";
-import { somePeople } from "@smoothui/data/people";
 
 /** The component autoplays on its own; this is just a slightly brisker pace. */
 const INTERVAL_MS = 2800;
 const CARD_WIDTH = 140;
 
-/** One host per event, drawn from the shared cast. */
-const HOSTS = somePeople(4, 30);
-
-const events: Event[] = [
-  {
-    badge: "Hosting",
-    id: 1,
-    image:
-      "https://ik.imagekit.io/16u211libb/smoothui/scenes/cloud-meadow.webp?tr=w-400,h-640,f-auto",
-    location: "Prospect Park",
-    participants: [
-      {
-        avatar: `${HOSTS[0].avatar}?tr=w-72,h-72,f-auto`,
-      },
-    ],
-    subtitle: "Sat, June 14 · 6:00 AM",
-    title: "Sunrise Yoga",
-  },
-  {
-    badge: "Going",
-    id: 2,
-    image:
-      "https://ik.imagekit.io/16u211libb/smoothui/scenes/ember-drift-warm.webp?tr=w-400,h-640,f-auto",
-    location: "Rue Léon",
-    participants: [
-      {
-        avatar: `${HOSTS[1].avatar}?tr=w-72,h-72,f-auto`,
-      },
-    ],
-    subtitle: "Fri, June 20 · 8:00 PM",
-    title: "Supper Club",
-  },
-  {
-    badge: "Going",
-    id: 3,
-    image:
-      "https://ik.imagekit.io/16u211libb/smoothui/scenes/moonrise-valley.webp?tr=w-400,h-640,f-auto",
-    location: "Praia do Amado",
-    participants: [
-      {
-        avatar: `${HOSTS[2].avatar}?tr=w-72,h-72,f-auto`,
-      },
-    ],
-    subtitle: "Sun, June 22 · 7:30 AM",
-    title: "Dawn Patrol",
-  },
-  {
-    badge: "Interested",
-    id: 4,
-    image:
-      "https://ik.imagekit.io/16u211libb/smoothui/scenes/golden-ridge.webp?tr=w-400,h-640,f-auto",
-    location: "Rooftop, Bldg 9",
-    participants: [
-      {
-        avatar: `${HOSTS[3].avatar}?tr=w-72,h-72,f-auto`,
-      },
-    ],
-    subtitle: "Thu, June 26 · 9:00 PM",
-    title: "Open-Air Cinema",
-  },
-];
+const events: Event[] = INVITES.map((invite, index) => ({
+  badge: invite.badge,
+  id: invite.id,
+  image: inviteImage(invite.scene, 400, 640),
+  location: invite.location,
+  participants: [
+    { avatar: `${INVITE_HOSTS[index].avatar}?tr=w-72,h-72,f-auto` },
+  ],
+  subtitle: invite.subtitle,
+  title: invite.title,
+}));
 
 /**
  * Already self-driving — the invitation deck advances on its own interval, and

--- a/apps/docs/examples/canvas/phototab.tsx
+++ b/apps/docs/examples/canvas/phototab.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { PHOTO_TABS, sceneSrc } from "@docs/examples/shared/demo-fixtures";
 import type { PhototabTab } from "@repo/smoothui/components/phototab";
 import Phototab from "@repo/smoothui/components/phototab";
 import { Mountain, TreePine, Waves } from "lucide-react";
@@ -9,28 +10,15 @@ import { preload } from "react-dom";
 
 /** Long enough to look at the photograph before it changes. */
 const SWITCH_MS = 2600;
+const ICONS = [<Mountain key="m" />, <Waves key="w" />, <TreePine key="t" />];
+
 const FRAME = 240;
 
-const tabs: PhototabTab[] = [
-  {
-    icon: <Mountain />,
-    image:
-      "https://ik.imagekit.io/16u211libb/smoothui/scenes/blue-ridge-night.webp?tr=w-600,h-600,f-auto",
-    name: "Ridge line",
-  },
-  {
-    icon: <Waves />,
-    image:
-      "https://ik.imagekit.io/16u211libb/smoothui/scenes/lake-camp.webp?tr=w-600,h-600,f-auto",
-    name: "Lake shore",
-  },
-  {
-    icon: <TreePine />,
-    image:
-      "https://ik.imagekit.io/16u211libb/smoothui/scenes/watercolor-grove.webp?tr=w-600,h-600,f-auto",
-    name: "Pale grove",
-  },
-];
+const tabs: PhototabTab[] = PHOTO_TABS.map((tab, index) => ({
+  icon: ICONS[index],
+  image: sceneSrc(tab.scene, "w-600,h-600"),
+  name: tab.name,
+}));
 
 /**
  * The glass tab bar normally waits below the frame until the photo is hovered,

--- a/apps/docs/examples/canvas/scrollable-card-stack.tsx
+++ b/apps/docs/examples/canvas/scrollable-card-stack.tsx
@@ -1,9 +1,12 @@
 "use client";
 
+import {
+  STACK_CAST,
+  STACK_SCENES,
+  sceneSrc,
+} from "@docs/examples/shared/demo-fixtures";
 import ScrollableCardStack from "@repo/smoothui/components/scrollable-card-stack";
 import { founder } from "@smoothui/data";
-import { somePeople } from "@smoothui/data/people";
-import { sceneById } from "@smoothui/data/scenes";
 import { useReducedMotion } from "motion/react";
 import { useEffect, useRef } from "react";
 
@@ -11,39 +14,23 @@ import { useEffect, useRef } from "react";
 const ADVANCE_MS = 2000;
 const CARD_HEIGHT = 150;
 
-const photo = (id: string) => `${sceneById(id)?.src}?tr=w-600,h-380,f-auto`;
-const face = (person: { avatar: string }) =>
-  `${person.avatar}?tr=w-80,h-80,f-auto`;
-
-// Two of the cast plus the real account. The invented pair link to example.com
-// rather than to x.com handles they do not own.
-const [second, third] = somePeople(2, 12);
-
 const items = [
   {
     avatar: `${founder.avatar}&tr=w-80,h-80,f-auto`,
     handle: "@educalvolpz",
     href: founder.social.twitter,
-    id: "ridge",
-    image: photo("blue-ridge-night"),
+    id: STACK_SCENES[0],
+    image: sceneSrc(STACK_SCENES[0], "w-600,h-380"),
     name: founder.name,
   },
-  {
-    avatar: face(second),
-    handle: second.handle,
-    href: `https://example.com/${second.handle.replace("@", "")}`,
-    id: "harbour",
-    image: photo("lake-camp"),
-    name: second.name,
-  },
-  {
-    avatar: face(third),
-    handle: third.handle,
-    href: `https://example.com/${third.handle.replace("@", "")}`,
-    id: "dunes",
-    image: photo("dune-shadow"),
-    name: third.name,
-  },
+  ...STACK_CAST.slice(0, 2).map((person, index) => ({
+    avatar: `${person.avatar}?tr=w-80,h-80,f-auto`,
+    handle: person.handle,
+    href: `https://example.com/${person.handle.replace("@", "")}`,
+    id: STACK_SCENES[index + 1],
+    image: sceneSrc(STACK_SCENES[index + 1], "w-600,h-380"),
+    name: person.name,
+  })),
 ];
 
 /**

--- a/apps/docs/examples/canvas/tilt-card.tsx
+++ b/apps/docs/examples/canvas/tilt-card.tsx
@@ -1,5 +1,10 @@
 "use client";
 
+import {
+  sceneAlt,
+  sceneSrc,
+  TILT_SCENE,
+} from "@docs/examples/shared/demo-fixtures";
 import TiltCard from "@repo/smoothui/components/tilt-card";
 import { useReducedMotion } from "motion/react";
 import { useEffect, useRef } from "react";
@@ -69,11 +74,13 @@ const TiltCardCanvasDemo = () => {
       >
         <div className="relative h-[152px] w-full overflow-hidden">
           <img
-            alt="Warm ember bands over a plum ground"
+            alt={sceneAlt(TILT_SCENE)}
             className="h-full w-full scale-110 object-cover"
             data-tilt-depth="0.18"
             draggable={false}
-            src="https://ik.imagekit.io/16u211libb/smoothui/scenes/ember-drift-warm.webp?tr=w-480,h-320,f-auto"
+            height={320}
+            src={sceneSrc(TILT_SCENE, "w-480,h-320")}
+            width={480}
           />
           <div
             aria-hidden="true"

--- a/apps/docs/examples/canvas/wallet-card.tsx
+++ b/apps/docs/examples/canvas/wallet-card.tsx
@@ -5,8 +5,12 @@ import type {
   WalletMember,
 } from "@repo/smoothui/components/wallet-card";
 import WalletCard from "@repo/smoothui/components/wallet-card";
+import { somePeople } from "@smoothui/data/people";
 import { useReducedMotion } from "motion/react";
 import { useEffect, useState } from "react";
+
+/** The wallet belongs to one person; the rest are who it is shared with. */
+const [OWNER, ...SHARED] = somePeople(7, 40);
 
 /** How long a card stays on top before the stack reshuffles. */
 const CYCLE_MS = 2400;
@@ -18,7 +22,7 @@ const accounts: WalletAccount[] = [
     expiry: "08/29",
     gradient:
       "bg-[linear-gradient(145deg,oklch(0.5_0.13_268),oklch(0.25_0.08_268))]",
-    holder: "Ada Fontaine",
+    holder: OWNER.name,
     id: "everyday",
     label: "Everyday",
     last4: "4242",
@@ -30,7 +34,7 @@ const accounts: WalletAccount[] = [
     expiry: "02/31",
     gradient:
       "bg-[linear-gradient(145deg,oklch(0.52_0.11_158),oklch(0.26_0.06_158))]",
-    holder: "Ada Fontaine",
+    holder: OWNER.name,
     id: "savings",
     label: "Savings",
     last4: "1190",
@@ -42,7 +46,7 @@ const accounts: WalletAccount[] = [
     expiry: "11/28",
     gradient:
       "bg-[linear-gradient(145deg,oklch(0.62_0.13_62),oklch(0.32_0.08_48))]",
-    holder: "Ada Fontaine",
+    holder: OWNER.name,
     id: "travel",
     label: "Travel",
     last4: "0087",
@@ -54,7 +58,7 @@ const accounts: WalletAccount[] = [
     expiry: "05/30",
     gradient:
       "bg-[linear-gradient(145deg,oklch(0.4_0.02_264),oklch(0.18_0.01_264))]",
-    holder: "Ada Fontaine",
+    holder: OWNER.name,
     id: "reserve",
     label: "Reserve",
     last4: "7731",
@@ -62,11 +66,11 @@ const accounts: WalletAccount[] = [
   },
 ];
 
-const members: WalletMember[] = [
-  { id: "m1", name: "Ada Fontaine" },
-  { id: "m2", name: "Kenji Osei" },
-  { id: "m3", name: "Priya Nair" },
-];
+const members: WalletMember[] = SHARED.map((person) => ({
+  avatar: `${person.avatar}?tr=w-64,h-64,f-auto`,
+  id: person.id,
+  name: person.name,
+}));
 
 /**
  * The stack dealing itself. `activeId` is driven on a timer, so the card that

--- a/apps/docs/examples/cursor-follow.tsx
+++ b/apps/docs/examples/cursor-follow.tsx
@@ -2,13 +2,14 @@
 
 import CursorFollow from "@repo/smoothui/components/cursor-follow";
 import { getImageKitUrl } from "@smoothui/data";
+import { portraits } from "@smoothui/data/scenes";
 import Image from "next/image";
 
 const images = [
   {
     id: 1,
-    label: "Portrait of a person sitting in a chair",
-    src: getImageKitUrl("/images/personchair.webp", {
+    label: portraits[0].alt,
+    src: getImageKitUrl(`${portraits[0].src}`, {
       format: "auto",
       quality: 80,
       width: 384,
@@ -16,8 +17,8 @@ const images = [
   },
   {
     id: 2,
-    label: "A young man with curly hair",
-    src: getImageKitUrl("/images/youngman.webp", {
+    label: portraits[3].alt,
+    src: getImageKitUrl(`${portraits[3].src}`, {
       format: "auto",
       quality: 80,
       width: 384,

--- a/apps/docs/examples/expandable-cards.tsx
+++ b/apps/docs/examples/expandable-cards.tsx
@@ -4,6 +4,7 @@ import ExpandableCards, {
   type Card,
 } from "@repo/smoothui/components/expandable-cards";
 import { getAllPeople, getAvatarUrl, getImageKitUrl } from "@smoothui/data";
+import { sceneById } from "@smoothui/data/scenes";
 import { useState } from "react";
 
 const ExpandableCardsDemo = () => {
@@ -20,12 +21,12 @@ const ExpandableCardsDemo = () => {
       content:
         "Join us for the Summer Opening event, where we celebrate the start of a vibrant season filled with art and culture.",
       id: 1,
-      image: getImageKitUrl("/images/summer-opening.webp", {
+      image: getImageKitUrl(`${sceneById("cloud-meadow")?.src}`, {
         format: "auto",
         quality: 80,
         width: 600,
       }),
-      title: "Summer Opening",
+      title: "Cloud Meadow",
     },
     {
       author: {
@@ -36,12 +37,12 @@ const ExpandableCardsDemo = () => {
       content:
         "Explore the latest trends in fashion at our exclusive showcase, featuring renowned designers and unique styles.",
       id: 2,
-      image: getImageKitUrl("/images/fashion.webp", {
+      image: getImageKitUrl(`${sceneById("prism-meadow")?.src}`, {
         format: "auto",
         quality: 80,
         width: 600,
       }),
-      title: "Fashion",
+      title: "Prism Meadow",
     },
     {
       author: {
@@ -52,12 +53,12 @@ const ExpandableCardsDemo = () => {
       content:
         "Immerse yourself in the world of art at our gallery, showcasing stunning pieces from emerging and established artists.",
       id: 3,
-      image: getImageKitUrl("/images/galleryart.webp", {
+      image: getImageKitUrl(`${sceneById("nebula-canyon")?.src}`, {
         format: "auto",
         quality: 80,
         width: 600,
       }),
-      title: "Gallery Art",
+      title: "Nebula Canyon",
     },
     {
       author: {
@@ -68,12 +69,12 @@ const ExpandableCardsDemo = () => {
       content:
         "Join us on a journey through dreams, exploring the subconscious and the art of dreaming.",
       id: 4,
-      image: getImageKitUrl("/images/dreams.webp", {
+      image: getImageKitUrl(`${sceneById("moonrise-valley")?.src}`, {
         format: "auto",
         quality: 80,
         width: 600,
       }),
-      title: "Dreams",
+      title: "Moonrise",
     },
   ];
 

--- a/apps/docs/examples/figma-comment.tsx
+++ b/apps/docs/examples/figma-comment.tsx
@@ -2,22 +2,22 @@
 
 import FigmaComment from "@repo/smoothui/components/figma-comment";
 import { getImageKitUrl } from "@smoothui/data";
+import { somePeople } from "@smoothui/data/people";
+
+const [PERSON] = somePeople(1, 11);
 
 export default function FigmaCommentDemo() {
   return (
     <div className="flex min-h-[200px] flex-col items-center justify-center gap-8 p-8">
       <FigmaComment
-        authorName="Edu Calvo"
-        avatarAlt="Edu's avatar"
-        avatarUrl={getImageKitUrl(
-          "https://ik.imagekit.io/16u211libb/avatar-educalvolpz.jpeg?updatedAt=1765524159631",
-          {
-            format: "auto",
-            height: 48,
-            quality: 85,
-            width: 48,
-          }
-        )}
+        authorName={PERSON.name}
+        avatarAlt={PERSON.name}
+        avatarUrl={getImageKitUrl(`${PERSON.avatar}`, {
+          format: "auto",
+          height: 48,
+          quality: 85,
+          width: 48,
+        })}
         message="What happens if we adjust this to handle a light and dark mode? I'm not sure if we're ready to handle..."
         timestamp="Just now"
         width={200}

--- a/apps/docs/examples/image-metadata-preview.tsx
+++ b/apps/docs/examples/image-metadata-preview.tsx
@@ -20,7 +20,7 @@ const Example = () => {
         alt="Mountain landscape"
         description="Beautiful mountain landscape with snow-capped peaks"
         filename="desert-canyon.jpg"
-        imageSrc="/images/figma/bg-9.webp"
+        imageSrc="https://ik.imagekit.io/16u211libb/smoothui/scenes/rust-peak.webp?tr=w-800,f-auto"
         metadata={sampleMetadata}
         onShare={handleShare}
       />

--- a/apps/docs/examples/interactive-image-selector.tsx
+++ b/apps/docs/examples/interactive-image-selector.tsx
@@ -3,65 +3,18 @@
 import InteractiveImageSelector, {
   type ImageData,
 } from "@repo/smoothui/components/interactive-image-selector";
-import { getImageKitUrl } from "@smoothui/data";
+import { portraits } from "@smoothui/data/scenes";
 import { useEffect, useState } from "react";
 
-const demoImages: ImageData[] = [
-  {
-    id: 1,
-    src: getImageKitUrl("/images/womanorange.webp", {
-      format: "auto",
-      height: 400,
-      quality: 80,
-      width: 400,
-    }),
-  },
-  {
-    id: 2,
-    src: getImageKitUrl("/images/girl-nature.webp", {
-      format: "auto",
-      height: 400,
-      quality: 80,
-      width: 400,
-    }),
-  },
-  {
-    id: 3,
-    src: getImageKitUrl("/images/metrowoman.webp", {
-      format: "auto",
-      height: 400,
-      quality: 80,
-      width: 400,
-    }),
-  },
-  {
-    id: 4,
-    src: getImageKitUrl("/images/designerworking.webp", {
-      format: "auto",
-      height: 400,
-      quality: 80,
-      width: 400,
-    }),
-  },
-  {
-    id: 5,
-    src: getImageKitUrl("/images/girlglass.webp", {
-      format: "auto",
-      height: 400,
-      quality: 80,
-      width: 400,
-    }),
-  },
-  {
-    id: 6,
-    src: getImageKitUrl("/images/manup.webp", {
-      format: "auto",
-      height: 400,
-      quality: 80,
-      width: 400,
-    }),
-  },
-];
+/**
+ * The five editorial portraits, rather than six loose files sitting outside the
+ * `smoothui/` namespace on ImageKit. A selector of faces reads as a set when the
+ * faces are lit and graded the same way.
+ */
+const demoImages: ImageData[] = portraits.map((portrait, index) => ({
+  id: index + 1,
+  src: `${portrait.src}?tr=w-400,h-400,q-80,f-auto`,
+}));
 
 const InteractiveImageSelectorDemo = () => {
   const [selected, setSelected] = useState<number[]>([]);

--- a/apps/docs/examples/photo-stack.tsx
+++ b/apps/docs/examples/photo-stack.tsx
@@ -6,25 +6,25 @@ import PhotoStack, {
 
 const photos: PhotoStackPhoto[] = [
   {
-    alt: "Desert canyon at sunset",
+    alt: "A rust-red mountain against a pale sky",
     id: "canyon",
-    name: "Desert Canyon",
+    name: "Rust Peak",
     role: "Golden hour",
-    src: "/images/figma/bg-9.webp",
+    src: "https://ik.imagekit.io/16u211libb/smoothui/scenes/rust-peak.webp?tr=w-640,h-800,f-auto",
   },
   {
-    alt: "Palm grove in soft light",
+    alt: "A mountainside catching low golden light",
     id: "palms",
-    name: "Palm Grove",
+    name: "Golden Ridge",
     role: "Summer haze",
-    src: "/images/figma/bg-11.webp",
+    src: "https://ik.imagekit.io/16u211libb/smoothui/scenes/golden-ridge.webp?tr=w-640,h-800,f-auto",
   },
   {
-    alt: "City lights bokeh at night",
+    alt: "A vast moon rising over a wooded valley",
     id: "lights",
-    name: "City Lights",
+    name: "Moonrise",
     role: "After dark",
-    src: "/images/figma/bg-13.webp",
+    src: "https://ik.imagekit.io/16u211libb/smoothui/scenes/moonrise-valley.webp?tr=w-640,h-800,f-auto",
   },
 ];
 

--- a/apps/docs/examples/phototab.tsx
+++ b/apps/docs/examples/phototab.tsx
@@ -1,46 +1,14 @@
+import { PHOTO_TABS, sceneSrc } from "@docs/examples/shared/demo-fixtures";
 import Phototab, { type PhototabTab } from "@repo/smoothui/components/phototab";
-import { getImageKitUrl } from "@smoothui/data";
-import { Dog, Map as MapIcon, User } from "lucide-react";
+import { Mountain, TreePine, Waves } from "lucide-react";
 
-// Placeholder images (replace with your own if available)
-const Images = [
-  getImageKitUrl("/images/girl-summer.webp", {
-    format: "auto",
-    height: 300,
-    quality: 80,
-    width: 600,
-  }),
-  getImageKitUrl("/images/dog-white.webp", {
-    format: "auto",
-    height: 300,
-    quality: 80,
-    width: 600,
-  }),
-  getImageKitUrl("/images/surf.webp", {
-    format: "auto",
-    height: 300,
-    quality: 80,
-    width: 600,
-  }),
-];
+const ICONS = [<Mountain key="m" />, <Waves key="w" />, <TreePine key="t" />];
 
-const tabs: PhototabTab[] = [
-  {
-    icon: <User />,
-    image: Images[0],
-    name: "one",
-  },
-  {
-    icon: <Dog />,
-    image: Images[1],
-    name: "two",
-  },
-  {
-    icon: <MapIcon />,
-    image: Images[2],
-    name: "three",
-  },
-];
+const tabs: PhototabTab[] = PHOTO_TABS.map((tab, index) => ({
+  icon: ICONS[index],
+  image: sceneSrc(tab.scene, "w-600,h-600"),
+  name: tab.name,
+}));
 
 export default function PhototabDemo() {
   return (

--- a/apps/docs/examples/reviews-carousel.tsx
+++ b/apps/docs/examples/reviews-carousel.tsx
@@ -2,39 +2,28 @@
 
 import type { Review } from "@repo/smoothui/components/reviews-carousel";
 import ReviewsCarousel from "@repo/smoothui/components/reviews-carousel";
+import { somePeople } from "@smoothui/data/people";
 
-const sampleReviews: Review[] = [
-  {
-    author: "Sarah Johnson",
-    body: "SmoothUI has completely transformed how I build user interfaces. The animations are smooth, the components are well-designed, and the documentation is excellent. Highly recommend!",
-    id: 1,
-    title: "Frontend Developer at TechCorp",
-  },
-  {
-    author: "Michael Chen",
-    body: "I've been using SmoothUI for my latest project and I'm impressed by the quality of the components. The spring animations feel natural and the API is intuitive.",
-    id: 2,
-    title: "UI/UX Designer",
-  },
-  {
-    author: "Emily Rodriguez",
-    body: "The best part about SmoothUI is how easy it is to customize. I can create beautiful, animated interfaces without spending hours on implementation details.",
-    id: 3,
-    title: "Full Stack Developer",
-  },
-  {
-    author: "David Kim",
-    body: "As someone who values both aesthetics and performance, SmoothUI hits the perfect balance. The components are performant and look amazing.",
-    id: 4,
-    title: "Product Engineer",
-  },
-  {
-    author: "Lisa Anderson",
-    body: "The carousel component is particularly impressive. The spring physics make the interactions feel natural and delightful. Great work!",
-    id: 5,
-    title: "Creative Director",
-  },
+/**
+ * The words are the demo; who said them comes from the shared cast, so a
+ * reviewer here is the same person with the same job elsewhere in the docs.
+ */
+const BODIES = [
+  "SmoothUI has completely transformed how I build user interfaces. The animations are smooth, the components are well-designed, and the documentation is excellent. Highly recommend!",
+  "I've been using SmoothUI for my latest project and I'm impressed by the quality of the components. The spring animations feel natural and the API is intuitive.",
+  "The best part about SmoothUI is how easy it is to customize. I can create beautiful, animated interfaces without spending hours on implementation details.",
+  "As someone who values both aesthetics and performance, SmoothUI hits the perfect balance. The components are performant and look amazing.",
+  "The carousel component is particularly impressive. The spring physics make the interactions feel natural and delightful. Great work!",
 ];
+
+const sampleReviews: Review[] = somePeople(BODIES.length, 55).map(
+  (person, index) => ({
+    author: person.name,
+    body: BODIES[index],
+    id: index + 1,
+    title: `${person.role} at ${person.company}`,
+  })
+);
 
 export default function ReviewsCarouselDemo() {
   return (

--- a/apps/docs/examples/scrollable-card-stack.tsx
+++ b/apps/docs/examples/scrollable-card-stack.tsx
@@ -1,80 +1,49 @@
 "use client";
 
+import {
+  STACK_CAST,
+  STACK_SCENES,
+  sceneSrc,
+} from "@docs/examples/shared/demo-fixtures";
 import ScrollableCardStack from "@repo/smoothui/components/scrollable-card-stack";
-import { getAllPeople, getAvatarUrl, getImageKitUrl } from "@smoothui/data";
-import { somePeople } from "@smoothui/data/people";
-import { sceneById } from "@smoothui/data/scenes";
+import { founder } from "@smoothui/data";
 
-const CAST = somePeople(3, 5);
+/**
+ * The same cards as the landing-canvas demo, one card longer. Both read their
+ * people and scenes from the shared fixtures, so the component cannot show one
+ * set of faces on the landing and another in its own documentation.
+ *
+ * The real account is the only one with a real link; the invented three point
+ * at example.com rather than at x.com handles they do not own.
+ */
+const cards = [
+  {
+    avatar: `${founder.avatar}&tr=w-80,h-80,f-auto`,
+    handle: "@educalvolpz",
+    href: founder.social.twitter,
+    name: founder.name,
+  },
+  ...STACK_CAST.map((person) => ({
+    avatar: `${person.avatar}?tr=w-80,h-80,f-auto`,
+    handle: person.handle,
+    href: `https://example.com/${person.handle.replace("@", "")}`,
+    name: person.name,
+  })),
+];
+
+const items = cards.map((card, index) => ({
+  ...card,
+  id: STACK_SCENES[index],
+  image: sceneSrc(STACK_SCENES[index], "w-600,h-380"),
+}));
 
 export default function ScrollableCardStackDemo() {
-  const people = getAllPeople();
-
-  const cardData = [
-    {
-      avatar: getImageKitUrl(`${CAST[0].avatar}`, {
-        format: "auto",
-        height: 80,
-        quality: 85,
-        width: 80,
-      }), // Keep educlopez as requested
-      handle: "@educalvolpz",
-      href: "https://x.com/educalvolpz",
-      id: "siriorb",
-      image:
-        "https://ik.imagekit.io/16u211libb/smoothui/scenes/cloud-meadow.webp?tr=w-600,h-380,f-auto",
-      name: people[0]?.name || "Edu Calvo",
-    },
-    {
-      avatar: getAvatarUrl(people[1]?.avatar || "", 40),
-      handle: `@${
-        people[1]?.name?.toLowerCase().replace(/\s+/g, "") || "sarahchen"
-      }`,
-      href: `https://x.com/${
-        people[1]?.name?.toLowerCase().replace(/\s+/g, "") || "sarahchen"
-      }`,
-      id: "richpopover",
-      image: getImageKitUrl(`${sceneById("cloud-meadow")?.src}`, {
-        format: "auto",
-        quality: 80,
-        width: 600,
-      }),
-      name: people[1]?.name || "Sarah Chen",
-    },
-    {
-      avatar: getAvatarUrl(people[2]?.avatar || "", 40),
-      handle: `@${
-        people[2]?.name?.toLowerCase().replace(/\s+/g, "") || "marcusj"
-      }`,
-      href: `https://x.com/${
-        people[2]?.name?.toLowerCase().replace(/\s+/g, "") || "marcusj"
-      }`,
-      id: "sparkbites",
-      image:
-        "https://ik.imagekit.io/16u211libb/smoothui/scenes/lake-camp.webp?tr=w-600,h-380,f-auto",
-      name: people[2]?.name || "Marcus Johnson",
-    },
-    {
-      avatar: getAvatarUrl(people[3]?.avatar || "", 40),
-      handle: `@${
-        people[3]?.name?.toLowerCase().replace(/\s+/g, "") || "emilyrodriguez"
-      }`,
-      href: `https://x.com/${
-        people[3]?.name?.toLowerCase().replace(/\s+/g, "") || "emilyrodriguez"
-      }`,
-      id: "svgl",
-      image:
-        "https://ik.imagekit.io/16u211libb/smoothui/scenes/cyan-aurora.webp?tr=w-600,h-380,f-auto",
-      name: people[3]?.name || "Emily Rodriguez",
-    },
-  ];
-
   return (
     <div className="mx-auto w-full max-w-md">
       <ScrollableCardStack
         cardHeight={200}
         className="mx-auto"
-        items={cardData}
+        items={items}
         perspective={1200}
         transitionDuration={200}
       />

--- a/apps/docs/examples/scrollable-card-stack.tsx
+++ b/apps/docs/examples/scrollable-card-stack.tsx
@@ -2,25 +2,27 @@
 
 import ScrollableCardStack from "@repo/smoothui/components/scrollable-card-stack";
 import { getAllPeople, getAvatarUrl, getImageKitUrl } from "@smoothui/data";
+import { somePeople } from "@smoothui/data/people";
+import { sceneById } from "@smoothui/data/scenes";
+
+const CAST = somePeople(3, 5);
 
 export default function ScrollableCardStackDemo() {
   const people = getAllPeople();
 
   const cardData = [
     {
-      avatar: getImageKitUrl(
-        "https://ik.imagekit.io/16u211libb/avatar-educalvolpz.jpeg?updatedAt=1765524159631",
-        {
-          format: "auto",
-          height: 80,
-          quality: 85,
-          width: 80,
-        }
-      ), // Keep educlopez as requested
+      avatar: getImageKitUrl(`${CAST[0].avatar}`, {
+        format: "auto",
+        height: 80,
+        quality: 85,
+        width: 80,
+      }), // Keep educlopez as requested
       handle: "@educalvolpz",
       href: "https://x.com/educalvolpz",
       id: "siriorb",
-      image: "/images/figma/bg-5.webp",
+      image:
+        "https://ik.imagekit.io/16u211libb/smoothui/scenes/cloud-meadow.webp?tr=w-600,h-380,f-auto",
       name: people[0]?.name || "Edu Calvo",
     },
     {
@@ -32,14 +34,11 @@ export default function ScrollableCardStackDemo() {
         people[1]?.name?.toLowerCase().replace(/\s+/g, "") || "sarahchen"
       }`,
       id: "richpopover",
-      image: getImageKitUrl(
-        "https://ik.imagekit.io/16u211libb/smoothui/girl-nature.webp?updatedAt=1764932272804",
-        {
-          format: "auto",
-          quality: 80,
-          width: 600,
-        }
-      ),
+      image: getImageKitUrl(`${sceneById("cloud-meadow")?.src}`, {
+        format: "auto",
+        quality: 80,
+        width: 600,
+      }),
       name: people[1]?.name || "Sarah Chen",
     },
     {
@@ -51,7 +50,8 @@ export default function ScrollableCardStackDemo() {
         people[2]?.name?.toLowerCase().replace(/\s+/g, "") || "marcusj"
       }`,
       id: "sparkbites",
-      image: "/images/figma/bg-8.webp",
+      image:
+        "https://ik.imagekit.io/16u211libb/smoothui/scenes/lake-camp.webp?tr=w-600,h-380,f-auto",
       name: people[2]?.name || "Marcus Johnson",
     },
     {
@@ -63,7 +63,8 @@ export default function ScrollableCardStackDemo() {
         people[3]?.name?.toLowerCase().replace(/\s+/g, "") || "emilyrodriguez"
       }`,
       id: "svgl",
-      image: "/images/figma/bg-1.webp",
+      image:
+        "https://ik.imagekit.io/16u211libb/smoothui/scenes/cyan-aurora.webp?tr=w-600,h-380,f-auto",
       name: people[3]?.name || "Emily Rodriguez",
     },
   ];

--- a/apps/docs/examples/shared/demo-fixtures.ts
+++ b/apps/docs/examples/shared/demo-fixtures.ts
@@ -1,0 +1,108 @@
+/**
+ * Fixtures shared between a component's docs example and its landing-canvas
+ * demo.
+ *
+ * The two demos are authored separately on purpose — the canvas one is smaller,
+ * has no controls and self-animates — but they must be recognisably the same
+ * thing, because clicking a tile on the landing opens the docs example. When
+ * each kept its own copy of the data they drifted: the same component showed
+ * different photographs, and in one case an entirely different set of events.
+ *
+ * So the content lives here once. Layout stays with each demo.
+ */
+
+import { somePeople } from "@smoothui/data/people";
+import { sceneById } from "@smoothui/data/scenes";
+
+const src = (id: string, tr: string) => `${sceneById(id)?.src}?tr=${tr},f-auto`;
+
+/** Alt text always comes from the picture, never written alongside it. */
+export const sceneAlt = (id: string) => sceneById(id)?.alt ?? "";
+
+// ----------------------------------------------------------- apple-invites
+
+export interface InviteFixture {
+  badge: string;
+  id: number;
+  location: string;
+  scene: string;
+  subtitle: string;
+  title: string;
+}
+
+export const INVITES: InviteFixture[] = [
+  {
+    badge: "Hosting",
+    id: 1,
+    location: "Prospect Park",
+    scene: "cloud-meadow",
+    subtitle: "Sat, June 14 · 6:00 AM",
+    title: "Sunrise Yoga",
+  },
+  {
+    badge: "Going",
+    id: 2,
+    location: "Rue Léon",
+    // An 8pm supper, so warm light rather than a night mountain range.
+    scene: "ember-drift-warm",
+    subtitle: "Fri, June 20 · 8:00 PM",
+    title: "Supper Club",
+  },
+  {
+    badge: "Going",
+    id: 3,
+    location: "Praia do Amado",
+    scene: "golden-ridge",
+    subtitle: "Sun, June 22 · 7:30 AM",
+    title: "Dawn Patrol",
+  },
+  {
+    badge: "Interested",
+    id: 4,
+    location: "Rooftop, Bldg 9",
+    // A 9pm screening under the sky.
+    scene: "moonrise-valley",
+    subtitle: "Thu, June 26 · 9:00 PM",
+    title: "Open-Air Cinema",
+  },
+];
+
+/** One host per event, so the same face hosts the same event in both demos. */
+export const INVITE_HOSTS = somePeople(INVITES.length, 30);
+
+export const inviteImage = (scene: string, width: number, height: number) =>
+  src(scene, `w-${width},h-${height}`);
+
+// ----------------------------------------------------------------- phototab
+
+export const PHOTO_TABS = [
+  { name: "Ridge line", scene: "blue-ridge-night" },
+  { name: "Lake shore", scene: "lake-camp" },
+  { name: "Pale grove", scene: "watercolor-grove" },
+];
+
+// ------------------------------------------------- scrollable-card-stack
+
+/** The founder plus two of the cast, in that order, in both demos. */
+export const STACK_CAST = somePeople(3, 12);
+
+export const STACK_SCENES = [
+  "blue-ridge-night",
+  "lake-camp",
+  "dune-shadow",
+  "cyan-aurora",
+];
+
+// ---------------------------------------------------------------- tilt-card
+
+/** The photo the tilt is demonstrated on, in both demos. */
+export const TILT_SCENE = "golden-ridge";
+
+/** The caption printed over it — the card is a mountain pass, so it says so. */
+export const TILT_CARD = {
+  eyebrow: "Ridge pass",
+  meta: "Gate 04 · 09:41",
+  title: "Northern Traverse",
+};
+
+export const sceneSrc = src;

--- a/apps/docs/examples/skeleton-loader.tsx
+++ b/apps/docs/examples/skeleton-loader.tsx
@@ -2,8 +2,12 @@
 
 import Skeleton from "@repo/smoothui/components/skeleton-loader";
 import SmoothButton from "@repo/smoothui/components/smooth-button";
+import { somePeople } from "@smoothui/data/people";
 import Image from "next/image";
 import { useState } from "react";
+
+/** One face from the shared cast, so the skeleton resolves into a real person. */
+const [PERSON] = somePeople(1, 3);
 
 export default function SkeletonLoaderDemo() {
   const [loading, setLoading] = useState(true);
@@ -16,16 +20,16 @@ export default function SkeletonLoaderDemo() {
             alt="Surf"
             className="h-40 w-full object-cover"
             height={160}
-            src="/images/figma/bg-5.webp"
+            src="https://ik.imagekit.io/16u211libb/smoothui/scenes/cloud-meadow.webp?tr=w-480,f-auto"
             width={320}
           />
           <div className="p-4">
             <div className="flex items-center gap-3">
               <Image
-                alt="Avatar"
+                alt={PERSON.name}
                 className="size-12 rounded-full"
                 height={48}
-                src="https://ik.imagekit.io/16u211libb/avatar-educalvolpz.jpeg?tr=w-48,h-48"
+                src={`${PERSON.avatar}?tr=w-48,h-48,f-auto`}
                 width={48}
               />
               <div>

--- a/apps/docs/examples/tilt-card.tsx
+++ b/apps/docs/examples/tilt-card.tsx
@@ -1,5 +1,11 @@
 "use client";
 
+import {
+  sceneAlt,
+  sceneSrc,
+  TILT_CARD,
+  TILT_SCENE,
+} from "@docs/examples/shared/demo-fixtures";
 import TiltCard from "@repo/smoothui/components/tilt-card";
 
 export default function TiltCardDemo() {
@@ -53,6 +59,44 @@ export default function TiltCardDemo() {
           <h3 className="font-semibold text-foreground text-sm">No glare</h3>
           <p className="mt-2 text-muted-foreground text-xs leading-relaxed">
             A subtler tilt-only variant without the glare overlay.
+          </p>
+        </div>
+      </TiltCard>
+
+      {/* The same card the landing canvas shows, so clicking that tile opens a
+          page where you can find what you clicked. */}
+      <TiltCard
+        className="w-64 overflow-hidden rounded-2xl shadow-[0_22px_50px_-26px_rgb(0_0_0/0.65)]"
+        glareOpacity={0.32}
+        maxTilt={16}
+        parallax
+        perspective={800}
+        scale={1.04}
+      >
+        <div className="relative h-40 w-full overflow-hidden">
+          <img
+            alt={sceneAlt(TILT_SCENE)}
+            className="h-full w-full scale-110 object-cover"
+            data-tilt-depth="0.18"
+            draggable={false}
+            height={320}
+            src={sceneSrc(TILT_SCENE, "w-480,h-320")}
+            width={480}
+          />
+          <div
+            aria-hidden="true"
+            className="absolute inset-0 bg-[linear-gradient(to_top,oklch(0.16_0.02_264/0.88),oklch(0.16_0.02_264/0.1)_62%)]"
+          />
+        </div>
+        <div className="absolute inset-x-0 bottom-0 p-4" data-tilt-depth="0.55">
+          <p className="font-medium text-[10px] text-white/65 uppercase tracking-[0.16em]">
+            {TILT_CARD.eyebrow}
+          </p>
+          <p className="font-semibold text-[17px] text-white leading-tight">
+            {TILT_CARD.title}
+          </p>
+          <p className="text-[11px] text-white/70 tabular-nums">
+            {TILT_CARD.meta}
           </p>
         </div>
       </TiltCard>

--- a/apps/docs/examples/user-account-avatar.tsx
+++ b/apps/docs/examples/user-account-avatar.tsx
@@ -5,18 +5,18 @@ import UserAccountAvatar, {
   type UserData,
 } from "@repo/smoothui/components/user-account-avatar";
 import { getImageKitUrl } from "@smoothui/data";
+import { somePeople } from "@smoothui/data/people";
 import { useEffect, useState } from "react";
 
+const [PERSON] = somePeople(1, 7);
+
 const demoUser: UserData = {
-  avatar: getImageKitUrl(
-    "https://ik.imagekit.io/16u211libb/avatar-educalvolpz.jpeg?updatedAt=1765524159631",
-    {
-      format: "auto",
-      height: 96,
-      quality: 85,
-      width: 96,
-    }
-  ),
+  avatar: getImageKitUrl(`${PERSON.avatar}`, {
+    format: "auto",
+    height: 96,
+    quality: 85,
+    width: 96,
+  }),
   email: "jane@example.com",
   name: "Jane Doe",
 };

--- a/apps/docs/examples/wallet-card.tsx
+++ b/apps/docs/examples/wallet-card.tsx
@@ -6,8 +6,12 @@ import type {
   WalletMember,
 } from "@repo/smoothui/components/wallet-card";
 import WalletCard from "@repo/smoothui/components/wallet-card";
+import { somePeople } from "@smoothui/data/people";
 import { ArrowUpRight, Plus } from "lucide-react";
 import { useState } from "react";
+
+/** The wallet belongs to one person; the rest are who it is shared with. */
+const [OWNER, ...SHARED] = somePeople(7, 40);
 
 const accounts: WalletAccount[] = [
   {
@@ -16,7 +20,7 @@ const accounts: WalletAccount[] = [
     expiry: "08/29",
     gradient:
       "bg-[linear-gradient(145deg,oklch(0.5_0.13_268),oklch(0.25_0.08_268))]",
-    holder: "Ada Fontaine",
+    holder: OWNER.name,
     id: "everyday",
     label: "Everyday",
     last4: "4242",
@@ -28,7 +32,7 @@ const accounts: WalletAccount[] = [
     expiry: "02/31",
     gradient:
       "bg-[linear-gradient(145deg,oklch(0.52_0.11_158),oklch(0.26_0.06_158))]",
-    holder: "Ada Fontaine",
+    holder: OWNER.name,
     id: "savings",
     label: "Savings",
     last4: "1190",
@@ -40,7 +44,7 @@ const accounts: WalletAccount[] = [
     expiry: "11/28",
     gradient:
       "bg-[linear-gradient(145deg,oklch(0.62_0.13_62),oklch(0.32_0.08_48))]",
-    holder: "Ada Fontaine",
+    holder: OWNER.name,
     id: "travel",
     label: "Travel",
     last4: "0087",
@@ -52,7 +56,7 @@ const accounts: WalletAccount[] = [
     expiry: "05/30",
     gradient:
       "bg-[linear-gradient(145deg,oklch(0.4_0.02_264),oklch(0.18_0.01_264))]",
-    holder: "Ada Fontaine",
+    holder: OWNER.name,
     id: "reserve",
     label: "Reserve",
     last4: "7731",
@@ -60,14 +64,11 @@ const accounts: WalletAccount[] = [
   },
 ];
 
-const members: WalletMember[] = [
-  { id: "m1", name: "Ada Fontaine" },
-  { id: "m2", name: "Kenji Osei" },
-  { id: "m3", name: "Priya Nair" },
-  { id: "m4", name: "Lucas Meyer" },
-  { id: "m5", name: "Sofia Reyes" },
-  { id: "m6", name: "Tomas Ilic" },
-];
+const members: WalletMember[] = SHARED.map((person) => ({
+  avatar: `${person.avatar}?tr=w-64,h-64,f-auto`,
+  id: person.id,
+  name: person.name,
+}));
 
 export default function WalletCardDemo() {
   const [activeId, setActiveId] = useState("everyday");

--- a/packages/smoothui/blocks/features/features-3/index.tsx
+++ b/packages/smoothui/blocks/features/features-3/index.tsx
@@ -14,7 +14,7 @@ const features = [
   {
     description:
       "Every component is designed with usability in mind. Clean interfaces that your users will love from the first interaction.",
-    image: getImageKitUrl("/images/designerworking.webp", {
+    image: getImageKitUrl("/smoothui/portraits/warm-wall.webp", {
       format: "auto",
       quality: 85,
       width: 800,

--- a/packages/smoothui/components/figma-comment/index.tsx
+++ b/packages/smoothui/components/figma-comment/index.tsx
@@ -47,7 +47,7 @@ export interface FigmaCommentProps {
 
 export default function FigmaComment({
   avatarUrl = getImageKitUrl(
-    "https://ik.imagekit.io/16u211libb/avatar-educalvolpz.jpeg?updatedAt=1765524159631",
+    "https://ik.imagekit.io/16u211libb/smoothui/people/alec-whitten.webp",
     {
       format: "auto",
       height: 48,
@@ -55,9 +55,9 @@ export default function FigmaComment({
       width: 48,
     }
   ),
-  avatarAlt = "Avatar",
+  avatarAlt = "Alec Whitten",
   className,
-  authorName = "Edu Calvo",
+  authorName = "Alec Whitten",
   timestamp = "Just now",
   message = "What happens if we adjust this to handle a light and dark mode? I'm not sure if we're ready to handle...",
   width = 180,

--- a/packages/smoothui/templates/chat-template/chat-sidebar.tsx
+++ b/packages/smoothui/templates/chat-template/chat-sidebar.tsx
@@ -17,7 +17,7 @@ import type { ChatConversation } from "./chat-data";
 
 /** A real photograph, so the footer is a person and not a lettered circle. */
 const USER_AVATAR =
-  "https://ik.imagekit.io/16u211libb/avatar-educalvolpz.jpeg?tr=w-64,h-64";
+  "https://ik.imagekit.io/16u211libb/smoothui/people/aysha-becker.webp?tr=w-64,h-64,f-auto";
 
 export type ChatSidebarProps = {
   activeId: string;


### PR DESCRIPTION
Follow-up to #127. The dictionaries only reached the files that had been hotlinking an external host; this covers everywhere else a demo shows a person, a background or an app.

## People

The maintainer's own face and name were the default in a shipped component, a shipped template and four demos, standing in for an arbitrary user — an account menu, a comment thread, a loading skeleton, a card stack. Those are cast members now.

He stays where he is genuinely the author: the blog byline, the blog post header, the avatar tutorial, and the `founder` export.

## Backgrounds

Six loose `public/images/figma/bg-*.webp` were shared across five demos, each picking one at random, so demos sitting next to each other in the docs shared no palette. They map onto named scenes — one scene per source file, so a background reused in two demos stays the same picture. `photo-stack`'s captions now follow the images rather than the other way round.

## Other slots

| Demo | Was | Now |
|---|---|---|
| `wallet-card` (+ canvas) | six names, no faces | cast members with avatars — `WalletMember` already took one |
| `reviews-carousel` | invented names and job titles | same words, cast name + role + company |
| `interactive-image-selector` | six loose files outside `smoothui/` | the five editorial portraits |
| `features-3` | a stock person photo | a portrait from the set (the other two images are product screenshots and stay) |

## Deliberately left alone

- `tweet-card` and `github-stars-animation` pull real avatars from their APIs.
- The `ai-*` conversation demos use a `SiriOrb` as the assistant's avatar — that is not a person.
- `swap-panel`, `favicon-search`, `drawer` and `grid-loader` matched an initials search but are capitalising a token symbol or a word, not rendering a person.

## Notes

Shipped code keeps literal URLs throughout, so the registry can still copy a component into a project with no `@smoothui/data` on the import path.

## Verification

- `pnpm test` — 1039 tests in 224 files, plus 70 in 7. All passing.
- `pnpm --filter docs typecheck` — clean.
- 10 affected demo pages checked: all 200, no stale asset paths anywhere in the repo.
