### PR TITLE
chore(friction-log): bump the action pin to v1.3.1

### DIFF
--- a/.github/workflows/friction-log.yml
+++ b/.github/workflows/friction-log.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: educlopez/friction-log@3ddd41bef9451be0967a4f55d8e08163231718f8 # v1.3.0
+      - uses: educlopez/friction-log@a59c3fffa7b91c966a8876085f502acda272fed7 # v1.3.1
         with:
           dry-run: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run || false }}
           force: ${{ github.event_name == 'workflow_dispatch' && inputs.force || false }}


### PR DESCRIPTION
Bump the friction-log action pin from `3ddd41b` (v1.3.0) to `a59c3ff` (v1.3.1).

v1.3.1 closes an authorization hole in skip markers: `lastSkipIndex` matched `<!-- friction-log:skipped -->` in any comment without checking who wrote it, so on a public repo any commenter could suppress a friction issue indefinitely — the sweep skipped it until an owner replied past the marker, and an owner who never saw the comment never did.

Both markers are now honoured only from the automation (`github-actions[bot]`, `cursor[bot]`) or an owner login.

Pin only; no other repo-side change needed. Upstream: educlopez/friction-log#19.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the friction log workflow to use version 1.3.1 of its action, including the latest reliability and maintenance updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->