### PR TITLE
chore(friction-log): add the GitHub-issue friction log and daily investigator

### DIFF
--- a/.github/ISSUE_TEMPLATE/friction.yml
+++ b/.github/ISSUE_TEMPLATE/friction.yml
@@ -1,0 +1,40 @@
+name: Friction
+description: Log a contributor or agent papercut while working in this repo
+title: 'Friction: '
+labels: [friction]
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Search open `friction` issues before filing. One papercut per issue.
+        This is for developing this repository, not a product feature request.
+        Omit secrets, tokens, and unrelated private content.
+  - type: textarea
+    id: happened
+    attributes:
+      label: What happened
+      description: What you were doing and what got in the way.
+    validations:
+      required: true
+  - type: textarea
+    id: wanted
+    attributes:
+      label: What you wanted
+      description: The expected path.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: How to reproduce
+      description: Commands, files, or conditions a later agent can follow.
+    validations:
+      required: true
+  - type: textarea
+    id: cost
+    attributes:
+      label: Cost
+      description:
+        Time lost, how often this happens, who it hits, and the workaround.
+    validations:
+      required: true

--- a/.github/workflows/friction-log.yml
+++ b/.github/workflows/friction-log.yml
@@ -22,15 +22,17 @@ concurrency:
   group: friction-log
   cancel-in-progress: false
 
+# The sweep reads issues over the API. It never checks out the repo, so
+# `contents` stays unset.
 permissions:
-  contents: read
   issues: read
 
 jobs:
   sweep:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: educlopez/friction-log@v1
+      - uses: educlopez/friction-log@bb972a83621af7ffa7d993f22791ba70dd4d2995 # v1.1.3
         with:
           dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
           force: ${{ github.event_name == 'workflow_dispatch' && inputs.force || false }}

--- a/.github/workflows/friction-log.yml
+++ b/.github/workflows/friction-log.yml
@@ -1,0 +1,39 @@
+# Lists open `friction` issues and, when any are eligible, spawns one
+# Cursor Cloud Agent. Powered by educlopez/friction-log.
+
+name: Friction log
+
+on:
+  schedule:
+    # ~05:00–06:00 Europe/Madrid (GitHub cron is UTC-only)
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: Scan only. Do not spawn an agent.
+        type: boolean
+        default: false
+      force:
+        description: Include issues marked skipped.
+        type: boolean
+        default: false
+
+concurrency:
+  group: friction-log
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: read
+
+jobs:
+  sweep:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: educlopez/friction-log@v1
+        with:
+          dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
+          force: ${{ github.event_name == 'workflow_dispatch' && inputs.force || false }}
+        env:
+          CURSOR_API_KEY: ${{ secrets.CURSOR_API_KEY }}
+          FRICTION_LOG_PAUSED: ${{ vars.FRICTION_LOG_PAUSED }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,3 +121,11 @@ Biome's linter will catch most issues automatically. Focus your attention on:
 ---
 
 Most formatting and common issues are automatically fixed by Biome. Run `pnpm dlx ultracite fix` before committing to ensure compliance.
+
+## Friction log
+
+Papercuts while developing this repo are GitHub issues labeled `friction`, not
+files in the tree. Load `.cursor/skills/friction-log/SKILL.md` when you hit one
+(policy: `docs/contributing/friction-log.md`). A daily Cursor agent
+([`educlopez/friction-log`](https://github.com/educlopez/friction-log))
+investigates them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,3 +293,11 @@ The build process includes test running - builds depend on passing tests (see `t
    - Replace string easing with `cubic-bezier` values
    - Add hover device detection for hover animations
    - Update `ANIMATION_IMPROVEMENTS.md` with changes
+
+## Friction log
+
+Papercuts while developing this repo are GitHub issues labeled `friction`, not
+files in the tree. Load `.cursor/skills/friction-log/SKILL.md` when you hit one
+(policy: `docs/contributing/friction-log.md`). A daily Cursor agent
+([`educlopez/friction-log`](https://github.com/educlopez/friction-log))
+investigates them.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -310,3 +310,10 @@ When you add a new component, the registry automatically picks it up from the co
 ## Questions?
 
 If you have questions, feel free to [open an issue](https://github.com/educlopez/smoothui/issues) on GitHub.
+
+## Friction log
+
+Repository papercuts — confusing docs, a script that needs a secret handshake, a
+type that lies — go in GitHub issues labeled `friction`, not in this file. See
+[docs/contributing/friction-log.md](docs/contributing/friction-log.md). Feature
+requests and bug reports about the published package stay ordinary issues.

--- a/docs/contributing/friction-log.md
+++ b/docs/contributing/friction-log.md
@@ -1,0 +1,69 @@
+# Friction log
+
+Contributor and agent papercuts while working in this repository live as GitHub
+issues labeled `friction`. They are not files in the tree.
+
+This is not a product feature request. File those as ordinary issues. This page
+is for developing `educlopez/smoothui`: confusing docs, a command that needs a secret
+handshake, a type that lies, a test that only fails locally.
+
+The policy lives here. Agents load
+[`.cursor/skills/friction-log/SKILL.md`](../../.cursor/skills/friction-log/SKILL.md)
+when they hit friction or when they are the daily investigator.
+
+Canonical tooling: [`educlopez/friction-log`](https://github.com/educlopez/friction-log).
+
+## File an entry
+
+Search open `friction` issues first. Comment on a match instead of opening a
+duplicate.
+
+Title: `Friction: <what hurt>`.
+
+Label: `friction`.
+
+Use the [Friction issue form](../../.github/ISSUE_TEMPLATE/friction.yml) or:
+
+```bash
+gh issue create --repo educlopez/smoothui --title "Friction: …" --label friction --body-file -
+```
+
+Write one issue per papercut. Include what you were doing, the unexpected cost,
+the workaround, and enough reproduction to investigate without the original
+session. Omit secrets, tokens, and unrelated private content.
+
+Do not commit a `.agents/friction-log/` or `docs/friction-log/` directory.
+GitHub is the log.
+
+## Daily investigation
+
+The `Friction log` GitHub Action runs daily at 04:00 UTC. It uses
+`educlopez/friction-log@v1` to list open `friction` issues and, when any are
+eligible and `CURSOR_API_KEY` is set, spawn one Cursor Cloud Agent on
+`educlopez/smoothui` `main`.
+
+The investigator chooses one outcome per issue:
+
+| Outcome       | What happens                                                                                       |
+| ------------- | -------------------------------------------------------------------------------------------------- |
+| Already fixed | Closes the issue with the evidence.                                                                |
+| Invalid       | Closes the issue (not repo friction, duplicate, or not actionable).                                |
+| Skip          | Comments a recommended fix and marks the issue skipped until @educlopez replies.                   |
+| Fix           | Opens a PR. Low and medium risk may squash-merge after green CI. High risk stays ready-for-review. |
+
+A skip comment includes `<!-- friction-log:skipped -->`. Later daily runs ignore
+that issue until @educlopez comments (approve the recommendation, close it, or
+give a different approach).
+
+## Operator controls
+
+| Command / control                        | Purpose                                 |
+| ---------------------------------------- | --------------------------------------- |
+| `npx github:educlopez/friction-log scan` | Read-only eligibility scan. No agent.   |
+| Repo variable `FRICTION_LOG_PAUSED=true` | Kill switch: scan, but do not spawn.    |
+| Actions → Friction log → Run workflow    | Manual sweep (`dry_run`, `force`).      |
+
+Create the `friction` label (color `#D4A017`) if it does not exist. Add a
+repository secret `CURSOR_API_KEY` (Cursor Dashboard → API Keys) so the daily
+job can spawn an investigator. Without that secret the Action still scans and
+exits successfully.


### PR DESCRIPTION
## What

- `docs/contributing/friction-log.md` — policy for filing and investigating papercuts
- `.cursor/skills/friction-log/SKILL.md` — how agents file friction and how the daily investigator picks an outcome
- `.github/ISSUE_TEMPLATE/friction.yml` — issue form for the `friction` label
- `.github/workflows/friction-log.yml` — daily sweep calling [`educlopez/friction-log@v1`](https://github.com/educlopez/friction-log)
- Cross-links from the contributor and agent docs

## Why

Agents notice repo papercuts constantly and then lose them, and a friction-log directory in the tree goes stale. GitHub issues labeled `friction` are the log. Once a day the Action lists eligible issues and spawns a single Cursor Cloud Agent that closes them as fixed, closes them as invalid, skips them for @educlopez, or ships a fix.

Already proven end to end on `educlopez/educalvolopez.com`: an issue became a reviewed, CI-green PR that merged on its own.

## Operator setup after merge

1. Add repository secret `CURSOR_API_KEY` (Cursor Dashboard → API Keys)
2. Optional kill switch: repo variable `FRICTION_LOG_PAUSED=true`
3. Optional first run: Actions → Friction log → Run workflow with `dry_run`

The `friction` label already exists. Without `CURSOR_API_KEY` the Action still scans and exits successfully, so merging this changes nothing until the secret is set.

## Notes

- The investigator runs on Composer, which draws from the cheap Cursor Models pool. One agent per day at most, and only when an eligible issue exists.
- Cron is staggered per repo so the rollout does not fire every sweep in the same minute.
- This repo publishes a package, so the skill's risk gate treats **any** change to exported components, props, CLI flags, or public types as high risk: the agent opens the PR and leaves it ready-for-review instead of merging.

## Testing

- Engine tests: 29 passed in `educlopez/friction-log`
- Both YAML files parse; no unrendered template placeholders

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a structured “Friction” issue form with required details for reporting development obstacles.
  * Added an automated daily process to review eligible friction reports, with manual triggering, dry-run, and pause controls.

* **Documentation**
  * Documented how to report, investigate, and manage friction-log entries.
  * Updated contributor and development guidance to distinguish friction reports from feature requests and bug reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->