### PR TITLE
feat(docs): forward page visits to portfolio activity feed

### DIFF
--- a/apps/docs/app/api/activity-beacon/route.ts
+++ b/apps/docs/app/api/activity-beacon/route.ts
@@ -1,0 +1,116 @@
+import { createHmac } from "node:crypto";
+import { NextResponse } from "next/server";
+
+const BOT_USER_AGENT_PATTERN =
+  /bot|crawler|spider|preview|lighthouse|pagespeed|slurp|facebookexternalhit|embedly|discord|slack|telegram|whatsapp|reddit/i;
+
+const PATH_PATTERN = /^\/(?!\/)[^\\]*$/;
+const COUNTRY_CODE_PATTERN = /^[A-Z]{2}$/;
+
+const ACTIVITY_ENDPOINT = "https://educalvolopez.com/api/activity";
+
+interface BeaconPayload {
+  path: string;
+  title?: string;
+}
+
+function isValidPayload(value: unknown): value is BeaconPayload {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const { path, title } = value as Record<string, unknown>;
+
+  if (
+    typeof path !== "string" ||
+    path.length > 500 ||
+    !PATH_PATTERN.test(path)
+  ) {
+    return false;
+  }
+
+  if (
+    title !== undefined &&
+    (typeof title !== "string" || title.length > 500)
+  ) {
+    return false;
+  }
+
+  return true;
+}
+
+export async function POST(request: Request) {
+  const secret = process.env.ACTIVITY_INGEST_HMAC_SECRET;
+
+  if (!secret) {
+    return NextResponse.json({ ok: true, skipped: true });
+  }
+
+  const userAgent = request.headers.get("user-agent") ?? "";
+  if (BOT_USER_AGENT_PATTERN.test(userAgent)) {
+    return NextResponse.json({ ok: true, skipped: true });
+  }
+
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON" }, { status: 400 });
+  }
+
+  if (!isValidPayload(payload)) {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  const { path, title } = payload;
+
+  const rawCity = request.headers.get("x-vercel-ip-city");
+  let city: string | undefined;
+  if (rawCity) {
+    try {
+      city = decodeURIComponent(rawCity);
+    } catch {
+      city = undefined;
+    }
+  }
+
+  const rawCountry = request.headers.get("x-vercel-ip-country");
+  const country =
+    rawCountry && COUNTRY_CODE_PATTERN.test(rawCountry)
+      ? rawCountry
+      : undefined;
+
+  const region = request.headers.get("x-vercel-ip-country-region") ?? undefined;
+
+  const body = JSON.stringify({
+    idempotency_key: `smoothui:visit:${crypto.randomUUID()}`,
+    meta: {
+      path,
+      ...(title ? { title } : {}),
+      ...(city ? { city } : {}),
+      ...(country ? { country } : {}),
+      ...(region ? { region } : {}),
+    },
+    source: "smoothui",
+    speed: "signal",
+    type: "visit",
+  });
+
+  const signature = createHmac("sha256", secret).update(body).digest("hex");
+
+  try {
+    await fetch(ACTIVITY_ENDPOINT, {
+      body,
+      headers: {
+        "Content-Type": "application/json",
+        "x-activity-signature": signature,
+      },
+      method: "POST",
+      signal: AbortSignal.timeout(3000),
+    });
+  } catch {
+    // Best-effort forward: never fail the response because the relay failed.
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/docs/app/layout.tsx
+++ b/apps/docs/app/layout.tsx
@@ -1,3 +1,4 @@
+import { ActivityBeacon } from "@docs/components/activity-beacon";
 import { SoundProvider } from "@docs/components/sound-provider";
 import { COMPONENT_COUNT } from "@docs/lib/generated/counts";
 import { KitProvider } from "@docs/lib/kit-context";
@@ -113,6 +114,7 @@ export default function Layout({ children }: LayoutProps<"/">) {
         />
       </head>
       <body className="flex min-h-screen flex-col">
+        <ActivityBeacon />
         {enableVercelAnalytics && <Analytics />}
         {enableVercelAnalytics && <SpeedInsights />}
         <RootProvider>

--- a/apps/docs/components/activity-beacon.tsx
+++ b/apps/docs/components/activity-beacon.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect } from "react";
+
+/**
+ * Forwards every route change to our own /api/activity-beacon endpoint,
+ * which signs and relays it server-side to the portfolio's activity feed.
+ * Fire-and-forget: never blocks rendering and never surfaces errors.
+ */
+export function ActivityBeacon() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    fetch("/api/activity-beacon", {
+      body: JSON.stringify({ path: pathname, title: document.title }),
+      headers: { "Content-Type": "application/json" },
+      keepalive: true,
+      method: "POST",
+    }).catch(() => {
+      // Best-effort telemetry: never let a failed beacon affect the page.
+    });
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
## Resumen

Añade un beacon de actividad server-side para la app `docs` (smoothui.dev):

- **Cliente** (`apps/docs/components/activity-beacon.tsx`): componente montado en el layout raíz que, en cada cambio de ruta (`usePathname`), envía un `POST` fire-and-forget al propio endpoint `/api/activity-beacon` con `{ path, title }`. Los errores se descartan en silencio y nunca bloquean el render.
- **Servidor** (`apps/docs/app/api/activity-beacon/route.ts`): ruta que valida el payload (path relativo al sitio, longitud máxima, sin backslashes; title opcional), descarta tráfico de bots por user-agent, añade geolocalización aproximada a partir de las cabeceras de Vercel (`x-vercel-ip-city`, `x-vercel-ip-country`, `x-vercel-ip-country-region`), firma el cuerpo con HMAC-SHA256 y lo reenvía al feed de actividad del portfolio (`https://educalvolopez.com/api/activity`) con un timeout de ~3s. Nunca se exponen IPs, cookies ni cabeceras de auth en el payload reenviado.

Si `ACTIVITY_INGEST_HMAC_SECRET` no está definida, la ruta responde `{ ok: true, skipped: true }` sin hacer nada más (no-op seguro).

## Notas de despliegue

`ACTIVITY_INGEST_HMAC_SECRET` ya está configurada en Vercel (proyecto `smoothui`, entorno de producción), por lo que no se requiere ninguna acción adicional en Vercel para que esto funcione en producción.

## Test plan

- [x] `pnpm --filter docs typecheck` — sin errores
- [x] `pnpm --filter docs build` — build de producción completo, sin errores
- [x] `npx ultracite check` sobre los archivos nuevos/modificados — sin hallazgos
- [ ] Verificar en producción que las visitas aparecen en el feed de actividad del portfolio

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added background activity tracking across documentation pages.
  * Activity data includes the current page path and title.
  * Tracking requests are filtered for invalid or automated traffic and handled without interrupting browsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->